### PR TITLE
Refactor parsing logic for Measurement

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -18,7 +18,10 @@ import org.joda.time.format.DateTimeFormatter;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -104,7 +107,9 @@ public final class LocalIndexReader implements QueryInsightsReader {
             try {
                 SearchResponse searchResponse = client.search(searchRequest).actionGet();
                 for (SearchHit hit : searchResponse.getHits()) {
-                    SearchQueryRecord record = SearchQueryRecord.getRecord(hit, namedXContentRegistry);
+                    XContentParser parser = XContentType.JSON.xContent()
+                        .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, hit.getSourceAsString());
+                    SearchQueryRecord record = SearchQueryRecord.fromXContent(parser);
                     records.add(record);
                 }
             } catch (IndexNotFoundException ignored) {} catch (Exception e) {

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -240,8 +240,19 @@ final public class QueryInsightsTestUtils {
         Map<MetricType, Measurement> measurements = Map.of(MetricType.LATENCY, new Measurement(1L));
 
         Map<String, Long> phaseLatencyMap = new HashMap<>();
+        phaseLatencyMap.put("expand", 1L);
+        phaseLatencyMap.put("query", 10L);
+        phaseLatencyMap.put("fetch", 1L);
         Map<Attribute, Object> attributes = new HashMap<>();
         attributes.put(Attribute.SEARCH_TYPE, SearchType.QUERY_THEN_FETCH.toString().toLowerCase(Locale.ROOT));
+        attributes.put(Attribute.PHASE_LATENCY_MAP, phaseLatencyMap);
+        attributes.put(
+            Attribute.TASK_RESOURCE_USAGES,
+            List.of(
+                new TaskResourceInfo("action", 2L, 1L, "id", new TaskResourceUsage(1000L, 2000L)),
+                new TaskResourceInfo("action2", 3L, 1L, "id2", new TaskResourceUsage(2000L, 1000L))
+            )
+        );
 
         return new SearchQueryRecord(timestamp, measurements, attributes);
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
@@ -41,7 +41,7 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
 
     public void testToXContent() throws IOException {
         char[] expectedXcontent =
-            "{\"top_queries\":[{\"timestamp\":1706574180000,\"phase_latency_map\":{\"expand\":1,\"query\":10,\"fetch\":1},\"search_type\":\"query_then_fetch\",\"node_id\":\"node_for_top_queries_test\",\"measurements\":{\"latency\":{\"number\":1,\"count\":1,\"aggregationType\":\"NONE\"}}}]}"
+            "{\"top_queries\":[{\"timestamp\":1706574180000,\"node_id\":\"node_for_top_queries_test\",\"phase_latency_map\":{\"expand\":1,\"query\":10,\"fetch\":1},\"task_resource_usages\":[{\"action\":\"action\",\"taskId\":2,\"parentTaskId\":1,\"nodeId\":\"id\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":1000,\"memory_in_bytes\":2000}},{\"action\":\"action2\",\"taskId\":3,\"parentTaskId\":1,\"nodeId\":\"id2\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":2000,\"memory_in_bytes\":1000}}],\"search_type\":\"query_then_fetch\",\"measurements\":{\"latency\":{\"number\":1,\"count\":1,\"aggregationType\":\"NONE\"}}}]}"
                 .toCharArray();
         TopQueries topQueries = QueryInsightsTestUtils.createFixedTopQueries();
         ClusterName clusterName = new ClusterName("test-cluster");

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
@@ -41,7 +41,7 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
 
     public void testToXContent() throws IOException {
         char[] expectedXcontent =
-            "{\"top_queries\":[{\"timestamp\":1706574180000,\"node_id\":\"node_for_top_queries_test\",\"search_type\":\"query_then_fetch\",\"measurements\":{\"latency\":{\"number\":1,\"count\":1,\"aggregationType\":\"NONE\"}}}]}"
+            "{\"top_queries\":[{\"timestamp\":1706574180000,\"phase_latency_map\":{\"expand\":1,\"query\":10,\"fetch\":1},\"search_type\":\"query_then_fetch\",\"node_id\":\"node_for_top_queries_test\",\"measurements\":{\"latency\":{\"number\":1,\"count\":1,\"aggregationType\":\"NONE\"}}}]}"
                 .toCharArray();
         TopQueries topQueries = QueryInsightsTestUtils.createFixedTopQueries();
         ClusterName clusterName = new ClusterName("test-cluster");

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
@@ -14,7 +14,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -52,6 +54,16 @@ public class SearchQueryRecordTests extends OpenSearchTestCase {
         SearchQueryRecord record1 = QueryInsightsTestUtils.createFixedSearchQueryRecord();
         SearchQueryRecord record2 = QueryInsightsTestUtils.createFixedSearchQueryRecord();
         assertEquals(record1, record2);
+    }
+
+    public void testFromXContent() {
+        SearchQueryRecord record = QueryInsightsTestUtils.createFixedSearchQueryRecord();
+        try (XContentParser recordParser = createParser(JsonXContent.jsonXContent, record.toString())) {
+            SearchQueryRecord parsedRecord = SearchQueryRecord.fromXContent(recordParser);
+            QueryInsightsTestUtils.checkRecordsEquals(List.of(record), List.of(parsedRecord));
+        } catch (Exception e) {
+            fail("Test should not throw exceptions when parsing search query record");
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Currently the path to parse a `Measurement` Object in `SearchQueryRecord` assumes measurement only has a Number value. Since we introduced aggregation in https://github.com/opensearch-project/query-insights/pull/66/files#diff-121513dc0c9407809aae27a6def385b2238c68e417b199cd1fe570220fc5c28cR23, `Measurement` now is an Object with `number`, `count` and `aggregation type` fields. we need to refactor the parsing logic in all related paths.

### Issues Resolved
https://github.com/opensearch-project/query-insights/issues/107

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
