### PR TITLE
Increment latency, cpu and memory histograms for query/aggregation/sort query types

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
@@ -66,7 +66,7 @@ public final class SearchQueryCategorizer {
     }
 
     /**
-     * Consume records and increment counters for the records including latency, cpu and memory histograms.
+     * Consume records and increment categorization counters and histograms for the records including latency, cpu and memory.
      * @param records records to consume
      */
     public void consumeRecords(List<SearchQueryRecord> records) {
@@ -76,9 +76,9 @@ public final class SearchQueryCategorizer {
     }
 
     /**
-     * Increment categorizations counters for the given source search query and
+     * Increment categorizations counters for the given search query record and
      * also increment latency, cpu and memory related histograms.
-     * @param record search query source
+     * @param record search query record
      */
     public void categorize(SearchQueryRecord record) {
         SearchSourceBuilder source = (SearchSourceBuilder) record.getAttributes().get(Attribute.SOURCE);
@@ -139,6 +139,8 @@ public final class SearchQueryCategorizer {
      * Reset the search query categorizer and its counters
      */
     public void reset() {
-        instance = null;
+        synchronized (SearchQueryCategorizer.class) {
+            instance = null;
+        }
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizingVisitor.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizingVisitor.java
@@ -11,6 +11,9 @@ package org.opensearch.plugin.insights.core.service.categorizer;
 import org.apache.lucene.search.BooleanClause;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+
+import java.util.Map;
 
 /**
  * Class to visit the query builder tree and also track the level information.
@@ -19,21 +22,23 @@ import org.opensearch.index.query.QueryBuilderVisitor;
 final class SearchQueryCategorizingVisitor implements QueryBuilderVisitor {
     private final int level;
     private final SearchQueryCounters searchQueryCounters;
+    private final Map<MetricType, Number> measurements;
 
-    public SearchQueryCategorizingVisitor(SearchQueryCounters searchQueryCounters) {
-        this(searchQueryCounters, 0);
+    public SearchQueryCategorizingVisitor(SearchQueryCounters searchQueryCounters, Map<MetricType, Number> measurements) {
+        this(searchQueryCounters, 0, measurements);
     }
 
-    private SearchQueryCategorizingVisitor(SearchQueryCounters counters, int level) {
+    private SearchQueryCategorizingVisitor(SearchQueryCounters counters, int level, Map<MetricType, Number> measurements) {
         this.searchQueryCounters = counters;
         this.level = level;
+        this.measurements = measurements;
     }
 
     public void accept(QueryBuilder qb) {
-        searchQueryCounters.incrementCounter(qb, level);
+        searchQueryCounters.incrementCounter(qb, level, measurements);
     }
 
     public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
-        return new SearchQueryCategorizingVisitor(searchQueryCounters, level + 1);
+        return new SearchQueryCategorizingVisitor(searchQueryCounters, level + 1, measurements);
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
@@ -171,28 +171,4 @@ public final class SearchQueryCounters {
         );
         return counter;
     }
-
-    /**
-     * Get Query type latency histogram
-     * @return histogram
-     */
-    public Histogram getQueryTypeLatencyHistogram() {
-        return queryTypeLatencyHistogram;
-    }
-
-    /**
-     * Get Query type cpu histogram
-     * @return histogram
-     */
-    public Histogram getQueryTypeCpuHistogram() {
-        return queryTypeCpuHistogram;
-    }
-
-    /**
-     * Get Query type memory histogram
-     * @return histogram
-     */
-    public Histogram getQueryTypeMemoryHistogram() {
-        return queryTypeMemoryHistogram;
-    }
 }

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -52,8 +52,27 @@ final public class QueryInsightsTestUtils {
 
     public QueryInsightsTestUtils() {}
 
+    /**
+     * Returns list of randomly generated search query records.
+     * @param count number of records
+     * @return List of records
+     */
     public static List<SearchQueryRecord> generateQueryInsightRecords(int count) {
         return generateQueryInsightRecords(count, count, System.currentTimeMillis(), 0);
+    }
+
+    /**
+     * Returns list of randomly generated search query records.
+     * @param count number of records
+     * @param searchSourceBuilder source
+     * @return List of records
+     */
+    public static List<SearchQueryRecord> generateQueryInsightRecords(int count, SearchSourceBuilder searchSourceBuilder) {
+        List<SearchQueryRecord> records = generateQueryInsightRecords(count, count, System.currentTimeMillis(), 0);
+        for (SearchQueryRecord record : records) {
+            record.getAttributes().put(Attribute.SOURCE, searchSourceBuilder);
+        }
+        return records;
     }
 
     /**

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizor/SearchQueryCategorizerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizor/SearchQueryCategorizerTests.java
@@ -59,10 +59,9 @@ public final class SearchQueryCategorizerTests extends OpenSearchTestCase {
 
     private SearchQueryCategorizer searchQueryCategorizer;
 
-    private Map<MetricType, Number> measurements;
-
     @Before
     public void setup() {
+        SearchQueryCategorizer.getInstance(mock(MetricsRegistry.class)).reset();
         metricsRegistry = mock(MetricsRegistry.class);
         when(metricsRegistry.createCounter(any(String.class), any(String.class), any(String.class))).thenAnswer(
             invocation -> mock(Counter.class)


### PR DESCRIPTION
Integrate latency and resource usage data to the query categorization data.

### Description
Followup for the [following](https://github.com/opensearch-project/query-insights/pull/16/files), we now increment histograms for latency, cpu and memory for each query type, aggregation type and sort order.

### Issues Resolved
resolves https://github.com/opensearch-project/OpenSearch/issues/14588

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
