### PR TITLE
fix query insights zip versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ validateNebulaPom.enabled = false
 buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+        isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
     }
 
     repositories {
@@ -65,6 +67,17 @@ buildscript {
     dependencies {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
     }
+}
+
+allprojects {
+  group 'org.opensearch'
+  version = opensearch_version.tokenize('-')[0] + '.0'
+  if (buildVersionQualifier) {
+    version += "-${buildVersionQualifier}"
+  }
+  if (isSnapshot) {
+    version += "-SNAPSHOT"
+  }
 }
 
 repositories {


### PR DESCRIPTION
### Description
Currently the build is failing with
```
2024-07-19 19:37:51 ERROR    ERROR: Artifact query-insights.zip is invalid. Expected filename to include one of ['2.16.0.0'].
```
We are missing the correct version variable set up in the build script.

### Test
```
./scripts/build.sh -v 3.0.0 -s true
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ VERSION=3.0.0
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ SNAPSHOT=true
+ getopts :h:v:q:s:o:p:a: arg
+ '[' -z 3.0.0 ']'
+ [[ ! -z '' ]]
+ [[ true == \t\r\u\e ]]
+ VERSION=3.0.0-SNAPSHOT
+ '[' -z '' ']'
+ OUTPUT=artifacts
+ mkdir -p artifacts
+ ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=3.0.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/8.8/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
Daemon will be stopped at the end of the build
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.8
  OS Info               : Mac OS X 14.5 (aarch64)
  JDK Version           : 17 (Amazon Corretto JDK)
  JAVA_HOME             : /Users/cyji/.sdkman/candidates/java/17.0.7-amzn
  Random Testing Seed   : 5C11FBD8E80DDB25
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 45s
11 actionable tasks: 9 executed, 2 from cache
++ find . -path '*build/distributions/*.zip'
+ zipPath=./build/distributions/query-insights-3.0.0.0-SNAPSHOT.zip
++ dirname ./build/distributions/query-insights-3.0.0.0-SNAPSHOT.zip
+ distributions=./build/distributions
+ echo 'COPY ./build/distributions/*.zip'
COPY ./build/distributions/*.zip
+ mkdir -p artifacts/plugins
+ cp ./build/distributions/query-insights-3.0.0.0-SNAPSHOT.zip ./artifacts/plugins
+ ./gradlew publishPluginZipPublicationToMavenLocal -Dopensearch.version=3.0.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.8
  OS Info               : Mac OS X 14.5 (aarch64)
  JDK Version           : 17 (Amazon Corretto JDK)
  JAVA_HOME             : /Users/cyji/.sdkman/candidates/java/17.0.7-amzn
  Random Testing Seed   : C5E7F8638788329B
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 760ms
9 actionable tasks: 3 executed, 6 up-to-date
+ ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=3.0.0-SNAPSHOT -Dbuild.snapshot=true -Dbuild.version_qualifier=
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 8.8
  OS Info               : Mac OS X 14.5 (aarch64)
  JDK Version           : 17 (Amazon Corretto JDK)
  JAVA_HOME             : /Users/cyji/.sdkman/candidates/java/17.0.7-amzn
  Random Testing Seed   : 133092F4E40EAAE4
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 449ms
9 actionable tasks: 2 executed, 7 up-to-date
+ mkdir -p artifacts/maven/org/opensearch
+ cp -r ./build/local-staging-repo/org/opensearch/. artifacts/maven/org/opensearch
```
```
ls ./build/distributions
query-insights-3.0.0.0-SNAPSHOT-javadoc.jar
query-insights-3.0.0.0-SNAPSHOT-sources.jar
query-insights-3.0.0.0-SNAPSHOT.jar
query-insights-3.0.0.0-SNAPSHOT.pom
query-insights-3.0.0.0-SNAPSHOT.zip
```

### Issues Resolved
https://github.com/opensearch-project/query-insights/issues/33

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
