### PR TITLE
Use separate targets for security enabled tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -271,9 +271,8 @@ integTest {
     jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'
   }
   if (System.getProperty("security.enabled") == "true" || System.getProperty("https") == "true") {
-    // Exclude this IT, because they executed in another task (:integTestWithSecurity)
-    exclude 'org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRestIT.class'
-    exclude 'org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterIT.class'
+    // Exclude the ITs when security is enabled, because they executed in another task (:integTestWithSecurity)
+    exclude 'org/opensearch/plugin/insights/**/*IT.class'
   }
 }
 
@@ -345,7 +344,7 @@ task integTestWithSecurity(type: RestIntegTestTask) {
   }
 
   filter {
-    includeTestsMatching 'org.opensearch.plugin.insights.rules.resthandler.top_queries.TopQueriesRestIT'
+    includeTestsMatching 'org.opensearch.plugin.insights.*IT'
   }
 }
 


### PR DESCRIPTION
### Description
Use separate targets for security enabled tests. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
