### PR TITLE
Add github action for security enabled integ tests

### DIFF
--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -1,0 +1,89 @@
+name: Security Plugin IT
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - 'integ-test/**'
+      - '.github/workflows/integ-tests-with-security.yml'
+
+jobs:
+  Get-CI-Image-Tag:
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    with:
+      product: opensearch
+
+  security-it-linux:
+    needs: Get-CI-Image-Tag
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 21 ]
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    runs-on: ubuntu-latest
+    container:
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
+      options: --user root
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Build with Gradle
+        run: |
+          chown -R 1000:1000 `pwd`
+          su `id -un 1000` -c "./gradlew integTestWithSecurity"
+
+      - name: Upload test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        continue-on-error: true
+        with:
+          name: test-reports-${{ matrix.os }}-${{ matrix.java }}
+          path: |
+            integ-test/build/reports/**
+            integ-test/build/testclusters/*/logs/*
+            integ-test/build/testclusters/*/config/*
+
+  security-it-windows-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, macos-13 ]
+        java: [ 21 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+
+      - name: Build with Gradle
+        run: ./gradlew integTestWithSecurity
+
+      - name: Upload test reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        continue-on-error: true
+        with:
+          name: test-reports-${{ matrix.os }}-${{ matrix.java }}
+          path: |
+            integ-test/build/reports/**
+            integ-test/build/testclusters/*/logs/*
+            integ-test/build/testclusters/*/config/*

--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,7 @@ test {
 tasks.named("check").configure { dependsOn(integTest) }
 
 integTest {
+  useCluster testClusters.integTest
   // The --debug-jvm command-line option makes the cluster debuggable; this makes the tests debuggable
   if (System.getProperty("test.debug") != null) {
     jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
@@ -243,15 +244,13 @@ integTest {
   filter {
     includeTestsMatching 'org.opensearch.plugin.insights.rules.resthandler.top_queries.TopQueriesRestIT'
   }
+
   if (System.getProperty("security.enabled") == "true") {
-    useCluster testClusters.integTestWithSecurity
     getClusters().forEach { cluster ->
       configureSecurityPlugin(cluster)
     }
     systemProperty "user", "admin"
     systemProperty "password", "admin"
-  } else {
-    useCluster testClusters.integTest
   }
 }
 


### PR DESCRIPTION
### Description
Add github action for security enabled integ tests.
Also fix the integ test error by always using integ test cluster in integTest job

### Issues Resolved
Related to https://github.com/opensearch-project/query-insights/issues/39

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
