### PR TITLE
Top n queries historical queries from local index and time range

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -79,7 +79,8 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             clusterService.getClusterSettings(),
             threadPool,
             client,
-            metricsRegistry
+            metricsRegistry,
+            xContentRegistry
         );
         return List.of(queryInsightsService, new QueryInsightsListener(clusterService, queryInsightsService));
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -78,7 +78,6 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
         }
         try {
             final String index = getDateTimeFromFormat();
-            // client.prepareIndex().setRequireAlias()
             final BulkRequestBuilder bulkRequestBuilder = client.prepareBulk().setTimeout(TimeValue.timeValueMinutes(1));
             for (SearchQueryRecord record : records) {
                 bulkRequestBuilder.add(

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -78,7 +78,7 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
         }
         try {
             final String index = getDateTimeFromFormat();
-//            client.prepareIndex().setRequireAlias()
+            // client.prepareIndex().setRequireAlias()
             final BulkRequestBuilder bulkRequestBuilder = client.prepareBulk().setTimeout(TimeValue.timeValueMinutes(1));
             for (SearchQueryRecord record : records) {
                 bulkRequestBuilder.add(

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -78,6 +78,7 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
         }
         try {
             final String index = getDateTimeFromFormat();
+//            client.prepareIndex().setRequireAlias()
             final BulkRequestBuilder bulkRequestBuilder = client.prepareBulk().setTimeout(TimeValue.timeValueMinutes(1));
             for (SearchQueryRecord record : records) {
                 bulkRequestBuilder.add(

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.reader;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.index.query.*;
+import org.opensearch.index.search.MatchQuery;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Local index reader for reading query insights data from local OpenSearch indices.
+ */
+public final class LocalIndexReader implements QueryInsightsReader {
+    /**
+     * Logger of the local index reader
+     */
+    private final Logger logger = LogManager.getLogger();
+    private final Client client;
+    private DateTimeFormatter indexPattern;
+    private final NamedXContentRegistry namedXContentRegistry;
+
+    /**
+     * Constructor of LocalIndexReader
+     *
+     * @param client OS client
+     * @param indexPattern the pattern of index to read from
+     * @param namedXContentRegistry for parsing purposes
+     */
+    public LocalIndexReader(final Client client, final DateTimeFormatter indexPattern, final NamedXContentRegistry namedXContentRegistry) {
+        this.indexPattern = indexPattern;
+        this.client = client;
+        this.namedXContentRegistry = namedXContentRegistry;
+    }
+
+    /**
+     * Getter of indexPattern
+     *
+     * @return indexPattern
+     */
+    public DateTimeFormatter getIndexPattern() {
+        return indexPattern;
+    }
+
+    /**
+     * Setter of indexPattern
+     *
+     * @param indexPattern index pattern
+     * @return the current LocalIndexReader
+     */
+    public LocalIndexReader setIndexPattern(DateTimeFormatter indexPattern) {
+        this.indexPattern = indexPattern;
+        return this;
+    }
+
+    /**
+     * Export a list of SearchQueryRecord from local index
+     *
+     * @param from start timestamp
+     * @param to end timestamp
+     * @return list of SearchQueryRecords whose timestamps fall between from and to
+     */
+    @Override
+    public List<SearchQueryRecord> read(final String from, final String to) {
+        List<SearchQueryRecord> records = new ArrayList<>();
+        final DateTime start = new DateTime(Long.valueOf(from), DateTimeZone.UTC);
+        DateTime end = new DateTime(Long.valueOf(to), DateTimeZone.UTC);
+        if (end.compareTo(DateTime.now()) > 0){
+            end = DateTime.now();
+        }
+        DateTime curr = start;
+        while (curr.compareTo(end.plusDays(1).withTimeAtStartOfDay()) < 0) {
+            String index = getDateTimeFromFormat(curr);
+            SearchRequest searchRequest = new SearchRequest(index);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            MatchQueryBuilder excludeQuery = QueryBuilders.matchQuery("indices", "top_queries*");
+            RangeQueryBuilder rangeQuery = QueryBuilders.rangeQuery("timestamp").from(from).to(to);
+            QueryBuilder query = QueryBuilders.boolQuery().must(rangeQuery).mustNot(excludeQuery);
+            searchSourceBuilder.query(query);
+            searchRequest.source(searchSourceBuilder);
+            try {
+                SearchResponse searchResponse = client.search(searchRequest).actionGet();
+                for (SearchHit hit : searchResponse.getHits()) {
+                    SearchQueryRecord record = SearchQueryRecord.getRecord(hit, namedXContentRegistry);
+                    records.add(record);
+                }
+            } catch (IndexNotFoundException ignored) {
+            } catch (Exception e) {
+                logger.error("Unable to parse search hit: ", e);
+            }
+            curr = curr.plusDays(1);
+
+        }
+        return records;
+    }
+
+    /**
+     * Close the reader sink
+     */
+    @Override
+    public void close() {
+        logger.debug("Closing the LocalIndexReader..");
+    }
+
+    private String getDateTimeFromFormat(DateTime current) {
+        return indexPattern.print(current);
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
@@ -8,10 +8,9 @@
 
 package org.opensearch.plugin.insights.core.reader;
 
-import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
-
 import java.io.Closeable;
 import java.util.List;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 
 /**
  * Base interface for Query Insights readers

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.reader;
+
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+
+import java.io.Closeable;
+import java.util.List;
+
+/**
+ * Base interface for Query Insights readers
+ */
+public interface QueryInsightsReader extends Closeable {
+    /**
+     * Reader a list of SearchQueryRecord
+     *
+     * @param from string
+     * @param to string
+     * @return List of SearchQueryRecord
+     */
+    List<SearchQueryRecord> read(final String from, final String to);
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.reader;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.joda.time.format.DateTimeFormat;
+import org.opensearch.client.Client;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+
+import javax.naming.Name;
+
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.*;
+
+/**
+ * Factory class for validating and creating Readers based on provided settings
+ */
+public class QueryInsightsReaderFactory {
+    /**
+     * Logger of the query insights Reader factory
+     */
+    private final Logger logger = LogManager.getLogger();
+    final private Client client;
+    final private Set<QueryInsightsReader> Readers;
+
+    /**
+     * Constructor of QueryInsightsReaderFactory
+     *
+     * @param client OS client
+     */
+    public QueryInsightsReaderFactory(final Client client) {
+        this.client = client;
+        this.Readers = new HashSet<>();
+    }
+
+    /**
+     * Validate Reader sink config
+     *
+     * @param settings Reader sink config {@link Settings}
+     * @throws IllegalArgumentException if provided Reader sink config settings are invalid
+     */
+    public void validateReaderConfig(final Settings settings) throws IllegalArgumentException {
+        final String indexPattern = settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN);
+        if (indexPattern.isEmpty()) {
+            throw new IllegalArgumentException("Empty index pattern configured for the Reader");
+        }
+        try {
+            DateTimeFormat.forPattern(indexPattern);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "Invalid index pattern [%s] configured for the Reader", indexPattern)
+            );
+        }
+    }
+
+    /**
+     * Create a Reader based on provided parameters
+     *
+     * @param indexPattern the index pattern if creating an index Reader
+     * @param namedXContentRegistry for parsing purposes
+     * @return QueryInsightsReader the created Reader
+     */
+    public QueryInsightsReader createReader(String indexPattern, NamedXContentRegistry namedXContentRegistry) {
+        QueryInsightsReader Reader = new LocalIndexReader(client, DateTimeFormat.forPattern(indexPattern), namedXContentRegistry);
+        this.Readers.add(Reader);
+        return Reader;
+    }
+
+    /**
+     * Update a Reader based on provided parameters
+     *
+     * @param Reader The Reader to update
+     * @param indexPattern the index pattern if creating a index Reader
+     * @return QueryInsightsReader the updated Reader sink
+     */
+    public QueryInsightsReader updateReader(QueryInsightsReader Reader, String indexPattern) {
+        if (Reader.getClass() == LocalIndexReader.class) {
+            ((LocalIndexReader) Reader).setIndexPattern(DateTimeFormat.forPattern(indexPattern));
+        }
+        return Reader;
+    }
+
+    /**
+     * Close a Reader
+     *
+     * @param Reader the Reader to close
+     */
+    public void closeReader(QueryInsightsReader Reader) throws IOException {
+        if (Reader != null) {
+            Reader.close();
+            this.Readers.remove(Reader);
+        }
+    }
+
+    /**
+     * Close all Readers
+     *
+     */
+    public void closeAllReaders() {
+        for (QueryInsightsReader Reader : Readers) {
+            try {
+                closeReader(Reader);
+            } catch (IOException e) {
+                logger.error("Fail to close query insights Reader, error: ", e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
@@ -8,6 +8,9 @@
 
 package org.opensearch.plugin.insights.core.reader;
 
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Locale;
@@ -18,10 +21,6 @@ import org.joda.time.format.DateTimeFormat;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-
-import javax.naming.Name;
-
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.*;
 
 /**
  * Factory class for validating and creating Readers based on provided settings
@@ -81,7 +80,7 @@ public class QueryInsightsReaderFactory {
      * Update a Reader based on provided parameters
      *
      * @param Reader The Reader to update
-     * @param indexPattern the index pattern if creating a index Reader
+     * @param indexPattern the index pattern if creating an index Reader
      * @return QueryInsightsReader the updated Reader sink
      */
     public QueryInsightsReader updateReader(QueryInsightsReader Reader, String indexPattern) {

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/package-info.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Query Insights reader
+ */
+package org.opensearch.plugin.insights.core.reader;

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -121,8 +121,8 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         for (MetricType type : MetricType.allMetricTypes()) {
             clusterSettings.addSettingsUpdateConsumer(
                 getExporterSettings(type),
-                (settings -> setExporterReader(type, settings)),
-                (settings -> validateExporterReaderConfig(type, settings))
+                (settings -> setExporterAndReader(type, settings)),
+                (settings -> validateExporterAndReaderConfig(type, settings))
             );
         }
 
@@ -304,7 +304,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      * @param type {@link MetricType}
      * @param settings exporter and reader settings
      */
-    public void setExporterReader(final MetricType type, final Settings settings) {
+    public void setExporterAndReader(final MetricType type, final Settings settings) {
         if (topQueriesServices.containsKey(type)) {
             TopQueriesService tqs = topQueriesServices.get(type);
             tqs.setExporter(settings);
@@ -326,10 +326,10 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      * @param type {@link MetricType}
      * @param settings exporter and reader settings
      */
-    public void validateExporterReaderConfig(final MetricType type, final Settings settings) {
+    public void validateExporterAndReaderConfig(final MetricType type, final Settings settings) {
         if (topQueriesServices.containsKey(type)) {
             TopQueriesService tqs = topQueriesServices.get(type);
-            tqs.validateExporterReaderConfig(settings);
+            tqs.validateExporterAndReaderConfig(settings);
         }
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -81,7 +81,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      * Query Insights reader factory
      */
     final QueryInsightsReaderFactory queryInsightsReaderFactory;
-  
+
     /**
      * Flags for enabling insight data grouping for different metric types
      */

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -36,8 +36,6 @@ import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
 
-import javax.naming.Name;
-
 /**
  * Service responsible for gathering, analyzing, storing and exporting
  * information related to search queries
@@ -104,7 +102,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         final Client client,
         final MetricsRegistry metricsRegistry,
         final NamedXContentRegistry namedXContentRegistry
-        ) {
+    ) {
         enableCollect = new HashMap<>();
         queryRecordsQueue = new LinkedBlockingQueue<>(QueryInsightsSettings.QUERY_RECORD_QUEUE_CAPACITY);
         this.threadPool = threadPool;
@@ -115,7 +113,10 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         topQueriesServices = new HashMap<>();
         for (MetricType metricType : MetricType.allMetricTypes()) {
             enableCollect.put(metricType, false);
-            topQueriesServices.put(metricType, new TopQueriesService(metricType, threadPool, queryInsightsExporterFactory, queryInsightsReaderFactory));
+            topQueriesServices.put(
+                metricType,
+                new TopQueriesService(metricType, threadPool, queryInsightsExporterFactory, queryInsightsReaderFactory)
+            );
         }
         for (MetricType type : MetricType.allMetricTypes()) {
             clusterSettings.addSettingsUpdateConsumer(

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -42,10 +42,10 @@ import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporterFactory
 import org.opensearch.plugin.insights.core.exporter.SinkType;
 import org.opensearch.plugin.insights.core.reader.QueryInsightsReader;
 import org.opensearch.plugin.insights.core.reader.QueryInsightsReaderFactory;
-import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.core.service.grouper.MinMaxHeapQueryGrouper;
 import org.opensearch.plugin.insights.core.service.grouper.QueryGrouper;
 import org.opensearch.plugin.insights.rules.model.AggregationType;
+import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -61,11 +61,19 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     }
 
     /**
-     * Get from and to for timestamp request
-     * @return String[] of from and to timestamp
+     * Get from for timestamp request
+     * @return String of fromtimestamp
      */
-    public String[] getTimeRange() {
-        return new String[] { from, to };
+    public String getFrom() {
+        return from;
+    }
+
+    /**
+     * Get to for timestamp request
+     * @return String of to timestamp
+     */
+    public String getTo() {
+        return to;
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -62,9 +62,10 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
 
     /**
      * Get from and to for timestamp request
+     * @return String[] of from and to timestamp
      */
     public String[] getTimeRange() {
-        return new String[] {from, to};
+        return new String[] { from, to };
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -20,6 +20,8 @@ import org.opensearch.plugin.insights.rules.model.MetricType;
 public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
 
     final MetricType metricType;
+    final String from;
+    final String to;
 
     /**
      * Constructor for TopQueriesRequest
@@ -30,6 +32,8 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     public TopQueriesRequest(final StreamInput in) throws IOException {
         super(in);
         this.metricType = MetricType.readFromStream(in);
+        this.from = null;
+        this.to = null;
     }
 
     /**
@@ -37,11 +41,15 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
      * If none are passed, cluster level top queries will be returned.
      *
      * @param metricType {@link MetricType}
+     * @param from start timestamp
+     * @param to end timestamp
      * @param nodesIds the nodeIds specified in the request
      */
-    public TopQueriesRequest(final MetricType metricType, final String... nodesIds) {
+    public TopQueriesRequest(final MetricType metricType, final String from, final String to, final String... nodesIds) {
         super(nodesIds);
         this.metricType = metricType;
+        this.from = from;
+        this.to = to;
     }
 
     /**
@@ -49,6 +57,13 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
      */
     public MetricType getMetricType() {
         return metricType;
+    }
+
+    /**
+     * Get from and to for timestamp request
+     */
+    public String[] getTimeRange() {
+        return new String[] {from, to};
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -9,8 +9,11 @@
 package org.opensearch.plugin.insights.rules.model;
 
 import java.io.IOException;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -21,7 +24,12 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
-import org.opensearch.core.xcontent.*;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.core.xcontent.XContentParserUtils;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
@@ -126,11 +134,8 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
         long timestamp = 0L;
         Map<MetricType, Number> measurements = new HashMap<>();
         Map<Attribute, Object> attributes = new HashMap<>();
-        XContentParser parser = XContentType.JSON.xContent().createParser(
-            namedXContentRegistry,
-            LoggingDeprecationHandler.INSTANCE,
-            hit.getSourceAsString()
-        );
+        XContentParser parser = XContentType.JSON.xContent()
+            .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString());
         parser.nextToken();
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -9,26 +9,80 @@
 package org.opensearch.plugin.insights.rules.model;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
-import org.opensearch.core.xcontent.MediaTypeRegistry;
-import org.opensearch.core.xcontent.ToXContent;
-import org.opensearch.core.xcontent.ToXContentObject;
-import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceInfo;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
+import org.opensearch.core.xcontent.*;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.tasks.Task;
 
 /**
  * SearchQueryRecord represents a minimal atomic record stored in the Query Insight Framework,
  * which contains extensive information related to a search query.
  */
 public class SearchQueryRecord implements ToXContentObject, Writeable {
+    private static final Logger log = LogManager.getLogger(SearchQueryRecord.class);
     private final long timestamp;
     private final Map<MetricType, Number> measurements;
     private final Map<Attribute, Object> attributes;
+    /**
+     * Timestamp
+     */
+    public static final String TIMESTAMP = "timestamp";
+    /**
+     * Latency time
+     */
+    public static final String LATENCY = "latency";
+    /**
+     * CPU usage
+     */
+    public static final String CPU = "cpu";
+    /**
+     * Memory usage
+     */
+    public static final String MEMORY = "memory";
+    /**
+     * The search query type
+     */
+    public static final String SEARCH_TYPE = "search_type";
+    /**
+     * The search query source
+     */
+    public static final String SOURCE = "source";
+    /**
+     * Total shards queried
+     */
+    public static final String TOTAL_SHARDS = "total_shards";
+    /**
+     * The indices involved
+     */
+    public static final String INDICES = "indices";
+    /**
+     * The per phase level latency map for a search query
+     */
+    public static final String PHASE_LATENCY_MAP = "phase_latency_map";
+    /**
+     * The node id for this request
+     */
+    public static final String NODE_ID = "node_id";
+    /**
+     * Tasks level resource usages in this request
+     */
+    public static final String TASK_RESOURCE_USAGES = "task_resource_usages";
+    /**
+     * Custom search request labels
+     */
+    public static final String LABELS = "labels";
 
     /**
      * Constructor of SearchQueryRecord
@@ -59,6 +113,126 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
         this.measurements = measurements;
         this.attributes = attributes;
         this.timestamp = timestamp;
+    }
+
+    /**
+     * Returns a SearchQueryRecord from a SearchHit
+     *
+     * @param hit SearchHit to parse into SearchQueryRecord
+     * @param namedXContentRegistry NamedXContentRegistry for parsing purposes
+     * @return SearchQueryRecord
+     */
+    public static SearchQueryRecord getRecord(SearchHit hit, NamedXContentRegistry namedXContentRegistry) throws IOException {
+        long timestamp = 0L;
+        Map<MetricType, Number> measurements = new HashMap<>();
+        Map<Attribute, Object> attributes = new HashMap<>();
+        XContentParser parser = XContentType.JSON.xContent().createParser(
+            namedXContentRegistry,
+            LoggingDeprecationHandler.INSTANCE,
+            hit.getSourceAsString()
+        );
+        parser.nextToken();
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+            try {
+                switch (fieldName) {
+                    case TIMESTAMP:
+                        timestamp = parser.longValue();
+                        break;
+                    case LATENCY:
+                    case CPU:
+                    case MEMORY:
+                        MetricType metric = MetricType.fromString(fieldName);
+                        measurements.put(metric, metric.parseValue(parser.longValue()));
+                        break;
+                    case SEARCH_TYPE:
+                        attributes.put(Attribute.SEARCH_TYPE, parser.text());
+                        break;
+                    case SOURCE:
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+                        attributes.put(Attribute.SOURCE, SearchSourceBuilder.fromXContent(parser, false));
+                        break;
+                    case TOTAL_SHARDS:
+                        attributes.put(Attribute.TOTAL_SHARDS, parser.intValue());
+                        break;
+                    case INDICES:
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                        List<String> indices = new ArrayList<>();
+                        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                            indices.add(parser.text());
+                        }
+                        attributes.put(Attribute.INDICES, indices.toArray());
+                        break;
+                    case PHASE_LATENCY_MAP:
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+                        Map<String, Long> phaseLatencyMap = new HashMap<>();
+                        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                            String phase = parser.currentName();
+                            parser.nextToken();
+                            phaseLatencyMap.put(phase, parser.longValue());
+                        }
+                        attributes.put(Attribute.PHASE_LATENCY_MAP, phaseLatencyMap);
+                        break;
+                    case NODE_ID:
+                        attributes.put(Attribute.NODE_ID, parser.text());
+                        break;
+                    case TASK_RESOURCE_USAGES:
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                        List<TaskResourceInfo> tasksResourceUsages = new ArrayList<>();
+                        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                            String action = "";
+                            long taskId = 0L;
+                            long parentTaskId = 0L;
+                            String nodeId = "";
+                            TaskResourceUsage taskRU = new TaskResourceUsage(0L, 0L);
+                            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+                            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                                String usageFields = parser.currentName();
+                                parser.nextToken();
+                                switch (usageFields) {
+                                    case "action":
+                                        action = parser.text();
+                                        break;
+                                    case "taskId":
+                                        taskId = parser.longValue();
+                                        break;
+                                    case "parentTaskId":
+                                        parentTaskId = parser.longValue();
+                                        break;
+                                    case "nodeId":
+                                        nodeId = parser.text();
+                                        break;
+                                    case "taskResourceUsage":
+                                        taskRU = TaskResourceUsage.fromXContent(parser);
+                                        break;
+                                    default:
+                                        break;
+                                }
+                            }
+                            TaskResourceInfo resourceInfo = new TaskResourceInfo(action, taskId, parentTaskId, nodeId, taskRU);
+                            tasksResourceUsages.add(resourceInfo);
+                        }
+                        attributes.put(Attribute.TASK_RESOURCE_USAGES, tasksResourceUsages);
+                        break;
+                    case LABELS:
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+                        Map<String, Object> labels = new HashMap<>();
+                        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                            parser.nextToken();
+                            labels.put(Task.X_OPAQUE_ID, parser.text());
+                        }
+                        attributes.put(Attribute.LABELS, labels);
+                        break;
+                    default:
+                        break;
+                }
+            } catch (Exception e) {
+                log.error("Error when parsing through search hit", e);
+            }
+        }
+        return new SearchQueryRecord(timestamp, measurements, attributes);
     }
 
     /**
@@ -109,7 +283,7 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
     }
 
     @Override
-    public XContentBuilder toXContent(final XContentBuilder builder, final ToXContent.Params params) throws IOException {
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject();
         builder.field("timestamp", timestamp);
         for (Map.Entry<Attribute, Object> entry : attributes.entrySet()) {

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -11,12 +11,13 @@ package org.opensearch.plugin.insights.rules.model;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.Strings;
@@ -34,7 +35,6 @@ import org.opensearch.core.xcontent.XContentParserUtils;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
-import org.opensearch.Version;
 
 /**
  * SearchQueryRecord represents a minimal atomic record stored in the Query Insight Framework,
@@ -93,7 +93,7 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      * Custom search request labels
      */
     public static final String LABELS = "labels";
-  
+
     public static final String MEASUREMENTS = "measurements";
     private String groupingId;
 
@@ -149,7 +149,7 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      */
     public static SearchQueryRecord getRecord(SearchHit hit, NamedXContentRegistry namedXContentRegistry) throws IOException {
         long timestamp = 0L;
-        Map<MetricType, Number> measurements = new HashMap<>();
+        Map<MetricType, Measurement> measurements = new HashMap<>();
         Map<Attribute, Object> attributes = new HashMap<>();
         XContentParser parser = XContentType.JSON.xContent()
             .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString());
@@ -167,7 +167,7 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
                     case CPU:
                     case MEMORY:
                         MetricType metric = MetricType.fromString(fieldName);
-                        measurements.put(metric, metric.parseValue(parser.longValue()));
+                        measurements.put(metric, new Measurement(metric.parseValue(parser.longValue())));
                         break;
                     case SEARCH_TYPE:
                         attributes.put(Attribute.SEARCH_TYPE, parser.text());

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
@@ -67,12 +67,14 @@ public class RestTopQueriesAction extends BaseRestHandler {
     static TopQueriesRequest prepareRequest(final RestRequest request) {
         final String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         final String metricType = request.param("type", MetricType.LATENCY.toString());
+        final String from = request.param("from");
+        final String to = request.param("to");
         if (!ALLOWED_METRICS.contains(metricType)) {
             throw new IllegalArgumentException(
                 String.format(Locale.ROOT, "request [%s] contains invalid metric type [%s]", request.path(), metricType)
             );
         }
-        return new TopQueriesRequest(MetricType.fromString(metricType), nodesIds);
+        return new TopQueriesRequest(MetricType.fromString(metricType), from, to, nodesIds);
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -86,13 +86,13 @@ public class TransportTopQueriesAction extends TransportNodesAction<
             default:
                 size = clusterService.getClusterSettings().get(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE);
         }
-        final String[] timeRange = topQueriesRequest.getTimeRange();
-        if (timeRange[0] != null && timeRange[1] != null) {
+        final String from = topQueriesRequest.getFrom();
+        final String to = topQueriesRequest.getTo();
+        if (from != null && to != null) {
             responses.add(
                 new TopQueries(
                     clusterService.localNode(),
-                    queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType())
-                        .getTopQueriesRecordsFromIndex(timeRange[0], timeRange[1])
+                    queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType()).getTopQueriesRecordsFromIndex(from, to)
                 )
             );
         }
@@ -112,10 +112,11 @@ public class TransportTopQueriesAction extends TransportNodesAction<
     @Override
     protected TopQueries nodeOperation(final NodeRequest nodeRequest) {
         final TopQueriesRequest request = nodeRequest.request;
-        final String[] timeRange = request.getTimeRange();
+        final String from = request.getFrom();
+        final String to = request.getTo();
         return new TopQueries(
             clusterService.localNode(),
-            queryInsightsService.getTopQueriesService(request.getMetricType()).getTopQueriesRecords(true, timeRange[0], timeRange[1])
+            queryInsightsService.getTopQueriesService(request.getMetricType()).getTopQueriesRecords(true, from, to)
         );
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -88,7 +88,13 @@ public class TransportTopQueriesAction extends TransportNodesAction<
         }
         final String[] timeRange = topQueriesRequest.getTimeRange();
         if (timeRange[0] != null && timeRange[1] != null) {
-            responses.add(new TopQueries(clusterService.localNode(), queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType()).getTopQueriesRecordsFromIndex(timeRange[0], timeRange[1])));
+            responses.add(
+                new TopQueries(
+                    clusterService.localNode(),
+                    queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType())
+                        .getTopQueriesRecordsFromIndex(timeRange[0], timeRange[1])
+                )
+            );
         }
         return new TopQueriesResponse(clusterService.getClusterName(), responses, failures, size, topQueriesRequest.getMetricType());
     }

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -86,6 +86,10 @@ public class TransportTopQueriesAction extends TransportNodesAction<
             default:
                 size = clusterService.getClusterSettings().get(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE);
         }
+        final String[] timeRange = topQueriesRequest.getTimeRange();
+        if (timeRange[0] != null && timeRange[1] != null) {
+            responses.add(new TopQueries(clusterService.localNode(), queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType()).getTopQueriesRecordsFromIndex(timeRange[0], timeRange[1])));
+        }
         return new TopQueriesResponse(clusterService.getClusterName(), responses, failures, size, topQueriesRequest.getMetricType());
     }
 
@@ -102,9 +106,10 @@ public class TransportTopQueriesAction extends TransportNodesAction<
     @Override
     protected TopQueries nodeOperation(final NodeRequest nodeRequest) {
         final TopQueriesRequest request = nodeRequest.request;
+        final String[] timeRange = request.getTimeRange();
         return new TopQueries(
             clusterService.localNode(),
-            queryInsightsService.getTopQueriesService(request.getMetricType()).getTopQueriesRecords(true)
+            queryInsightsService.getTopQueriesService(request.getMetricType()).getTopQueriesRecords(true, timeRange[0], timeRange[1])
         );
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -180,7 +180,6 @@ public class QueryInsightsSettings {
      * Config key for export index
      */
     public static final String EXPORT_INDEX = "config.index";
-
     /**
      * Settings and defaults for top queries exporters
      */
@@ -201,6 +200,7 @@ public class QueryInsightsSettings {
      * Default exporter type of top queries
      */
     public static final String DEFAULT_TOP_QUERIES_EXPORTER_TYPE = SinkType.LOCAL_INDEX.toString();
+
 
     /**
      * Settings for the exporter of top latency queries

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -201,7 +201,6 @@ public class QueryInsightsSettings {
      */
     public static final String DEFAULT_TOP_QUERIES_EXPORTER_TYPE = SinkType.LOCAL_INDEX.toString();
 
-
     /**
      * Settings for the exporter of top latency queries
      */

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
@@ -65,8 +65,8 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
 
         BytesReference sourceRef;
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-            builder.map(sourceMap); // Writes the map to XContentBuilder
-            sourceRef = BytesReference.bytes(builder); // Converts XContentBuilder to BytesReference
+            builder.map(sourceMap);
+            sourceRef = BytesReference.bytes(builder);
         } catch (IOException e) {
             throw new RuntimeException("Failed to build XContent", e);
         }

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.reader;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.lucene.search.TotalHits;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.junit.Before;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.common.action.ActionFuture;
+import org.opensearch.common.document.DocumentField;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Granular tests for the {@link LocalIndexReaderTests} class.
+ */
+public class LocalIndexReaderTests extends OpenSearchTestCase {
+    private final DateTimeFormatter format = DateTimeFormat.forPattern("YYYY.MM.dd");
+    private final Client client = mock(Client.class);
+    private final NamedXContentRegistry namedXContentRegistry = mock(NamedXContentRegistry.class);
+    private LocalIndexReader localIndexReader;
+
+    @Before
+    public void setup() {
+        localIndexReader = new LocalIndexReader(client, format, namedXContentRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testReadRecords() {
+        ActionFuture<SearchResponse> responseActionFuture = mock(ActionFuture.class);
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("timestamp", DateTime.now(DateTimeZone.UTC).getMillis());
+        sourceMap.put("indices", Collections.singletonList("my-index-0"));
+        sourceMap.put("source", Map.of());
+        sourceMap.put("labels", Map.of());
+        sourceMap.put("cpu", 10000);
+        sourceMap.put("memory", 20000);
+        sourceMap.put("latency", 3);
+
+        BytesReference sourceRef;
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.map(sourceMap); // Writes the map to XContentBuilder
+            sourceRef = BytesReference.bytes(builder); // Converts XContentBuilder to BytesReference
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to build XContent", e);
+        }
+
+        SearchHit hit = new SearchHit(
+            1,
+            "id1",
+            Collections.singletonMap("_source", new DocumentField("_source", List.of(sourceMap))),
+            new HashMap<>()
+        );
+        hit.sourceRef(sourceRef);
+        SearchHits searchHits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        when(searchResponse.getHits()).thenReturn(searchHits);
+        when(responseActionFuture.actionGet()).thenReturn(searchResponse);
+        when(client.search(any(SearchRequest.class))).thenReturn(responseActionFuture);
+        String time = DateTime.now(DateTimeZone.UTC).toString();
+        List<SearchQueryRecord> records = List.of();
+        try {
+            records = localIndexReader.read(time, time);
+        } catch (Exception e) {
+            fail("No exception should be thrown when reading query insights data");
+        }
+        assertNotNull(records);
+        assertEquals(1, records.size());
+    }
+
+    public void testClose() {
+        try {
+            localIndexReader.close();
+        } catch (Exception e) {
+            fail("No exception should be thrown when closing local index reader");
+        }
+    }
+
+    public void testGetAndSetIndexPattern() {
+        DateTimeFormatter newFormatter = mock(DateTimeFormatter.class);
+        localIndexReader.setIndexPattern(newFormatter);
+        assert (localIndexReader.getIndexPattern() == newFormatter);
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
@@ -36,7 +36,6 @@ public class QueryInsightsReaderFactoryTests extends OpenSearchTestCase {
 
     public void testValidateConfigWhenResetReader() {
         Settings.Builder settingsBuilder = Settings.builder();
-        // empty settings
         Settings settings = settingsBuilder.build();
         try {
             queryInsightsReaderFactory.validateReaderConfig(settings);

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.reader;
+
+import static org.mockito.Mockito.mock;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
+
+import org.joda.time.format.DateTimeFormat;
+import org.junit.Before;
+import org.opensearch.client.Client;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Granular tests for the {@link QueryInsightsReaderFactoryTests} class.
+ */
+public class QueryInsightsReaderFactoryTests extends OpenSearchTestCase {
+    private final String format = DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
+
+    private final Client client = mock(Client.class);
+    private final NamedXContentRegistry namedXContentRegistry = mock(NamedXContentRegistry.class);
+    private QueryInsightsReaderFactory queryInsightsReaderFactory;
+
+    @Before
+    public void setup() {
+        queryInsightsReaderFactory = new QueryInsightsReaderFactory(client);
+    }
+
+    public void testValidateConfigWhenResetReader() {
+        Settings.Builder settingsBuilder = Settings.builder();
+        // empty settings
+        Settings settings = settingsBuilder.build();
+        try {
+            queryInsightsReaderFactory.validateReaderConfig(settings);
+        } catch (Exception e) {
+            fail("No exception should be thrown when setting is null");
+        }
+    }
+
+    public void testInvalidReaderTypeConfig() {
+        Settings.Builder settingsBuilder = Settings.builder();
+        Settings settings = settingsBuilder.put(EXPORT_INDEX, "some_invalid_type").build();
+        assertThrows(IllegalArgumentException.class, () -> { queryInsightsReaderFactory.validateReaderConfig(settings); });
+    }
+
+    public void testCreateAndCloseReader() {
+        QueryInsightsReader reader1 = queryInsightsReaderFactory.createReader(format, namedXContentRegistry);
+        assertTrue(reader1 instanceof LocalIndexReader);
+        try {
+            queryInsightsReaderFactory.closeReader(reader1);
+            queryInsightsReaderFactory.closeAllReaders();
+        } catch (Exception e) {
+            fail("No exception should be thrown when closing reader");
+        }
+    }
+
+    public void testUpdateReader() {
+        LocalIndexReader reader = new LocalIndexReader(client, DateTimeFormat.forPattern(format), namedXContentRegistry);
+        queryInsightsReaderFactory.updateReader(reader, "yyyy-MM-dd-HH");
+        assertEquals(DateTimeFormat.forPattern("yyyy-MM-dd-HH"), reader.getIndexPattern());
+    }
+
+}

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -120,7 +120,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
 
         assertEquals(
             QueryInsightsSettings.DEFAULT_TOP_N_SIZE,
-            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false).size()
+            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null).size()
         );
     }
 
@@ -143,7 +143,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         assertTrue(queryInsightsService.addRecord(records.get(numberOfRecordsRequired - 1)));
 
         queryInsightsService.drainRecords();
-        assertEquals(1, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false).size());
+        assertEquals(1, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null).size());
     }
 
     public void testAddRecordGroupBySimilarityWithTwoGroups() {
@@ -162,6 +162,6 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         }
 
         queryInsightsService.drainRecords();
-        assertEquals(2, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false).size());
+        assertEquals(2, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null).size());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
@@ -30,6 +31,7 @@ import org.opensearch.threadpool.ThreadPool;
 public class QueryInsightsServiceTests extends OpenSearchTestCase {
     private final ThreadPool threadPool = mock(ThreadPool.class);
     private final Client client = mock(Client.class);
+    private final NamedXContentRegistry namedXContentRegistry = mock(NamedXContentRegistry.class);
     private QueryInsightsService queryInsightsService;
     private QueryInsightsService queryInsightsServiceSpy;
 
@@ -39,7 +41,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         Settings settings = settingsBuilder.build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         QueryInsightsTestUtils.registerAllQueryInsightsSettings(clusterSettings);
-        queryInsightsService = new QueryInsightsService(clusterSettings, threadPool, client, NoopMetricsRegistry.INSTANCE);
+        queryInsightsService = new QueryInsightsService(clusterSettings, threadPool, client, NoopMetricsRegistry.INSTANCE, namedXContentRegistry);
         queryInsightsService.enableCollection(MetricType.LATENCY, true);
         queryInsightsService.enableCollection(MetricType.CPU, true);
         queryInsightsService.enableCollection(MetricType.MEMORY, true);
@@ -56,7 +58,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         queryInsightsService.drainRecords();
         assertEquals(
             QueryInsightsSettings.DEFAULT_TOP_N_SIZE,
-            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false).size()
+            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null).size()
         );
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -40,7 +40,13 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         Settings settings = settingsBuilder.build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         QueryInsightsTestUtils.registerAllQueryInsightsSettings(clusterSettings);
-        queryInsightsService = new QueryInsightsService(clusterSettings, threadPool, client, NoopMetricsRegistry.INSTANCE, namedXContentRegistry);
+        queryInsightsService = new QueryInsightsService(
+            clusterSettings,
+            threadPool,
+            client,
+            NoopMetricsRegistry.INSTANCE,
+            namedXContentRegistry
+        );
         queryInsightsService.enableCollection(MetricType.LATENCY, true);
         queryInsightsService.enableCollection(MetricType.CPU, true);
         queryInsightsService.enableCollection(MetricType.MEMORY, true);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -119,13 +119,13 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         records = QueryInsightsTestUtils.generateQueryInsightRecords(5, 5, System.currentTimeMillis() - 1000 * 60 * 10, 0);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(0, topQueriesService.getTopQueriesRecords(true).size());
+        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null).size());
 
         // Create 10 records at now + 1 minute, to make sure they belong to the current window
         records = QueryInsightsTestUtils.generateQueryInsightRecords(10, 10, System.currentTimeMillis() + 1000 * 60, 0);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(10, topQueriesService.getTopQueriesRecords(true).size());
+        assertEquals(10, topQueriesService.getTopQueriesRecords(true, null, null).size());
     }
 
     public void testRollingWindowsWithDifferentGroup() {
@@ -137,13 +137,13 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
 
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(0, topQueriesService.getTopQueriesRecords(true).size());
+        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null).size());
 
         // Create 10 records at now + 1 minute, to make sure they belong to the current window
         records = QueryInsightsTestUtils.generateQueryInsightRecords(10, 10, System.currentTimeMillis() + 1000 * 60, 0);
         QueryInsightsTestUtils.populateSameQueryHashcodes(records);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(1, topQueriesService.getTopQueriesRecords(true).size());
+        assertEquals(1, topQueriesService.getTopQueriesRecords(true, null, null).size());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -17,6 +17,7 @@ import org.opensearch.cluster.coordination.DeterministicTaskQueue;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
 import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporterFactory;
+import org.opensearch.plugin.insights.core.reader.QueryInsightsReaderFactory;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
@@ -30,10 +31,11 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     private TopQueriesService topQueriesService;
     private final ThreadPool threadPool = mock(ThreadPool.class);
     private final QueryInsightsExporterFactory queryInsightsExporterFactory = mock(QueryInsightsExporterFactory.class);
+    private final QueryInsightsReaderFactory queryInsightsReaderFactory = mock(QueryInsightsReaderFactory.class);
 
     @Before
     public void setup() {
-        topQueriesService = new TopQueriesService(MetricType.LATENCY, threadPool, queryInsightsExporterFactory);
+        topQueriesService = new TopQueriesService(MetricType.LATENCY, threadPool, queryInsightsExporterFactory, queryInsightsReaderFactory);
         topQueriesService.setTopNSize(Integer.MAX_VALUE);
         topQueriesService.setWindowSize(new TimeValue(Long.MAX_VALUE));
         topQueriesService.setEnabled(true);
@@ -44,7 +46,7 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         topQueriesService.consumeRecords(records);
         assertTrue(
             QueryInsightsTestUtils.checkRecordsEqualsWithoutOrder(
-                topQueriesService.getTopQueriesRecords(false),
+                topQueriesService.getTopQueriesRecords(false, null, null),
                 records,
                 MetricType.LATENCY
             )
@@ -57,20 +59,20 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         records = QueryInsightsTestUtils.generateQueryInsightRecords(5, 5, System.currentTimeMillis() - 1000 * 60 * 10, 0);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(0, topQueriesService.getTopQueriesRecords(true).size());
+        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null).size());
 
         // Create 10 records at now + 1 minute, to make sure they belong to the current window
         records = QueryInsightsTestUtils.generateQueryInsightRecords(10, 10, System.currentTimeMillis() + 1000 * 60, 0);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(10, topQueriesService.getTopQueriesRecords(true).size());
+        assertEquals(10, topQueriesService.getTopQueriesRecords(true, null, null).size());
     }
 
     public void testSmallNSize() {
         final List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(10);
         topQueriesService.setTopNSize(1);
         topQueriesService.consumeRecords(records);
-        assertEquals(1, topQueriesService.getTopQueriesRecords(false).size());
+        assertEquals(1, topQueriesService.getTopQueriesRecords(false, null, null).size());
     }
 
     public void testValidateTopNSize() {
@@ -83,7 +85,7 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
 
     public void testGetTopQueriesWhenNotEnabled() {
         topQueriesService.setEnabled(false);
-        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.getTopQueriesRecords(false); });
+        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.getTopQueriesRecords(false, null, null); });
     }
 
     public void testValidateWindowSize() {

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequestTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequestTests.java
@@ -22,7 +22,7 @@ public class TopQueriesRequestTests extends OpenSearchTestCase {
      * Check that we can set the metric type
      */
     public void testSetMetricType() throws Exception {
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, randomAlphaOfLength(5));
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, randomAlphaOfLength(5));
         TopQueriesRequest deserializedRequest = roundTripRequest(request);
         assertEquals(request.getMetricType(), deserializedRequest.getMetricType());
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesActionTests.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesRequest;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -25,6 +27,8 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
     public void testEmptyNodeIdsValidType() {
         Map<String, String> params = new HashMap<>();
         params.put("type", randomFrom(ALLOWED_METRICS));
+        params.put("from", DateTime.now(DateTimeZone.UTC).toString());
+        params.put("to", DateTime.now(DateTimeZone.UTC).toString());
         RestRequest restRequest = buildRestRequest(params);
         TopQueriesRequest actual = RestTopQueriesAction.prepareRequest(restRequest);
         assertEquals(0, actual.nodesIds().length);
@@ -50,6 +54,57 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
         assertEquals(
             String.format(Locale.ROOT, "request [/_insights/top_queries] contains invalid metric type [%s]", params.get("type")),
             exception.getMessage()
+        );
+    }
+
+    public void testInValidFrom() {
+        Map<String, String> params = new HashMap<>();
+        params.put("from", "not valid timestamp");
+        params.put("to", DateTime.now(DateTimeZone.UTC).toString());
+        RestRequest restRequest = buildRestRequest(params);
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest); });
+        assertEquals(
+            String.format(
+                Locale.ROOT,
+                "request [/_insights/top_queries] contains invalid 'from' date format. Expected ISO8601 format string (YYYY-MM-DD'T'HH:mm:ss.SSSZ): [%s]",
+                params.get("from")
+            ),
+            exception.getMessage()
+        );
+    }
+
+    public void testInValidTo() {
+        Map<String, String> params = new HashMap<>();
+        params.put("from", DateTime.now(DateTimeZone.UTC).toString());
+        params.put("to", "not valid timestamp");
+        RestRequest restRequest = buildRestRequest(params);
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest); });
+        assertEquals(
+            String.format(
+                Locale.ROOT,
+                "request [/_insights/top_queries] contains invalid 'to' date format. Expected ISO8601 format string (YYYY-MM-DD'T'HH:mm:ss.SSSZ): [%s]",
+                params.get("to")
+            ),
+            exception.getMessage()
+        );
+    }
+
+    public void testMissingOneTimeParam() {
+        Map<String, String> params = new HashMap<>();
+        params.put("from", DateTime.now(DateTimeZone.UTC).toString());
+        RestRequest restRequest = buildRestRequest(params);
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest); });
+        assertEquals(
+            "request [/_insights/top_queries] is missing one of the time parameters. Both must be provided",
+            exception.getMessage()
+        );
+        Map<String, String> params2 = new HashMap<>();
+        params2.put("to", DateTime.now(DateTimeZone.UTC).toString());
+        RestRequest restRequest2 = buildRestRequest(params2);
+        Exception exception2 = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest2); });
+        assertEquals(
+            "request [/_insights/top_queries] is missing one of the time parameters. Both must be provided",
+            exception2.getMessage()
         );
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
@@ -64,7 +64,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
         }
 
         public TopQueriesResponse createNewResponse() {
-            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null,  null);
+            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null);
             return newResponse(request, List.of(), List.of());
         }
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
@@ -64,7 +64,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
         }
 
         public TopQueriesResponse createNewResponse() {
-            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY);
+            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null,  null);
             return newResponse(request, List.of(), List.of());
         }
     }


### PR DESCRIPTION
### Description

When the local index exporter is enabled, historical top N queries data is stored there. Previously, obtaining these historical queries required manually searching through each index. To simplify this process for users, we've introduced two parameters: 'from' and 'to', to the top n queries request. This allows users to define the time range for retrieving historical data. Please ensure that from and to are in ISO format. 

For example, you could make this following call to retrieve the top N queries from August 25, 2024, at 15:00 UTC to August 30, 2024, at 17:00 UTC.
`curl -X GET "http://localhost:9200/_insights/top_queries?from=2024-08-25T15:00:00.000Z&to=2024-08-30T17:00:00.000Z"`

### Issues Resolved
Closes #12 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
