### PR TITLE
Fix security based integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,18 +259,9 @@ integTest {
   if (System.getProperty("test.debug") != null) {
     jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
   }
-  // NOTE: this IT config discovers only junit5 (jupiter) tests.
-  // https://github.com/opensearch-project/sql/issues/1974
-  filter {
-    includeTestsMatching 'org.opensearch.plugin.insights.rules.resthandler.top_queries.TopQueriesRestIT'
-  }
-
-  if (System.getProperty("security.enabled") == "true") {
-    getClusters().forEach { cluster ->
-      configureSecurityPlugin(cluster)
-    }
-    systemProperty "user", "admin"
-    systemProperty "password", "admin"
+  if (System.getProperty("security.enabled") == "true" || System.getProperty("https") == "true") {
+    // Exclude this IT, because they executed in another task (:integTestWithSecurity)
+    exclude 'org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRestIT.class'
   }
 }
 
@@ -341,8 +332,6 @@ task integTestWithSecurity(type: RestIntegTestTask) {
     jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
   }
 
-  // NOTE: this IT config discovers only junit5 (jupiter) tests.
-  // https://github.com/opensearch-project/sql/issues/1974
   filter {
     includeTestsMatching 'org.opensearch.plugin.insights.rules.resthandler.top_queries.TopQueriesRestIT'
   }


### PR DESCRIPTION
### Description
Fix security based integration tests, now the security based integration tests are running with `integTestWithSecurity` only.

### Issues Resolved
https://github.com/opensearch-project/query-insights/issues/39

### Test
Here are the test steps for future references
1. run ci-runner container
```
docker run -u root -it opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3 /bin/bash
```
2. clone the opensearch-build repo
3. Run the following command
```
PATH=/home/ci-runner/.nvm/versions/node/v18.19.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin JAVA_HOME=/opt/java/openjdk-21 ./test.sh integ-test manifests/2.16.0/opensearch-2.16.0-test.yml --component query-insights --paths opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.16.0/latest/linux/x64/tar
```
4. To test the changes, push the local change to your private repo. Then change the `__checkout__ ` function in `src/git/git_repository.py` like this.
```
 def __checkout__(self) -> None:
        self.execute_silent("git init", self.dir)
        self.execute_silent("git remote add origin https://github.com/ansjcy/query-insights.git", self.dir)
        self.execute_silent("git fetch --depth 1 origin 67af75afa5cb1945edea298a373d79265e4eb7ed", self.dir)
        self.execute_silent("git checkout FETCH_HEAD", self.dir)
        self.sha = self.output("git rev-parse HEAD", self.dir)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
