### PR TITLE
Make sure listener is started when query metrics enabled

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -81,7 +81,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             client,
             metricsRegistry
         );
-        return List.of(queryInsightsService, new QueryInsightsListener(clusterService, queryInsightsService));
+        return List.of(queryInsightsService, new QueryInsightsListener(clusterService, queryInsightsService, false));
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
@@ -118,6 +118,7 @@ public class QueryInsightsExporterFactory {
      * Close an exporter
      *
      * @param exporter the exporter to close
+     * @throws IOException exception
      */
     public void closeExporter(QueryInsightsExporter exporter) throws IOException {
         if (exporter != null) {

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -118,7 +118,6 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
      * @param searchQueryMetricsEnabled boolean flag
      */
     public void setSearchQueryMetricsEnabled(boolean searchQueryMetricsEnabled) {
-        log.info("Setting query metrics enabled as : " + searchQueryMetricsEnabled);
         boolean oldSearchQueryMetricsEnabled = queryInsightsService.isSearchQueryMetricsFeatureEnabled();
         this.queryInsightsService.enableSearchQueryMetricsFeature(searchQueryMetricsEnabled);
         if (searchQueryMetricsEnabled) {
@@ -137,9 +136,6 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     private void updateSettingsForSearchQueryMetrics() {
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(SEARCH_QUERY_METRICS_ENABLED_SETTING, v -> setSearchQueryMetricsEnabled(v));
-        log.info(
-            "Setting setSearchQueryMetricsEnabled as : " + clusterService.getClusterSettings().get(SEARCH_QUERY_METRICS_ENABLED_SETTING)
-        );
         setSearchQueryMetricsEnabled(clusterService.getClusterSettings().get(SEARCH_QUERY_METRICS_ENABLED_SETTING));
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -114,7 +114,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     }
 
     /**
-     * Enable or disable top queries insights collection for {@link MetricType}
+     * Enable or disable top queries insights collection for {@link MetricType}.
      * This function will enable or disable the corresponding listeners
      * and query insights services.
      *
@@ -122,57 +122,33 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
      * @param isCurrentMetricEnabled boolean
      */
     public void setEnableTopQueries(final MetricType metricType, final boolean isCurrentMetricEnabled) {
-        boolean isTopNFeaturePreviouslyDisabled = !queryInsightsService.isTopNFeatureEnabled();
         this.queryInsightsService.enableCollection(metricType, isCurrentMetricEnabled);
-        boolean isTopNFeatureCurrentlyDisabled = !queryInsightsService.isTopNFeatureEnabled();
-
-        if (isTopNFeatureCurrentlyDisabled) {
-            if (!isTopNFeaturePreviouslyDisabled) {
-                checkAndStopQueryInsights();
-            }
-        } else {
-            if (isTopNFeaturePreviouslyDisabled) {
-                checkAndRestartQueryInsights();
-            }
-        }
+        updateQueryInsightsState();
     }
 
     /**
-     * Set search query metrics enabled to enable collection of search query categorization metrics
+     * Set search query metrics enabled to enable collection of search query categorization metrics.
      * @param searchQueryMetricsEnabled boolean flag
      */
     public void setSearchQueryMetricsEnabled(boolean searchQueryMetricsEnabled) {
-        boolean oldSearchQueryMetricsEnabled = queryInsightsService.isSearchQueryMetricsFeatureEnabled();
         this.queryInsightsService.enableSearchQueryMetricsFeature(searchQueryMetricsEnabled);
-        if (searchQueryMetricsEnabled) {
-            if (!oldSearchQueryMetricsEnabled) {
-                checkAndRestartQueryInsights();
-            }
-        } else {
-            if (oldSearchQueryMetricsEnabled) {
-                checkAndStopQueryInsights();
-            }
-        }
+        updateQueryInsightsState();
     }
 
     /**
-     * Stops query insights service if no features enabled
+     * Update the query insights service state based on the enabled features.
+     * If any feature is enabled, it starts the service. If no features are enabled, it stops the service.
      */
-    public void checkAndStopQueryInsights() {
-        if (!queryInsightsService.isAnyFeatureEnabled()) {
-            super.setEnabled(false);
-            queryInsightsService.stop();
-        }
-    }
+    private void updateQueryInsightsState() {
+        boolean anyFeatureEnabled = queryInsightsService.isAnyFeatureEnabled();
 
-    /**
-     * Restarts query insights service if any feature enabled
-     */
-    public void checkAndRestartQueryInsights() {
-        if (queryInsightsService.isAnyFeatureEnabled()) {
+        if (anyFeatureEnabled && !super.isEnabled()) {
             super.setEnabled(true);
             queryInsightsService.stop();
             queryInsightsService.start();
+        } else if (!anyFeatureEnabled && super.isEnabled()) {
+            super.setEnabled(false);
+            queryInsightsService.stop();
         }
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -235,25 +235,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Stops query insights service if no features enabled
-     */
-    public void checkAndStopQueryInsights() {
-        if (!isAnyFeatureEnabled()) {
-            this.stop();
-        }
-    }
-
-    /**
-     * Restarts query insights service if any feature enabled
-     */
-    public void checkAndRestartQueryInsights() {
-        if (isAnyFeatureEnabled()) {
-            this.stop();
-            this.start();
-        }
-    }
-
-    /**
      * Validate the window size config for a metricType
      *
      * @param type {@link MetricType}

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -363,6 +363,7 @@ public class TopQueriesService {
 
     /**
      * Close the top n queries service
+     * @throws IOException exception
      */
     public void close() throws IOException {
         queryInsightsExporterFactory.closeExporter(this.exporter);

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -46,6 +46,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
 
     /**
      * Get the type of requested metrics
+     * @return MetricType for current top query service
      */
     public MetricType getMetricType() {
         return metricType;

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -85,6 +85,7 @@ public enum Attribute {
      *
      * @param out            the StreamOutput to write
      * @param attributeValue the Attribute value to write
+     * @throws IOException exception
      */
     @SuppressWarnings("unchecked")
     public static void writeValueTo(StreamOutput out, Object attributeValue) throws IOException {

--- a/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
@@ -117,7 +117,7 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
 
         int numberOfShards = 10;
 
-        QueryInsightsListener queryInsightsListener = new QueryInsightsListener(clusterService, queryInsightsService, false);
+        QueryInsightsListener queryInsightsListener = new QueryInsightsListener(clusterService, queryInsightsService);
 
         when(searchRequest.getOrCreateAbsoluteStartMillis()).thenReturn(timestamp);
         when(searchRequest.searchType()).thenReturn(searchType);
@@ -183,7 +183,7 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
         CountDownLatch countDownLatch = new CountDownLatch(numRequests);
 
         for (int i = 0; i < numRequests; i++) {
-            searchListenersList.add(new QueryInsightsListener(clusterService, queryInsightsService, false));
+            searchListenersList.add(new QueryInsightsListener(clusterService, queryInsightsService));
         }
 
         for (int i = 0; i < numRequests; i++) {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -10,7 +10,6 @@ package org.opensearch.plugin.insights.core.service;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 import org.junit.Before;
 import org.opensearch.client.Client;
@@ -74,38 +73,18 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         assertNotNull(queryInsightsService.getSearchQueryCategorizer());
 
         // Enable search query metrics
-        queryInsightsService.setSearchQueryMetricsEnabled(true);
+        queryInsightsService.enableSearchQueryMetricsFeature(true);
 
         // Assert that searchQueryMetricsEnabled is true and searchQueryCategorizer is initialized
         assertTrue(queryInsightsService.isSearchQueryMetricsFeatureEnabled());
         assertNotNull(queryInsightsService.getSearchQueryCategorizer());
 
         // Disable search query metrics
-        queryInsightsService.setSearchQueryMetricsEnabled(false);
+        queryInsightsService.enableSearchQueryMetricsFeature(false);
 
         // Assert that searchQueryMetricsEnabled is false and searchQueryCategorizer is not null
         assertFalse(queryInsightsService.isSearchQueryMetricsFeatureEnabled());
         assertNotNull(queryInsightsService.getSearchQueryCategorizer());
 
-    }
-
-    public void testFeaturesEnableDisable() {
-        // Test case 1: All metric type collection disabled and search query metrics disabled, enable search query metrics
-        queryInsightsServiceSpy.enableCollection(MetricType.LATENCY, false);
-        queryInsightsServiceSpy.enableCollection(MetricType.CPU, false);
-        queryInsightsServiceSpy.enableCollection(MetricType.MEMORY, false);
-        queryInsightsServiceSpy.setSearchQueryMetricsEnabled(false);
-
-        queryInsightsServiceSpy.setSearchQueryMetricsEnabled(true);
-        verify(queryInsightsServiceSpy).checkAndRestartQueryInsights();
-
-        // Test case 2: All metric type collection disabled and search query metrics enabled, disable search query metrics
-        queryInsightsServiceSpy.enableCollection(MetricType.LATENCY, false);
-        queryInsightsServiceSpy.enableCollection(MetricType.CPU, false);
-        queryInsightsServiceSpy.enableCollection(MetricType.MEMORY, false);
-        queryInsightsServiceSpy.setSearchQueryMetricsEnabled(true);
-
-        queryInsightsServiceSpy.setSearchQueryMetricsEnabled(false);
-        verify(queryInsightsServiceSpy).checkAndStopQueryInsights();
     }
 }


### PR DESCRIPTION
### Description
Listener is only started when Top N is enabled. We need to also start the listener when query metrics is enabled.
Also completed some minor refactoring and updating tests.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
