### PR TITLE
Add data models for health stats API

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.client.Client;
@@ -449,10 +450,9 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      * @return QueryInsightsHealthStats
      */
     public QueryInsightsHealthStats getHealthStats() {
-        Map<MetricType, TopQueriesHealthStats> topQueriesHealthStatsMap = new HashMap<>();
-        for (Map.Entry<MetricType, TopQueriesService> entry : topQueriesServices.entrySet()) {
-            topQueriesHealthStatsMap.put(entry.getKey(), entry.getValue().getHealthStats());
-        }
+        Map<MetricType, TopQueriesHealthStats> topQueriesHealthStatsMap = topQueriesServices.entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getHealthStats()));
         return new QueryInsightsHealthStats(
             threadPool.info(QUERY_INSIGHTS_EXECUTOR),
             this.queryRecordsQueue.size(),

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -49,6 +49,7 @@ import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.healthStats.TopQueriesHealthStats;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -515,5 +516,14 @@ public class TopQueriesService {
         topQueriesStore.clear();
         topQueriesHistorySnapshot.set(new ArrayList<>());
         topQueriesCurrentSnapshot.set(new ArrayList<>());
+    }
+
+    /**
+     * Get top queries service health stats
+     *
+     * @return TopQueriesHealthStats
+     */
+    public TopQueriesHealthStats getHealthStats() {
+        return new TopQueriesHealthStats(this.topQueriesStore.size(), this.queryGrouper.getHealthStats());
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/grouper/QueryGrouper.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/grouper/QueryGrouper.java
@@ -10,6 +10,7 @@ package org.opensearch.plugin.insights.core.service.grouper;
 
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.healthStats.QueryGrouperHealthStats;
 
 /**
  * Interface for grouping search queries based on grouping type for the metric type.
@@ -57,4 +58,11 @@ public interface QueryGrouper {
      * @param topNSize the new top N size
      */
     void updateTopNSize(int topNSize);
+
+    /**
+     * Get health stats of the QueryGrouperService
+     *
+     * @return QueryGrouperHealthStats
+     */
+    QueryGrouperHealthStats getHealthStats();
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/MetricType.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/MetricType.java
@@ -62,7 +62,7 @@ public enum MetricType implements Comparator<Number> {
      * @param metricType the MetricType to write
      * @throws IOException IOException
      */
-    static void writeTo(final StreamOutput out, final MetricType metricType) throws IOException {
+    public static void writeTo(final StreamOutput out, final MetricType metricType) throws IOException {
         out.writeString(metricType.toString());
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryGrouperHealthStats.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryGrouperHealthStats.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.healthStats;
+
+import java.io.IOException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+/**
+ * Represents the health statistics of the query grouper.
+ */
+public class QueryGrouperHealthStats implements ToXContentFragment, Writeable {
+    private final int queryGroupCount;
+    private final int queryGroupHeapSize;
+    private static final String QUERY_GROUP_COUNT = "QueryGroupCount";
+    private static final String QUERY_GROUP_HEAP_SIZE = "QueryGroupHeapSize";
+
+    /**
+     * Constructor to read QueryGrouperHealthStats from a StreamInput.
+     *
+     * @param in the StreamInput to read the QueryGrouperHealthStats from
+     * @throws IOException IOException
+     */
+    public QueryGrouperHealthStats(final StreamInput in) throws IOException {
+        this.queryGroupCount = in.readInt();
+        this.queryGroupHeapSize = in.readInt();
+    }
+
+    /**
+     * Constructor of QueryGrouperHealthStats
+     *
+     * @param queryGroupCount Number of groups in the grouper
+     * @param queryGroupHeapSize Heap size of the grouper
+     */
+    public QueryGrouperHealthStats(final int queryGroupCount, final int queryGroupHeapSize) {
+        this.queryGroupCount = queryGroupCount;
+        this.queryGroupHeapSize = queryGroupHeapSize;
+    }
+
+    /**
+     * Write QueryGrouperHealthStats Object to output stream
+     * @param out streamOutput
+     * @throws IOException IOException
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInt(queryGroupCount);
+        out.writeInt(queryGroupHeapSize);
+    }
+
+    /**
+     * Write QueryGrouperHealthStats object to XContent
+     *
+     * @param builder XContentBuilder
+     * @param params Parameters
+     * @return XContentBuilder
+     * @throws IOException IOException
+     */
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(QUERY_GROUP_COUNT, queryGroupCount);
+        builder.field(QUERY_GROUP_HEAP_SIZE, queryGroupHeapSize);
+        return builder;
+    }
+
+    /**
+     * Gets the number of query groups.
+     *
+     * @return the query group count
+     */
+    public int getQueryGroupCount() {
+        return queryGroupCount;
+    }
+
+    /**
+     * Gets the query group heap size.
+     *
+     * @return the query group heap size
+     */
+    public int getQueryGroupHeapSize() {
+        return queryGroupHeapSize;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryGrouperHealthStats.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryGrouperHealthStats.java
@@ -21,8 +21,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 public class QueryGrouperHealthStats implements ToXContentFragment, Writeable {
     private final int queryGroupCount;
     private final int queryGroupHeapSize;
-    private static final String QUERY_GROUP_COUNT = "QueryGroupCount";
-    private static final String QUERY_GROUP_HEAP_SIZE = "QueryGroupHeapSize";
+    private static final String QUERY_GROUP_COUNT_TOTAL = "QueryGroupCount_Total";
+    private static final String QUERY_GROUP_COUNT_MAX_HEAP = "QueryGroupCount_MaxHeap";
 
     /**
      * Constructor to read QueryGrouperHealthStats from a StreamInput.
@@ -67,8 +67,8 @@ public class QueryGrouperHealthStats implements ToXContentFragment, Writeable {
      */
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(QUERY_GROUP_COUNT, queryGroupCount);
-        builder.field(QUERY_GROUP_HEAP_SIZE, queryGroupHeapSize);
+        builder.field(QUERY_GROUP_COUNT_TOTAL, queryGroupCount);
+        builder.field(QUERY_GROUP_COUNT_MAX_HEAP, queryGroupHeapSize);
         return builder;
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryInsightsHealthStats.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryInsightsHealthStats.java
@@ -1,0 +1,136 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.healthStats;
+
+import java.io.IOException;
+import java.util.Map;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.threadpool.ThreadPoolInfo;
+
+/**
+ * QueryInsightsHealthStats holds the stats on one node to indicate the health of the Query Insights plugin.
+ */
+public class QueryInsightsHealthStats implements ToXContentFragment, Writeable {
+    private final ThreadPool.Info threadPoolInfo;
+    private final int queryRecordsQueueSize;
+    private final Map<MetricType, TopQueriesHealthStats> topQueriesHealthStats;
+
+    private static final String THREAD_POOL_INFO = "ThreadPoolInfo";
+    private static final String QUERY_RECORDS_QUEUE_SIZE = "QueryRecordsQueueSize";
+    private static final String TOP_QUERIES_HEALTH_STATS = "TopQueriesHealthStats";
+
+    /**
+     * Constructor to read QueryInsightsHealthStats from a StreamInput.
+     *
+     * @param in the StreamInput to read the QueryInsightsHealthStats from
+     * @throws IOException if an I/O error occurs
+     */
+    public QueryInsightsHealthStats(final StreamInput in) throws IOException {
+        this.threadPoolInfo = new ThreadPool.Info(in);
+        this.queryRecordsQueueSize = in.readInt();
+        this.topQueriesHealthStats = in.readMap(MetricType::readFromStream, TopQueriesHealthStats::new);
+    }
+
+    /**
+     * Constructor of QueryInsightsHealthStats
+     *
+     * @param threadPoolInfo the {@link ThreadPoolInfo} of the internal Query Insights threadPool
+     * @param queryRecordsQueueSize The generic Query Record Queue size
+     * @param topQueriesHealthStats Top Queries health stats
+     */
+    public QueryInsightsHealthStats(
+        final ThreadPool.Info threadPoolInfo,
+        final int queryRecordsQueueSize,
+        final Map<MetricType, TopQueriesHealthStats> topQueriesHealthStats
+    ) {
+        if (threadPoolInfo == null || topQueriesHealthStats == null) {
+            throw new IllegalArgumentException("Parameters cannot be null");
+        }
+        this.threadPoolInfo = threadPoolInfo;
+        this.queryRecordsQueueSize = queryRecordsQueueSize;
+        this.topQueriesHealthStats = topQueriesHealthStats;
+    }
+
+    /**
+     * Write QueryInsightsHealthStats object to XContent
+     *
+     * @param builder XContentBuilder
+     * @param params Parameters for build xContent
+     * @return XContentBuilder
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        // Write thread pool info object
+        builder.startObject(THREAD_POOL_INFO);
+        threadPoolInfo.toXContent(builder, params);
+        builder.endObject();
+        // Write query records queue size
+        builder.field(QUERY_RECORDS_QUEUE_SIZE, queryRecordsQueueSize);
+        // Write Top Queries health stats object
+        builder.startObject(TOP_QUERIES_HEALTH_STATS);
+        for (Map.Entry<MetricType, TopQueriesHealthStats> entry : topQueriesHealthStats.entrySet()) {
+            builder.startObject(entry.getKey().toString());
+            entry.getValue().toXContent(builder, params);
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    /**
+     * Write QueryInsightsHealthStats Object to output stream
+     *
+     * @param out streamOutput
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        threadPoolInfo.writeTo(out);
+        out.writeInt(queryRecordsQueueSize);
+        out.writeMap(
+            topQueriesHealthStats,
+            MetricType::writeTo,
+            (streamOutput, topQueriesHealthStats) -> topQueriesHealthStats.writeTo(out)
+        );
+    }
+
+    /**
+     * Get the thread pool info.
+     *
+     * @return the thread pool info
+     */
+    public ThreadPool.Info getThreadPoolInfo() {
+        return threadPoolInfo;
+    }
+
+    /**
+     * Get the query records queue size.
+     *
+     * @return the query records queue size
+     */
+    public int getQueryRecordsQueueSize() {
+        return queryRecordsQueueSize;
+    }
+
+    /**
+     * Get the top queries health stats.
+     *
+     * @return the top queries health stats
+     */
+    public Map<MetricType, TopQueriesHealthStats> getTopQueriesHealthStats() {
+        return topQueriesHealthStats;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/TopQueriesHealthStats.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/TopQueriesHealthStats.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.healthStats;
+
+import java.io.IOException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+/**
+ *  Represents the health statistics of top queries, including heap sizes and query grouper health stats.
+ */
+public class TopQueriesHealthStats implements ToXContentFragment, Writeable {
+    private final int topQueriesHeapSize;
+    private final QueryGrouperHealthStats queryGrouperHealthStats;
+    private static final String TOP_QUERIES_HEAP_SIZE = "TopQueriesHeapSize";
+
+    /**
+     * Constructor to read TopQueriesHealthStats from a StreamInput.
+     *
+     * @param in the StreamInput to read the TopQueriesHealthStats from
+     * @throws IOException if an I/O error occurs
+     */
+    public TopQueriesHealthStats(final StreamInput in) throws IOException {
+        this.topQueriesHeapSize = in.readInt();
+        this.queryGrouperHealthStats = new QueryGrouperHealthStats(in);
+    }
+
+    /**
+     * Constructor of TopQueriesHealthStats
+     *
+     * @param topQueriesHeapSize Top Queries heap size
+     * @param queryGrouperHealthStats Health stats for query grouper
+     */
+    public TopQueriesHealthStats(final int topQueriesHeapSize, final QueryGrouperHealthStats queryGrouperHealthStats) {
+        this.topQueriesHeapSize = topQueriesHeapSize;
+        this.queryGrouperHealthStats = queryGrouperHealthStats;
+    }
+
+    /**
+     * Write TopQueriesHealthStats Object to output stream
+     *
+     * @param out streamOutput
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInt(topQueriesHeapSize);
+        queryGrouperHealthStats.writeTo(out);
+    }
+
+    /**
+     * Write TopQueriesHealthStats object to XContent
+     *
+     * @param builder XContentBuilder
+     * @param params Parameters
+     * @return XContentBuilder
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(TOP_QUERIES_HEAP_SIZE, topQueriesHeapSize);
+        queryGrouperHealthStats.toXContent(builder, params);
+        return builder;
+    }
+
+    /**
+     * Gets the top queries heap size.
+     *
+     * @return the top queries heap size
+     */
+    public int getTopQueriesHeapSize() {
+        return topQueriesHeapSize;
+    }
+
+    /**
+     * Gets the query grouper health stats.
+     *
+     * @return the query grouper health stats
+     */
+    public QueryGrouperHealthStats getQueryGrouperHealthStats() {
+        return queryGrouperHealthStats;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/package-info.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/healthStats/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * health stats models
+ */
+package org.opensearch.plugin.insights.rules.model.healthStats;

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -21,6 +21,7 @@ import org.opensearch.plugin.insights.core.reader.QueryInsightsReaderFactory;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.healthStats.TopQueriesHealthStats;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -145,5 +146,30 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
         assertEquals(1, topQueriesService.getTopQueriesRecords(true, null, null).size());
+    }
+
+    public void testGetHealthStats_EmptyService() {
+        // Get the health stats from an empty TopQueriesService
+        TopQueriesHealthStats healthStats = topQueriesService.getHealthStats();
+        // Validate the health stats
+        assertNotNull(healthStats);
+        assertEquals(0, healthStats.getTopQueriesHeapSize());
+        assertNotNull(healthStats.getQueryGrouperHealthStats());
+        assertEquals(0, healthStats.getQueryGrouperHealthStats().getQueryGroupCount());
+        assertEquals(0, healthStats.getQueryGrouperHealthStats().getQueryGroupHeapSize());
+    }
+
+    public void testGetHealthStats_WithData() {
+        // Add some mock records to the TopQueriesService
+        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(2);
+        topQueriesService.consumeRecords(records);
+        // Get the health stats after adding data
+        TopQueriesHealthStats healthStats = topQueriesService.getHealthStats();
+        // Validate the health stats
+        assertNotNull(healthStats);
+        assertEquals(2, healthStats.getTopQueriesHeapSize()); // Since we added two records
+        assertNotNull(healthStats.getQueryGrouperHealthStats());
+        // Assuming no grouping by default, expect QueryGroupCount to be 2
+        assertEquals(0, healthStats.getQueryGrouperHealthStats().getQueryGroupCount());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -149,7 +149,6 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     }
 
     public void testGetHealthStats_EmptyService() {
-        // Get the health stats from an empty TopQueriesService
         TopQueriesHealthStats healthStats = topQueriesService.getHealthStats();
         // Validate the health stats
         assertNotNull(healthStats);
@@ -160,16 +159,13 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     }
 
     public void testGetHealthStats_WithData() {
-        // Add some mock records to the TopQueriesService
         List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(2);
         topQueriesService.consumeRecords(records);
-        // Get the health stats after adding data
         TopQueriesHealthStats healthStats = topQueriesService.getHealthStats();
-        // Validate the health stats
         assertNotNull(healthStats);
         assertEquals(2, healthStats.getTopQueriesHeapSize()); // Since we added two records
         assertNotNull(healthStats.getQueryGrouperHealthStats());
-        // Assuming no grouping by default, expect QueryGroupCount to be 2
+        // Assuming no grouping by default, expect QueryGroupCount to be 0
         assertEquals(0, healthStats.getQueryGrouperHealthStats().getQueryGroupCount());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
@@ -19,6 +19,7 @@ import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.healthStats.QueryGrouperHealthStats;
 import org.opensearch.test.OpenSearchTestCase;
 
 /**
@@ -677,6 +678,24 @@ public class MinMaxHeapQueryGrouperTests extends OpenSearchTestCase {
         assertEquals(1, minMaxHeapQueryGrouper.numberOfTopGroups());
         assertEquals(850L, topQueriesStore.poll().getMeasurement(MetricType.LATENCY));
         assertEquals(2, minMaxHeapQueryGrouper.numberOfGroups());
+    }
+
+    public void testGetHealthStatsWithEmptyGrouper() {
+        QueryGrouperHealthStats healthStats = minMaxHeapQueryGrouper.getHealthStats();
+        // Expecting 0 group count and 0 heap size since no groups have been added
+        assertEquals(0, healthStats.getQueryGroupCount());
+        assertEquals(0, healthStats.getQueryGroupHeapSize());
+    }
+
+    public void testGetHealthStatsWithGroups() {
+        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(2);
+        minMaxHeapQueryGrouper.add(records.get(0));
+        minMaxHeapQueryGrouper.add(records.get(1));
+        QueryGrouperHealthStats healthStats = minMaxHeapQueryGrouper.getHealthStats();
+        // Verify that group count stats reflect the correct number of total groups
+        assertEquals(2, healthStats.getQueryGroupCount());
+        // Verify that heap size reflect the correct number of groups in max heap
+        assertEquals(0, healthStats.getQueryGroupHeapSize());
     }
 
     private MinMaxHeapQueryGrouper getQueryGroupingService(AggregationType aggregationType, int topNSize) {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
@@ -694,7 +694,6 @@ public class MinMaxHeapQueryGrouperTests extends OpenSearchTestCase {
         QueryGrouperHealthStats healthStats = minMaxHeapQueryGrouper.getHealthStats();
         // Verify that group count stats reflect the correct number of total groups
         assertEquals(2, healthStats.getQueryGroupCount());
-        // Verify that heap size reflect the correct number of groups in max heap
         assertEquals(0, healthStats.getQueryGroupHeapSize());
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryGrouperHealthStatsTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryGrouperHealthStatsTests.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.healthStats;
+
+import java.io.IOException;
+import java.util.Locale;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for the {@link QueryGrouperHealthStats} class.
+ */
+public class QueryGrouperHealthStatsTests extends OpenSearchTestCase {
+    private final int queryGroupCount = 10;
+    private final int queryGroupHeapSize = 5;
+
+    public void testConstructorAndGetters() {
+        QueryGrouperHealthStats stats = new QueryGrouperHealthStats(queryGroupCount, queryGroupHeapSize);
+        assertEquals(queryGroupCount, stats.getQueryGroupCount());
+        assertEquals(queryGroupHeapSize, stats.getQueryGroupHeapSize());
+    }
+
+    public void testSerialization() throws IOException {
+        QueryGrouperHealthStats stats = new QueryGrouperHealthStats(queryGroupCount, queryGroupHeapSize);
+        // Write to StreamOutput
+        BytesStreamOutput out = new BytesStreamOutput();
+        stats.writeTo(out);
+        // Read from StreamInput
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        QueryGrouperHealthStats deserializedStats = new QueryGrouperHealthStats(in);
+        // Assert equality
+        assertEquals(stats.getQueryGroupCount(), deserializedStats.getQueryGroupCount());
+        assertEquals(stats.getQueryGroupHeapSize(), deserializedStats.getQueryGroupHeapSize());
+    }
+
+    public void testToXContent() throws IOException {
+        QueryGrouperHealthStats stats = new QueryGrouperHealthStats(queryGroupCount, queryGroupHeapSize);
+        // Write to XContent
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        stats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String expectedJson = String.format(
+            Locale.ROOT,
+            "{\"QueryGroupCount\":%d,\"QueryGroupHeapSize\":%d}",
+            queryGroupCount,
+            queryGroupHeapSize
+        );
+        assertEquals(expectedJson, builder.toString());
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryGrouperHealthStatsTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryGrouperHealthStatsTests.java
@@ -38,21 +38,19 @@ public class QueryGrouperHealthStatsTests extends OpenSearchTestCase {
         // Read from StreamInput
         StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
         QueryGrouperHealthStats deserializedStats = new QueryGrouperHealthStats(in);
-        // Assert equality
         assertEquals(stats.getQueryGroupCount(), deserializedStats.getQueryGroupCount());
         assertEquals(stats.getQueryGroupHeapSize(), deserializedStats.getQueryGroupHeapSize());
     }
 
     public void testToXContent() throws IOException {
         QueryGrouperHealthStats stats = new QueryGrouperHealthStats(queryGroupCount, queryGroupHeapSize);
-        // Write to XContent
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         stats.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String expectedJson = String.format(
             Locale.ROOT,
-            "{\"QueryGroupCount\":%d,\"QueryGroupHeapSize\":%d}",
+            "{\"QueryGroupCount_Total\":%d,\"QueryGroupCount_MaxHeap\":%d}",
             queryGroupCount,
             queryGroupHeapSize
         );

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryInsightsHealthStatsTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryInsightsHealthStatsTests.java
@@ -69,7 +69,6 @@ public class QueryInsightsHealthStatsTests extends OpenSearchTestCase {
         // Read from StreamInput
         StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
         QueryInsightsHealthStats deserializedHealthStats = new QueryInsightsHealthStats(in);
-        // Assert equality
         assertEquals(healthStats.getQueryRecordsQueueSize(), deserializedHealthStats.getQueryRecordsQueueSize());
         assertNotNull(deserializedHealthStats.getThreadPoolInfo());
         assertNotNull(deserializedHealthStats.getTopQueriesHealthStats());
@@ -77,7 +76,6 @@ public class QueryInsightsHealthStatsTests extends OpenSearchTestCase {
 
     public void testToXContent() throws IOException {
         QueryInsightsHealthStats healthStats = new QueryInsightsHealthStats(threadPoolInfo, queryRecordsQueueSize, topQueriesHealthStats);
-        // Create XContentBuilder to build JSON
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
 
@@ -99,8 +97,8 @@ public class QueryInsightsHealthStatsTests extends OpenSearchTestCase {
             + "    \"TopQueriesHealthStats\": {\n"
             + "        \"latency\": {\n"
             + "            \"TopQueriesHeapSize\": 10,\n"
-            + "            \"QueryGroupCount\": 20,\n"
-            + "            \"QueryGroupHeapSize\": 15\n"
+            + "            \"QueryGroupCount_Total\": 20,\n"
+            + "            \"QueryGroupCount_MaxHeap\": 15\n"
             + "        }\n"
             + "    }\n"
             + "}";

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryInsightsHealthStatsTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryInsightsHealthStatsTests.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.healthStats;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ScalingExecutorBuilder;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * Unit tests for the {@link QueryInsightsHealthStats} class.
+ */
+public class QueryInsightsHealthStatsTests extends OpenSearchTestCase {
+    private ThreadPool threadPool;
+    private ThreadPool.Info threadPoolInfo;
+    private int queryRecordsQueueSize;
+    private Map<MetricType, TopQueriesHealthStats> topQueriesHealthStats;
+
+    @Before
+    public void setUpQueryInsightsHealthStats() {
+        this.threadPool = new TestThreadPool(
+            "QueryInsightsHealthStatsTests",
+            new ScalingExecutorBuilder(QueryInsightsSettings.QUERY_INSIGHTS_EXECUTOR, 1, 5, TimeValue.timeValueMinutes(5))
+        );
+        threadPoolInfo = threadPool.info(QueryInsightsSettings.QUERY_INSIGHTS_EXECUTOR);
+        queryRecordsQueueSize = 100;
+        topQueriesHealthStats = new HashMap<>();
+        topQueriesHealthStats.put(MetricType.LATENCY, new TopQueriesHealthStats(10, new QueryGrouperHealthStats(20, 15)));
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+    }
+
+    public void testConstructorAndGetters() {
+        QueryInsightsHealthStats healthStats = new QueryInsightsHealthStats(threadPoolInfo, queryRecordsQueueSize, topQueriesHealthStats);
+        assertNotNull(healthStats);
+        assertEquals(threadPoolInfo, healthStats.getThreadPoolInfo());
+        assertEquals(queryRecordsQueueSize, healthStats.getQueryRecordsQueueSize());
+        assertEquals(topQueriesHealthStats, healthStats.getTopQueriesHealthStats());
+    }
+
+    public void testSerialization() throws IOException {
+        QueryInsightsHealthStats healthStats = new QueryInsightsHealthStats(threadPoolInfo, queryRecordsQueueSize, topQueriesHealthStats);
+        // Write to StreamOutput
+        BytesStreamOutput out = new BytesStreamOutput();
+        healthStats.writeTo(out);
+        // Read from StreamInput
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        QueryInsightsHealthStats deserializedHealthStats = new QueryInsightsHealthStats(in);
+        // Assert equality
+        assertEquals(healthStats.getQueryRecordsQueueSize(), deserializedHealthStats.getQueryRecordsQueueSize());
+        assertNotNull(deserializedHealthStats.getThreadPoolInfo());
+        assertNotNull(deserializedHealthStats.getTopQueriesHealthStats());
+    }
+
+    public void testToXContent() throws IOException {
+        QueryInsightsHealthStats healthStats = new QueryInsightsHealthStats(threadPoolInfo, queryRecordsQueueSize, topQueriesHealthStats);
+        // Create XContentBuilder to build JSON
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+
+        healthStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String jsonOutput = builder.prettyPrint().toString();
+        // Expected JSON output
+        String expectedJson = "{\n"
+            + "    \"ThreadPoolInfo\": {\n"
+            + "        \"query_insights_executor\": {\n"
+            + "            \"type\": \"scaling\",\n"
+            + "            \"core\": 1,\n"
+            + "            \"max\": 5,\n"
+            + "            \"keep_alive\": \"5m\",\n"
+            + "            \"queue_size\": -1\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"QueryRecordsQueueSize\": 100,\n"
+            + "    \"TopQueriesHealthStats\": {\n"
+            + "        \"latency\": {\n"
+            + "            \"TopQueriesHeapSize\": 10,\n"
+            + "            \"QueryGroupCount\": 20,\n"
+            + "            \"QueryGroupHeapSize\": 15\n"
+            + "        }\n"
+            + "    }\n"
+            + "}";
+        assertEquals(expectedJson.replaceAll("\\s", ""), jsonOutput.replaceAll("\\s", ""));
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/TopQueriesHealthStatsTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/TopQueriesHealthStatsTests.java
@@ -38,7 +38,6 @@ public class TopQueriesHealthStatsTests extends OpenSearchTestCase {
         // Read from StreamInput
         StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
         TopQueriesHealthStats deserializedHealthStats = new TopQueriesHealthStats(in);
-        // Assert equality
         assertEquals(healthStats.getTopQueriesHeapSize(), deserializedHealthStats.getTopQueriesHeapSize());
         assertNotNull(deserializedHealthStats.getQueryGrouperHealthStats());
         assertEquals(
@@ -53,14 +52,13 @@ public class TopQueriesHealthStatsTests extends OpenSearchTestCase {
 
     public void testToXContent() throws IOException {
         TopQueriesHealthStats healthStats = new TopQueriesHealthStats(topQueriesHeapSize, queryGrouperHealthStats);
-        // Write to XContent
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         healthStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         String expectedJson = String.format(
             Locale.ROOT,
-            "{\"TopQueriesHeapSize\":%d,\"QueryGroupCount\":%d,\"QueryGroupHeapSize\":%d}",
+            "{\"TopQueriesHeapSize\":%d,\"QueryGroupCount_Total\":%d,\"QueryGroupCount_MaxHeap\":%d}",
             topQueriesHeapSize,
             queryGrouperHealthStats.getQueryGroupCount(),
             queryGrouperHealthStats.getQueryGroupHeapSize()

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/TopQueriesHealthStatsTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/TopQueriesHealthStatsTests.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.model.healthStats;
+
+import java.io.IOException;
+import java.util.Locale;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for the {@link TopQueriesHealthStats} class.
+ */
+public class TopQueriesHealthStatsTests extends OpenSearchTestCase {
+    private final int topQueriesHeapSize = 15;
+    private final QueryGrouperHealthStats queryGrouperHealthStats = new QueryGrouperHealthStats(10, 5);
+
+    public void testConstructorAndGetters() {
+        TopQueriesHealthStats healthStats = new TopQueriesHealthStats(topQueriesHeapSize, queryGrouperHealthStats);
+        assertEquals(topQueriesHeapSize, healthStats.getTopQueriesHeapSize());
+        assertEquals(queryGrouperHealthStats, healthStats.getQueryGrouperHealthStats());
+    }
+
+    public void testSerialization() throws IOException {
+        TopQueriesHealthStats healthStats = new TopQueriesHealthStats(topQueriesHeapSize, queryGrouperHealthStats);
+        // Write to StreamOutput
+        BytesStreamOutput out = new BytesStreamOutput();
+        healthStats.writeTo(out);
+        // Read from StreamInput
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        TopQueriesHealthStats deserializedHealthStats = new TopQueriesHealthStats(in);
+        // Assert equality
+        assertEquals(healthStats.getTopQueriesHeapSize(), deserializedHealthStats.getTopQueriesHeapSize());
+        assertNotNull(deserializedHealthStats.getQueryGrouperHealthStats());
+        assertEquals(
+            healthStats.getQueryGrouperHealthStats().getQueryGroupCount(),
+            deserializedHealthStats.getQueryGrouperHealthStats().getQueryGroupCount()
+        );
+        assertEquals(
+            healthStats.getQueryGrouperHealthStats().getQueryGroupHeapSize(),
+            deserializedHealthStats.getQueryGrouperHealthStats().getQueryGroupHeapSize()
+        );
+    }
+
+    public void testToXContent() throws IOException {
+        TopQueriesHealthStats healthStats = new TopQueriesHealthStats(topQueriesHeapSize, queryGrouperHealthStats);
+        // Write to XContent
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        healthStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        String expectedJson = String.format(
+            Locale.ROOT,
+            "{\"TopQueriesHeapSize\":%d,\"QueryGroupCount\":%d,\"QueryGroupHeapSize\":%d}",
+            topQueriesHeapSize,
+            queryGrouperHealthStats.getQueryGroupCount(),
+            queryGrouperHealthStats.getQueryGroupHeapSize()
+        );
+        assertEquals(expectedJson, builder.toString());
+    }
+}


### PR DESCRIPTION
### Description
Add data models and related unit tests for health stats API. It includes health stats data model for:
- top queries service
- query grouper service
- query insights service

### Issues Resolved
Related to https://github.com/opensearch-project/query-insights/issues/9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
