### PR TITLE
Move query categorization changes to plugin

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -91,28 +91,27 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
      * and query insights services.
      *
      * @param metricType {@link MetricType}
-     * @param enabled    boolean
+     * @param isCurrentMetricEnabled boolean
      */
-    public void setEnableTopQueries(final MetricType metricType, final boolean enabled) {
-        boolean isInsightsServiceDisabled = !queryInsightsService.isEnabled();
+    public void setEnableTopQueries(final MetricType metricType, final boolean isCurrentMetricEnabled) {
+        boolean isTopNFeatureDisabled = !queryInsightsService.isTopNFeatureEnabled();
+        this.queryInsightsService.enableCollection(metricType, isCurrentMetricEnabled);
 
-        if (!enabled) {
+        if (!isCurrentMetricEnabled) {
             // disable QueryInsightsListener only if all metrics collections are disabled now
             // and search query metrics is disabled.
-            if (isInsightsServiceDisabled) {
+            if (isTopNFeatureDisabled) {
                 super.setEnabled(false);
-                this.queryInsightsService.stop();
+                queryInsightsService.checkAndStopQueryInsights();
             }
         } else {
             super.setEnabled(true);
             // restart QueryInsightsListener only if none of metrics collections is enabled before and
             // search query metrics is disabled before.
-            if (isInsightsServiceDisabled) {
-                this.queryInsightsService.stop();
-                this.queryInsightsService.start();
+            if (isTopNFeatureDisabled) {
+                queryInsightsService.checkAndRestartQueryInsights();
             }
         }
-
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -94,18 +94,20 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
      * @param enabled    boolean
      */
     public void setEnableTopQueries(final MetricType metricType, final boolean enabled) {
-        boolean isAllMetricsDisabled = !queryInsightsService.isEnabled();
-        this.queryInsightsService.enableCollection(metricType, enabled);
+        boolean isInsightsServiceDisabled = !queryInsightsService.isEnabled();
+
         if (!enabled) {
-            // disable QueryInsightsListener only if all metrics collections are disabled now.
-            if (!queryInsightsService.isEnabled()) {
+            // disable QueryInsightsListener only if all metrics collections are disabled now
+            // and search query metrics is disabled.
+            if (isInsightsServiceDisabled) {
                 super.setEnabled(false);
                 this.queryInsightsService.stop();
             }
         } else {
             super.setEnabled(true);
-            // restart QueryInsightsListener only if none of metrics collections is enabled before.
-            if (isAllMetricsDisabled) {
+            // restart QueryInsightsListener only if none of metrics collections is enabled before and
+            // search query metrics is disabled before.
+            if (isInsightsServiceDisabled) {
                 this.queryInsightsService.stop();
                 this.queryInsightsService.start();
             }
@@ -176,7 +178,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
             }
             Map<Attribute, Object> attributes = new HashMap<>();
             attributes.put(Attribute.SEARCH_TYPE, request.searchType().toString().toLowerCase(Locale.ROOT));
-            attributes.put(Attribute.SOURCE, request.source().toString(FORMAT_PARAMS));
+            attributes.put(Attribute.SOURCE, request.source());
             attributes.put(Attribute.TOTAL_SHARDS, context.getNumShards());
             attributes.put(Attribute.INDICES, request.indices());
             attributes.put(Attribute.PHASE_LATENCY_MAP, searchRequestContext.phaseTookMap());

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -94,21 +94,18 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
      * @param isCurrentMetricEnabled boolean
      */
     public void setEnableTopQueries(final MetricType metricType, final boolean isCurrentMetricEnabled) {
-        boolean isTopNFeatureDisabled = !queryInsightsService.isTopNFeatureEnabled();
+        boolean isTopNFeaturePreviouslyDisabled = !queryInsightsService.isTopNFeatureEnabled();
         this.queryInsightsService.enableCollection(metricType, isCurrentMetricEnabled);
+        boolean isTopNFeatureCurrentlyDisabled = !queryInsightsService.isTopNFeatureEnabled();
 
-        if (!isCurrentMetricEnabled) {
-            // disable QueryInsightsListener only if all metrics collections are disabled now
-            // and search query metrics is disabled.
-            if (isTopNFeatureDisabled) {
-                super.setEnabled(false);
+        if (isTopNFeatureCurrentlyDisabled) {
+            super.setEnabled(false);
+            if (!isTopNFeaturePreviouslyDisabled) {
                 queryInsightsService.checkAndStopQueryInsights();
             }
         } else {
             super.setEnabled(true);
-            // restart QueryInsightsListener only if none of metrics collections is enabled before and
-            // search query metrics is disabled before.
-            if (isTopNFeatureDisabled) {
+            if (isTopNFeaturePreviouslyDisabled) {
                 queryInsightsService.checkAndRestartQueryInsights();
             }
         }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -310,14 +310,14 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      * @param searchQueryMetricsEnabled boolean flag
      */
     public void setSearchQueryMetricsEnabled(boolean searchQueryMetricsEnabled) {
-        boolean oldsearchQueryMetricsEnabled = isSearchQueryMetricsFeatureEnabled();
+        boolean oldSearchQueryMetricsEnabled = isSearchQueryMetricsFeatureEnabled();
         this.searchQueryMetricsEnabled = searchQueryMetricsEnabled;
         if (searchQueryMetricsEnabled) {
-            if (!oldsearchQueryMetricsEnabled) {
+            if (!oldSearchQueryMetricsEnabled) {
                 checkAndRestartQueryInsights();
             }
         } else {
-            if (oldsearchQueryMetricsEnabled) {
+            if (oldSearchQueryMetricsEnabled) {
                 checkAndStopQueryInsights();
             }
         }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitor.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitor.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.categorizer;
+
+import org.apache.lucene.search.BooleanClause;
+import org.opensearch.common.SetOnce;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Class to traverse the QueryBuilder tree and capture the query shape
+ */
+public final class QueryShapeVisitor implements QueryBuilderVisitor {
+    private final SetOnce<String> queryType = new SetOnce<>();
+    private final Map<BooleanClause.Occur, List<QueryShapeVisitor>> childVisitors = new EnumMap<>(BooleanClause.Occur.class);
+
+    @Override
+    public void accept(QueryBuilder qb) {
+        queryType.set(qb.getName());
+    }
+
+    @Override
+    public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+        // Should get called once per Occur value
+        if (childVisitors.containsKey(occur)) {
+            throw new IllegalStateException("child visitor already called for " + occur);
+        }
+        final List<QueryShapeVisitor> childVisitorList = new ArrayList<>();
+        QueryBuilderVisitor childVisitorWrapper = new QueryBuilderVisitor() {
+            QueryShapeVisitor currentChild;
+
+            @Override
+            public void accept(QueryBuilder qb) {
+                currentChild = new QueryShapeVisitor();
+                childVisitorList.add(currentChild);
+                currentChild.accept(qb);
+            }
+
+            @Override
+            public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+                return currentChild.getChildVisitor(occur);
+            }
+        };
+        childVisitors.put(occur, childVisitorList);
+        return childVisitorWrapper;
+    }
+
+    /**
+     * Convert query builder tree to json
+     * @return json query builder tree as a string
+     */
+    public String toJson() {
+        StringBuilder outputBuilder = new StringBuilder("{\"type\":\"").append(queryType.get()).append("\"");
+        for (Map.Entry<BooleanClause.Occur, List<QueryShapeVisitor>> entry : childVisitors.entrySet()) {
+            outputBuilder.append(",\"").append(entry.getKey().name().toLowerCase(Locale.ROOT)).append("\"[");
+            boolean first = true;
+            for (QueryShapeVisitor child : entry.getValue()) {
+                if (!first) {
+                    outputBuilder.append(",");
+                }
+                outputBuilder.append(child.toJson());
+                first = false;
+            }
+            outputBuilder.append("]");
+        }
+        outputBuilder.append("}");
+        return outputBuilder.toString();
+    }
+
+    /**
+     * Pretty print the query builder tree
+     * @param indent indent size
+     * @return Query builder tree as a pretty string
+     */
+    public String prettyPrintTree(String indent) {
+        StringBuilder outputBuilder = new StringBuilder(indent).append(queryType.get()).append("\n");
+        for (Map.Entry<BooleanClause.Occur, List<QueryShapeVisitor>> entry : childVisitors.entrySet()) {
+            outputBuilder.append(indent).append("  ").append(entry.getKey().name().toLowerCase(Locale.ROOT)).append(":\n");
+            for (QueryShapeVisitor child : entry.getValue()) {
+                outputBuilder.append(child.prettyPrintTree(indent + "    "));
+            }
+        }
+        return outputBuilder.toString();
+    }
+
+    /**
+     * Default constructor
+     */
+    public QueryShapeVisitor() {}
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryAggregationCategorizer.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryAggregationCategorizer.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.categorizer;
+
+import org.opensearch.search.aggregations.AggregationBuilder;
+import org.opensearch.search.aggregations.PipelineAggregationBuilder;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+import java.util.Collection;
+
+/**
+ * Increments the counters related to Aggregation Search Queries.
+ */
+public class SearchQueryAggregationCategorizer {
+
+    private static final String TYPE_TAG = "type";
+    private final SearchQueryCounters searchQueryCounters;
+
+    /**
+     * Constructor for SearchQueryAggregationCategorizer
+     * @param searchQueryCounters Object containing all query counters
+     */
+    public SearchQueryAggregationCategorizer(SearchQueryCounters searchQueryCounters) {
+        this.searchQueryCounters = searchQueryCounters;
+    }
+
+    /**
+     * Increment aggregation related counters
+     * @param aggregatorFactories input aggregations
+     */
+    public void incrementSearchQueryAggregationCounters(Collection<AggregationBuilder> aggregatorFactories) {
+        for (AggregationBuilder aggregationBuilder : aggregatorFactories) {
+            incrementCountersRecursively(aggregationBuilder);
+        }
+    }
+
+    private void incrementCountersRecursively(AggregationBuilder aggregationBuilder) {
+        // Increment counters for the current aggregation
+        String aggregationType = aggregationBuilder.getType();
+        searchQueryCounters.incrementAggCounter(1, Tags.create().addTag(TYPE_TAG, aggregationType));
+
+        // Recursively process sub-aggregations if any
+        Collection<AggregationBuilder> subAggregations = aggregationBuilder.getSubAggregations();
+        if (subAggregations != null && !subAggregations.isEmpty()) {
+            for (AggregationBuilder subAggregation : subAggregations) {
+                incrementCountersRecursively(subAggregation);
+            }
+        }
+
+        // Process pipeline aggregations
+        Collection<PipelineAggregationBuilder> pipelineAggregations = aggregationBuilder.getPipelineAggregations();
+        for (PipelineAggregationBuilder pipelineAggregation : pipelineAggregations) {
+            String pipelineAggregationType = pipelineAggregation.getType();
+            searchQueryCounters.incrementAggCounter(1, Tags.create().addTag(TYPE_TAG, pipelineAggregationType));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
@@ -129,4 +129,11 @@ public final class SearchQueryCategorizer {
     public SearchQueryCounters getSearchQueryCounters() {
         return this.searchQueryCounters;
     }
+
+    /**
+     * Reset the search query categorizer and its counters
+     */
+    public void reset() {
+        instance = null;
+    }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.categorizer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.plugin.insights.rules.model.Attribute;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.search.aggregations.AggregatorFactories;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+import java.util.List;
+
+/**
+ * Class to categorize the search queries based on the type and increment the relevant counters.
+ * Class also logs the query shape.
+ */
+public final class SearchQueryCategorizer {
+
+    private static final Logger log = LogManager.getLogger(SearchQueryCategorizer.class);
+
+    /**
+     * Contains all the search query counters
+     */
+    private final SearchQueryCounters searchQueryCounters;
+
+    final SearchQueryAggregationCategorizer searchQueryAggregationCategorizer;
+    private static SearchQueryCategorizer instance;
+
+    /**
+     * Constructor for SearchQueryCategorizor
+     * @param metricsRegistry opentelemetry metrics registry
+     */
+    private SearchQueryCategorizer(MetricsRegistry metricsRegistry) {
+        searchQueryCounters = new SearchQueryCounters(metricsRegistry);
+        searchQueryAggregationCategorizer = new SearchQueryAggregationCategorizer(searchQueryCounters);
+    }
+
+    /**
+     * Get singleton instance of SearchQueryCategorizer
+     * @param metricsRegistry metric registry
+     * @return singleton instance
+     */
+    public static SearchQueryCategorizer getInstance(MetricsRegistry metricsRegistry) {
+        if (instance == null) {
+            synchronized (SearchQueryCategorizer.class) {
+                if (instance == null) {
+                    instance = new SearchQueryCategorizer(metricsRegistry);
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Consume records and increment counters for the records
+     * @param records records to consume
+     */
+    public void consumeRecords(List<SearchQueryRecord> records) {
+        for (SearchQueryRecord record : records) {
+            SearchSourceBuilder source = (SearchSourceBuilder) record.getAttributes().get(Attribute.SOURCE);
+            categorize(source);
+        }
+    }
+
+    /**
+     * Increment categorizations counters for the given source search query
+     * @param source search query source
+     */
+    public void categorize(SearchSourceBuilder source) {
+        QueryBuilder topLevelQueryBuilder = source.query();
+        logQueryShape(topLevelQueryBuilder);
+        incrementQueryTypeCounters(topLevelQueryBuilder);
+        incrementQueryAggregationCounters(source.aggregations());
+        incrementQuerySortCounters(source.sorts());
+    }
+
+    private void incrementQuerySortCounters(List<SortBuilder<?>> sorts) {
+        if (sorts != null && sorts.size() > 0) {
+            for (SortBuilder<?> sortBuilder : sorts) {
+                String sortOrder = sortBuilder.order().toString();
+                searchQueryCounters.incrementSortCounter(1, Tags.create().addTag("sort_order", sortOrder));
+            }
+        }
+    }
+
+    private void incrementQueryAggregationCounters(AggregatorFactories.Builder aggregations) {
+        if (aggregations == null) {
+            return;
+        }
+
+        searchQueryAggregationCategorizer.incrementSearchQueryAggregationCounters(aggregations.getAggregatorFactories());
+    }
+
+    private void incrementQueryTypeCounters(QueryBuilder topLevelQueryBuilder) {
+        if (topLevelQueryBuilder == null) {
+            return;
+        }
+        QueryBuilderVisitor searchQueryVisitor = new SearchQueryCategorizingVisitor(searchQueryCounters);
+        topLevelQueryBuilder.visit(searchQueryVisitor);
+    }
+
+    private void logQueryShape(QueryBuilder topLevelQueryBuilder) {
+        if (log.isTraceEnabled()) {
+            if (topLevelQueryBuilder == null) {
+                return;
+            }
+            QueryShapeVisitor shapeVisitor = new QueryShapeVisitor();
+            topLevelQueryBuilder.visit(shapeVisitor);
+            log.trace("Query shape : {}", shapeVisitor.prettyPrintTree("  "));
+        }
+    }
+
+    /**
+     * Get search query counters
+     * @return search query counters
+     */
+    public SearchQueryCounters getSearchQueryCounters() {
+        return this.searchQueryCounters;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizingVisitor.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizingVisitor.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.categorizer;
+
+import org.apache.lucene.search.BooleanClause;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
+
+/**
+ * Class to visit the query builder tree and also track the level information.
+ * Increments the counters related to Search Query type.
+ */
+final class SearchQueryCategorizingVisitor implements QueryBuilderVisitor {
+    private final int level;
+    private final SearchQueryCounters searchQueryCounters;
+
+    public SearchQueryCategorizingVisitor(SearchQueryCounters searchQueryCounters) {
+        this(searchQueryCounters, 0);
+    }
+
+    private SearchQueryCategorizingVisitor(SearchQueryCounters counters, int level) {
+        this.searchQueryCounters = counters;
+        this.level = level;
+    }
+
+    public void accept(QueryBuilder qb) {
+        searchQueryCounters.incrementCounter(qb, level);
+    }
+
+    public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+        return new SearchQueryCategorizingVisitor(searchQueryCounters, level + 1);
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.categorizer;
+
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Class contains all the Counters related to search query types.
+ */
+public final class SearchQueryCounters {
+    private static final String LEVEL_TAG = "level";
+    private static final String UNIT = "1";
+    private final MetricsRegistry metricsRegistry;
+    /**
+     * Aggregation counter
+     */
+    private final Counter aggCounter;
+    /**
+     * Counter for all other query types (catch all)
+     */
+    private final Counter otherQueryCounter;
+    /**
+     * Counter for sort
+     */
+    private final Counter sortCounter;
+    private final Map<Class<? extends QueryBuilder>, Counter> queryHandlers;
+    /**
+     * Counter name to Counter object map
+     */
+    private final ConcurrentHashMap<String, Counter> nameToQueryTypeCounters;
+
+    /**
+     * Constructor
+     * @param metricsRegistry opentelemetry metrics registry
+     */
+    public SearchQueryCounters(MetricsRegistry metricsRegistry) {
+        this.metricsRegistry = metricsRegistry;
+        this.nameToQueryTypeCounters = new ConcurrentHashMap<>();
+        this.aggCounter = metricsRegistry.createCounter(
+            "search.query.type.agg.count",
+            "Counter for the number of top level agg search queries",
+            UNIT
+        );
+        this.otherQueryCounter = metricsRegistry.createCounter(
+            "search.query.type.other.count",
+            "Counter for the number of top level and nested search queries that do not match any other categories",
+            UNIT
+        );
+        this.sortCounter = metricsRegistry.createCounter(
+            "search.query.type.sort.count",
+            "Counter for the number of top level sort search queries",
+            UNIT
+        );
+        this.queryHandlers = new HashMap<>();
+
+    }
+
+    /**
+     * Increment counter
+     * @param queryBuilder query builder
+     * @param level level of query builder, 0 being highest level
+     */
+    public void incrementCounter(QueryBuilder queryBuilder, int level) {
+        String uniqueQueryCounterName = queryBuilder.getName();
+
+        Counter counter = nameToQueryTypeCounters.computeIfAbsent(uniqueQueryCounterName, k -> createQueryCounter(k));
+        counter.add(1, Tags.create().addTag(LEVEL_TAG, level));
+    }
+
+    /**
+     * Increment aggregate counter
+     * @param value value to increment
+     * @param tags tags
+     */
+    public void incrementAggCounter(double value, Tags tags) {
+        aggCounter.add(value, tags);
+    }
+
+    /**
+     * Increment sort counter
+     * @param value value to increment
+     * @param tags tags
+     */
+    public void incrementSortCounter(double value, Tags tags) {
+        sortCounter.add(value, tags);
+    }
+
+    /**
+     * Get aggregation counter
+     * @return aggregation counter
+     */
+    public Counter getAggCounter() {
+        return aggCounter;
+    }
+
+    /**
+     * Get sort counter
+     * @return sort counter
+     */
+    public Counter getSortCounter() {
+        return sortCounter;
+    }
+
+    /**
+     * Get counter based on the query builder name
+     * @param queryBuilderName query builder name
+     * @return counter
+     */
+    public Counter getCounterByQueryBuilderName(String queryBuilderName) {
+        return nameToQueryTypeCounters.get(queryBuilderName);
+    }
+
+    private Counter createQueryCounter(String counterName) {
+        Counter counter = metricsRegistry.createCounter(
+            "search.query.type." + counterName + ".count",
+            "Counter for the number of top level and nested " + counterName + " search queries",
+            UNIT
+        );
+        return counter;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/package-info.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Query Insights search query categorizor to collect metrics related to search queries
+ */
+package org.opensearch.plugin.insights.core.service.categorizer;

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -13,6 +13,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
+import org.opensearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -90,6 +91,8 @@ public enum Attribute {
     public static void writeValueTo(StreamOutput out, Object attributeValue) throws IOException {
         if (attributeValue instanceof List) {
             out.writeList((List<? extends Writeable>) attributeValue);
+        } else if (attributeValue instanceof SearchSourceBuilder) {
+            ((SearchSourceBuilder) attributeValue).writeTo(out);
         } else {
             out.writeGenericValue(attributeValue);
         }
@@ -106,6 +109,9 @@ public enum Attribute {
     public static Object readAttributeValue(StreamInput in, Attribute attribute) throws IOException {
         if (attribute == Attribute.TASK_RESOURCE_USAGES) {
             return in.readList(TaskResourceInfo::readFromStream);
+        } else if (attribute == Attribute.SOURCE) {
+            SearchSourceBuilder builder = new SearchSourceBuilder(in);
+            return builder;
         } else {
             return in.readGenericValue();
         }

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryCategorizationSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryCategorizationSettings.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.settings;
+
+import org.opensearch.common.settings.Setting;
+
+/**
+ * Settings for Query Categorization
+ */
+public class QueryCategorizationSettings {
+    /**
+     * Enabling search query metrics
+     */
+    public static final Setting<Boolean> SEARCH_QUERY_METRICS_ENABLED_SETTING = Setting.boolSetting(
+        "search.query.metrics.enabled",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Default constructor
+     */
+    public QueryCategorizationSettings() {}
+
+}

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -23,6 +23,8 @@ import org.opensearch.plugin.insights.settings.QueryCategorizationSettings;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.rest.RestHandler;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ExecutorBuilder;
@@ -32,7 +34,9 @@ import org.opensearch.threadpool.ThreadPool;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class QueryInsightsPluginTests extends OpenSearchTestCase {
 
@@ -41,6 +45,7 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
     private final Client client = mock(Client.class);
     private ClusterService clusterService;
     private final ThreadPool threadPool = mock(ThreadPool.class);
+    private MetricsRegistry metricsRegistry = mock(MetricsRegistry.class);
 
     @Before
     public void setup() {
@@ -50,6 +55,10 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         QueryInsightsTestUtils.registerAllQueryInsightsSettings(clusterSettings);
         clusterService = ClusterServiceUtils.createClusterService(settings, clusterSettings, threadPool);
+
+        when(metricsRegistry.createCounter(any(String.class), any(String.class), any(String.class))).thenAnswer(
+            invocation -> mock(Counter.class)
+        );
     }
 
     public void testGetSettings() {
@@ -87,7 +96,7 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
             null,
             null,
             null,
-            null
+            metricsRegistry
         );
         assertEquals(2, components.size());
         assertTrue(components.get(0) instanceof QueryInsightsService);

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.plugin.insights;
 
+import org.junit.Before;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
@@ -18,6 +19,7 @@ import org.opensearch.plugin.insights.core.listener.QueryInsightsListener;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
 import org.opensearch.plugin.insights.rules.resthandler.top_queries.RestTopQueriesAction;
+import org.opensearch.plugin.insights.settings.QueryCategorizationSettings;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.rest.RestHandler;
@@ -26,7 +28,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
 import org.opensearch.threadpool.ThreadPool;
-import org.junit.Before;
 
 import java.util.Arrays;
 import java.util.List;
@@ -65,7 +66,8 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
                 QueryInsightsSettings.TOP_N_MEMORY_QUERIES_ENABLED,
                 QueryInsightsSettings.TOP_N_MEMORY_QUERIES_SIZE,
                 QueryInsightsSettings.TOP_N_MEMORY_QUERIES_WINDOW_SIZE,
-                QueryInsightsSettings.TOP_N_MEMORY_EXPORTER_SETTINGS
+                QueryInsightsSettings.TOP_N_MEMORY_EXPORTER_SETTINGS,
+                QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING
             ),
             queryInsightsPlugin.getSettings()
         );
@@ -76,6 +78,8 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
             client,
             clusterService,
             threadPool,
+            null,
+            null,
             null,
             null,
             null,

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -20,7 +20,9 @@ import org.opensearch.plugin.insights.rules.action.top_queries.TopQueries;
 import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.settings.QueryCategorizationSettings;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
@@ -35,6 +37,8 @@ import java.util.TreeSet;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.test.OpenSearchTestCase.buildNewFakeTransportAddress;
 import static org.opensearch.test.OpenSearchTestCase.random;
@@ -43,8 +47,6 @@ import static org.opensearch.test.OpenSearchTestCase.randomArray;
 import static org.opensearch.test.OpenSearchTestCase.randomIntBetween;
 import static org.opensearch.test.OpenSearchTestCase.randomLong;
 import static org.opensearch.test.OpenSearchTestCase.randomLongBetween;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 final public class QueryInsightsTestUtils {
 
@@ -76,9 +78,13 @@ final public class QueryInsightsTestUtils {
             for (int j = 0; j < countOfPhases; ++j) {
                 phaseLatencyMap.put(randomAlphaOfLengthBetween(5, 10), randomLong());
             }
+
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            searchSourceBuilder.size(20); // Set the size parameter as needed
+
             Map<Attribute, Object> attributes = new HashMap<>();
             attributes.put(Attribute.SEARCH_TYPE, SearchType.QUERY_THEN_FETCH.toString().toLowerCase(Locale.ROOT));
-            attributes.put(Attribute.SOURCE, "{\"size\":20}");
+            attributes.put(Attribute.SOURCE, searchSourceBuilder);
             attributes.put(Attribute.TOTAL_SHARDS, randomIntBetween(1, 100));
             attributes.put(Attribute.INDICES, randomArray(1, 3, Object[]::new, () -> randomAlphaOfLengthBetween(5, 10)));
             attributes.put(Attribute.PHASE_LATENCY_MAP, phaseLatencyMap);
@@ -222,5 +228,6 @@ final public class QueryInsightsTestUtils {
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_MEMORY_QUERIES_SIZE);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_MEMORY_QUERIES_WINDOW_SIZE);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_MEMORY_EXPORTER_SETTINGS);
+        clusterSettings.registerSetting(QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING);
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.plugin.insights.core.listener;
 
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.action.search.SearchPhaseContext;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchRequestContext;
@@ -36,7 +38,6 @@ import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
 import org.opensearch.threadpool.ThreadPool;
-import org.junit.Before;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -47,8 +48,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
-
-import org.mockito.ArgumentCaptor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -136,7 +135,7 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
         assertEquals(timestamp.longValue(), generatedRecord.getTimestamp());
         assertEquals(numberOfShards, generatedRecord.getAttributes().get(Attribute.TOTAL_SHARDS));
         assertEquals(searchType.toString().toLowerCase(Locale.ROOT), generatedRecord.getAttributes().get(Attribute.SEARCH_TYPE));
-        assertEquals(searchSourceBuilder.toString(), generatedRecord.getAttributes().get(Attribute.SOURCE));
+        assertEquals(searchSourceBuilder, generatedRecord.getAttributes().get(Attribute.SOURCE));
         Map<String, String> labels = (Map<String, String>) generatedRecord.getAttributes().get(Attribute.LABELS);
         assertEquals("userLabel", labels.get(Task.X_OPAQUE_ID));
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -66,21 +66,21 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
 
     public void testSearchQueryMetricsEnabled() {
         // Initially, searchQueryMetricsEnabled should be false and searchQueryCategorizer should be null
-        assertFalse(queryInsightsService.isSearchQueryMetricsEnabled());
+        assertFalse(queryInsightsService.isSearchQueryMetricsFeatureEnabled());
         assertNotNull(queryInsightsService.getSearchQueryCategorizer());
 
         // Enable search query metrics
         queryInsightsService.setSearchQueryMetricsEnabled(true);
 
         // Assert that searchQueryMetricsEnabled is true and searchQueryCategorizer is initialized
-        assertTrue(queryInsightsService.isSearchQueryMetricsEnabled());
+        assertTrue(queryInsightsService.isSearchQueryMetricsFeatureEnabled());
         assertNotNull(queryInsightsService.getSearchQueryCategorizer());
 
         // Disable search query metrics
         queryInsightsService.setSearchQueryMetricsEnabled(false);
 
         // Assert that searchQueryMetricsEnabled is false and searchQueryCategorizer is not null
-        assertFalse(queryInsightsService.isSearchQueryMetricsEnabled());
+        assertFalse(queryInsightsService.isSearchQueryMetricsFeatureEnabled());
         assertNotNull(queryInsightsService.getSearchQueryCategorizer());
 
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -67,7 +67,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
     public void testSearchQueryMetricsEnabled() {
         // Initially, searchQueryMetricsEnabled should be false and searchQueryCategorizer should be null
         assertFalse(queryInsightsService.isSearchQueryMetricsEnabled());
-        assertNull(queryInsightsService.getSearchQueryCategorizer());
+        assertNotNull(queryInsightsService.getSearchQueryCategorizer());
 
         // Enable search query metrics
         queryInsightsService.setSearchQueryMetricsEnabled(true);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizor/QueryShapeVisitorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizor/QueryShapeVisitorTests.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.categorizor;
+
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.RegexpQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.plugin.insights.core.service.categorizer.QueryShapeVisitor;
+import org.opensearch.test.OpenSearchTestCase;
+
+public final class QueryShapeVisitorTests extends OpenSearchTestCase {
+    public void testQueryShapeVisitor() {
+        QueryBuilder builder = new BoolQueryBuilder().must(new TermQueryBuilder("foo", "bar"))
+            .filter(new ConstantScoreQueryBuilder(new RangeQueryBuilder("timestamp").from("12345677").to("2345678")))
+            .should(
+                new BoolQueryBuilder().must(new MatchQueryBuilder("text", "this is some text"))
+                    .mustNot(new RegexpQueryBuilder("color", "red.*"))
+            )
+            .must(new TermsQueryBuilder("genre", "action", "drama", "romance"));
+        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor();
+        builder.visit(shapeVisitor);
+        assertEquals(
+            "{\"type\":\"bool\",\"must\"[{\"type\":\"term\"},{\"type\":\"terms\"}],\"filter\"[{\"type\":\"constant_score\",\"filter\"[{\"type\":\"range\"}]}],\"should\"[{\"type\":\"bool\",\"must\"[{\"type\":\"match\"}],\"must_not\"[{\"type\":\"regexp\"}]}]}",
+            shapeVisitor.toJson()
+        );
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizor/SearchQueryCategorizerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizor/SearchQueryCategorizerTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.plugin.insights.core.service.categorizor;
 
+import org.junit.After;
+import org.mockito.Mockito;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.BoostingQueryBuilder;
 import org.opensearch.index.query.MatchNoneQueryBuilder;
@@ -59,6 +61,11 @@ public final class SearchQueryCategorizerTests extends OpenSearchTestCase {
             invocation -> mock(Counter.class)
         );
         searchQueryCategorizer = SearchQueryCategorizer.getInstance(metricsRegistry);
+    }
+
+    @After
+    public void cleanup() {
+        searchQueryCategorizer.reset();
     }
 
     public void testAggregationsQuery() {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizor/SearchQueryCategorizerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizor/SearchQueryCategorizerTests.java
@@ -1,0 +1,247 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.categorizor;
+
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.BoostingQueryBuilder;
+import org.opensearch.index.query.MatchNoneQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.QueryStringQueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.RegexpQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
+import org.opensearch.plugin.insights.core.service.categorizer.SearchQueryCategorizer;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.MultiTermsAggregationBuilder;
+import org.opensearch.search.aggregations.support.MultiTermsValuesSourceConfig;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.ScoreSortBuilder;
+import org.opensearch.search.sort.SortOrder;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
+import org.opensearch.telemetry.metrics.tags.Tags;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.util.Arrays;
+
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class SearchQueryCategorizerTests extends OpenSearchTestCase {
+
+    private static final String MULTI_TERMS_AGGREGATION = "multi_terms";
+
+    private MetricsRegistry metricsRegistry;
+
+    private SearchQueryCategorizer searchQueryCategorizer;
+
+    @Before
+    public void setup() {
+        metricsRegistry = mock(MetricsRegistry.class);
+        when(metricsRegistry.createCounter(any(String.class), any(String.class), any(String.class))).thenAnswer(
+            invocation -> mock(Counter.class)
+        );
+        searchQueryCategorizer = SearchQueryCategorizer.getInstance(metricsRegistry);
+    }
+
+    public void testAggregationsQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.aggregation(
+            new MultiTermsAggregationBuilder("agg1").terms(
+                Arrays.asList(
+                    new MultiTermsValuesSourceConfig.Builder().setFieldName("username").build(),
+                    new MultiTermsValuesSourceConfig.Builder().setFieldName("rating").build()
+                )
+            )
+        );
+        sourceBuilder.size(0);
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getAggCounter()).add(eq(1.0d), any(Tags.class));
+
+        ArgumentCaptor<Double> valueCaptor = ArgumentCaptor.forClass(Double.class);
+        ArgumentCaptor<Tags> tagsCaptor = ArgumentCaptor.forClass(Tags.class);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getAggCounter()).add(valueCaptor.capture(), tagsCaptor.capture());
+
+        double actualValue = valueCaptor.getValue();
+        String actualTag = (String) tagsCaptor.getValue().getTagsMap().get("type");
+
+        assertEquals(1.0d, actualValue, 0.0001);
+        assertEquals(MULTI_TERMS_AGGREGATION, actualTag);
+    }
+
+    public void testBoolQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        sourceBuilder.query(new BoolQueryBuilder().must(new MatchQueryBuilder("searchText", "fox")));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("bool")).add(eq(1.0d), any(Tags.class));
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("match")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testFunctionScoreQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        sourceBuilder.query(new FunctionScoreQueryBuilder(QueryBuilders.prefixQuery("text", "bro")));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("function_score")).add(
+            eq(1.0d),
+            any(Tags.class)
+        );
+    }
+
+    public void testMatchQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        sourceBuilder.query(QueryBuilders.matchQuery("tags", "php"));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("match")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testMatchPhraseQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        sourceBuilder.query(QueryBuilders.matchPhraseQuery("tags", "php"));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("match_phrase")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testMultiMatchQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        sourceBuilder.query(new MultiMatchQueryBuilder("foo bar", "myField"));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("multi_match")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testOtherQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        BoostingQueryBuilder queryBuilder = new BoostingQueryBuilder(
+            new TermQueryBuilder("unmapped_field", "foo"),
+            new MatchNoneQueryBuilder()
+        );
+        sourceBuilder.query(queryBuilder);
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("boosting")).add(eq(1.0d), any(Tags.class));
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("match_none")).add(eq(1.0d), any(Tags.class));
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("term")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testQueryStringQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder("foo:*");
+        sourceBuilder.query(queryBuilder);
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("query_string")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testRangeQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        RangeQueryBuilder rangeQuery = new RangeQueryBuilder("date");
+        rangeQuery.gte("1970-01-01");
+        rangeQuery.lt("1982-01-01");
+        sourceBuilder.query(rangeQuery);
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("range")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testRegexQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(new RegexpQueryBuilder("field", "text"));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("regexp")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testSortQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(QueryBuilders.matchQuery("tags", "ruby"));
+        sourceBuilder.sort("creationDate", SortOrder.DESC);
+        sourceBuilder.sort(new ScoreSortBuilder());
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("match")).add(eq(1.0d), any(Tags.class));
+        verify(searchQueryCategorizer.getSearchQueryCounters().getSortCounter(), times(2)).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testTermQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        sourceBuilder.query(QueryBuilders.termQuery("field", "value2"));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("term")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testWildcardQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+        sourceBuilder.query(new WildcardQueryBuilder("field", "text"));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("wildcard")).add(eq(1.0d), any(Tags.class));
+    }
+
+    public void testComplexQuery() {
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.size(50);
+
+        TermQueryBuilder termQueryBuilder = QueryBuilders.termQuery("field", "value2");
+        MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery("tags", "php");
+        RegexpQueryBuilder regexpQueryBuilder = new RegexpQueryBuilder("field", "text");
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder().must(termQueryBuilder)
+            .filter(matchQueryBuilder)
+            .should(regexpQueryBuilder);
+        sourceBuilder.query(boolQueryBuilder);
+        sourceBuilder.aggregation(new RangeAggregationBuilder("agg1").field("num"));
+
+        searchQueryCategorizer.categorize(sourceBuilder);
+
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("term")).add(eq(1.0d), any(Tags.class));
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("match")).add(eq(1.0d), any(Tags.class));
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("regexp")).add(eq(1.0d), any(Tags.class));
+        verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("bool")).add(eq(1.0d), any(Tags.class));
+        verify(searchQueryCategorizer.getSearchQueryCounters().getAggCounter()).add(eq(1.0d), any(Tags.class));
+    }
+}


### PR DESCRIPTION
Original PR : https://github.com/opensearch-project/OpenSearch/pull/14528

Query categorization changes to increment counters for search query related metrics currently resides on the search path and occurs before the request.

Move these changes to the query insights plugin and make sure the incrementing of counters happens separately from the search path.

Another option is to keep query categorization changes as is. However, this will lead to additional overhead on the search path. Furthermore, we need to tie query latency, cpu, memory with the query categorization data which will only be possible if we increment the counters after the request is completed and the query latency and resource usage data resides inside the plugin.

To support the above and to prevent doing these counter increments on the search path, we need to move query categorization changes to the query insights plugin.

Related Issues
Resolves https://github.com/opensearch-project/OpenSearch/issues/14527
Addresses https://github.com/opensearch-project/OpenSearch/issues/11596

Check List
 Functionality includes testing.
 API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
 Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
