### PR TITLE
fix build error in NodeRequest class for 2.x

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -10,6 +10,7 @@ package org.opensearch.plugin.insights.rules.transport.top_queries;
 
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.action.support.nodes.TransportNodesAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -22,7 +23,6 @@ import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesRequest
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesResponse;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
@@ -112,7 +112,7 @@ public class TransportTopQueriesAction extends TransportNodesAction<
     /**
      * Inner Node Top Queries Request
      */
-    public static class NodeRequest extends TransportRequest {
+    public static class NodeRequest extends BaseNodeRequest {
 
         final TopQueriesRequest request;
 


### PR DESCRIPTION
### Description
Currently in 2.x the build is failing with
```
Type parameter 'org.opensearch.plugin.insights.rules.transport.top_queries.TransportTopQueriesAction.NodeRequest' is not within its bound; should extend 'org.opensearch.action.support.nodes.BaseNodeRequest'
```
This is because we missed one change diff in 2.x when cutting the branch in query insights repo.

in 2.x we are still using the deprecated `BaseNodeRequest` while in 3.0 we switched to `TransportRequest` since we deprecated the BaseNodeRequest.

My previous related changes on 2.x in core repo: https://github.com/opensearch-project/OpenSearch/pull/12203/files#diff-933240c7b0d2df71fdafb54891e8508cff8c45efa814cd6ba3626b58dcd60ee5R126
My previous related changes on main in core repo: https://github.com/opensearch-project/OpenSearch/pull/11904/files#diff-933240c7b0d2df71fdafb54891e8508cff8c45efa814cd6ba3626b58dcd60ee5R126

Other examples in core:
- Example 1
    - main: https://github.com/opensearch-project/OpenSearch/blame/main/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java#L224
    - 2.x: https://github.com/opensearch-project/OpenSearch/blame/2.x/server/src/main/java/org/opensearch/action/admin/cluster/stats/TransportClusterStatsAction.java#L230
- Example 2
    - main: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java#L120
    - 2.x: https://github.com/opensearch-project/OpenSearch/blob/2.x/server/src/main/java/org/opensearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java#L120 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
