### PR TITLE
Add field type to query shape

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -239,7 +240,16 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
                 );
             }
 
-            String hashcode = QueryShapeGenerator.getShapeHashCodeAsString(request.source(), false);
+            Set<String> successfulShardIndices = searchRequestContext.getSuccessfulSearchShardIndices();
+            if (successfulShardIndices == null) {
+                successfulShardIndices = Collections.emptySet();
+            }
+            String hashcode = QueryShapeGenerator.getShapeHashCodeAsString(
+                request.source(),
+                false,
+                clusterService.state().getMetadata(),
+                successfulShardIndices
+            );
 
             Map<Attribute, Object> attributes = new HashMap<>();
             attributes.put(Attribute.SEARCH_TYPE, request.searchType().toString().toLowerCase(Locale.ROOT));

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGenerator.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGenerator.java
@@ -12,7 +12,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.hash.MurmurHash3;
 import org.opensearch.core.common.io.stream.NamedWriteable;
 import org.opensearch.index.query.QueryBuilder;
@@ -34,16 +39,28 @@ public class QueryShapeGenerator {
      * Method to get query shape hash code given a source
      * @param source search request source
      * @param showFields whether to include field data in query shape
+     * @param metadata contains index mappings
+     * @param searchIndices successful indices searched
      * @return Hash code of query shape as a MurmurHash3.Hash128 object (128-bit)
      */
-    public static MurmurHash3.Hash128 getShapeHashCode(SearchSourceBuilder source, Boolean showFields) {
-        final String shape = buildShape(source, showFields);
+    public static MurmurHash3.Hash128 getShapeHashCode(
+        SearchSourceBuilder source,
+        Boolean showFields,
+        Metadata metadata,
+        Set<String> searchIndices
+    ) {
+        final String shape = buildShape(source, showFields, metadata, searchIndices);
         final BytesRef shapeBytes = new BytesRef(shape);
         return MurmurHash3.hash128(shapeBytes.bytes, 0, shapeBytes.length, 0, new MurmurHash3.Hash128());
     }
 
-    public static String getShapeHashCodeAsString(SearchSourceBuilder source, Boolean showFields) {
-        MurmurHash3.Hash128 hashcode = getShapeHashCode(source, showFields);
+    public static String getShapeHashCodeAsString(
+        SearchSourceBuilder source,
+        Boolean showFields,
+        Metadata metadata,
+        Set<String> searchIndices
+    ) {
+        MurmurHash3.Hash128 hashcode = getShapeHashCode(source, showFields, metadata, searchIndices);
         String hashAsString = Long.toHexString(hashcode.h1) + Long.toHexString(hashcode.h2);
         return hashAsString;
     }
@@ -52,13 +69,15 @@ public class QueryShapeGenerator {
      * Method to build search query shape given a source
      * @param source search request source
      * @param showFields whether to append field data
+     * @param metadata contains index mappings
+     * @param searchIndices successful indices searched
      * @return Search query shape as String
      */
-    public static String buildShape(SearchSourceBuilder source, Boolean showFields) {
+    public static String buildShape(SearchSourceBuilder source, Boolean showFields, Metadata metadata, Set<String> searchIndices) {
         StringBuilder shape = new StringBuilder();
-        shape.append(buildQueryShape(source.query(), showFields));
-        shape.append(buildAggregationShape(source.aggregations(), showFields));
-        shape.append(buildSortShape(source.sorts(), showFields));
+        shape.append(buildQueryShape(source.query(), showFields, metadata, searchIndices));
+        shape.append(buildAggregationShape(source.aggregations(), showFields, metadata, searchIndices));
+        shape.append(buildSortShape(source.sorts(), showFields, metadata, searchIndices));
         return shape.toString();
     }
 
@@ -68,11 +87,11 @@ public class QueryShapeGenerator {
      * @param showFields whether to append field data
      * @return Query-section shape as String
      */
-    static String buildQueryShape(QueryBuilder queryBuilder, Boolean showFields) {
+    static String buildQueryShape(QueryBuilder queryBuilder, Boolean showFields, Metadata metadata, Set<String> searchIndices) {
         if (queryBuilder == null) {
             return EMPTY_STRING;
         }
-        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor();
+        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor(metadata, searchIndices);
         queryBuilder.visit(shapeVisitor);
         return shapeVisitor.prettyPrintTree(EMPTY_STRING, showFields);
     }
@@ -83,7 +102,12 @@ public class QueryShapeGenerator {
      * @param showFields whether to append field data
      * @return Aggregation shape as String
      */
-    static String buildAggregationShape(AggregatorFactories.Builder aggregationsBuilder, Boolean showFields) {
+    static String buildAggregationShape(
+        AggregatorFactories.Builder aggregationsBuilder,
+        Boolean showFields,
+        Metadata metadata,
+        Set<String> searchIndices
+    ) {
         if (aggregationsBuilder == null) {
             return EMPTY_STRING;
         }
@@ -92,7 +116,9 @@ public class QueryShapeGenerator {
             aggregationsBuilder.getPipelineAggregatorFactories(),
             new StringBuilder(),
             new StringBuilder(),
-            showFields
+            showFields,
+            metadata,
+            searchIndices
         );
         return aggregationShape.toString();
     }
@@ -102,7 +128,9 @@ public class QueryShapeGenerator {
         Collection<PipelineAggregationBuilder> pipelineAggregations,
         StringBuilder outputBuilder,
         StringBuilder baseIndent,
-        Boolean showFields
+        Boolean showFields,
+        Metadata metadata,
+        Set<String> searchIndices
     ) {
         //// Normal Aggregations ////
         if (aggregationBuilders.isEmpty() == false) {
@@ -113,7 +141,7 @@ public class QueryShapeGenerator {
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append(baseIndent).append(ONE_SPACE_INDENT.repeat(2)).append(aggBuilder.getType());
             if (showFields) {
-                stringBuilder.append(buildFieldDataString(aggBuilder));
+                stringBuilder.append(buildFieldDataString(aggBuilder, metadata, searchIndices));
             }
             stringBuilder.append("\n");
 
@@ -124,7 +152,9 @@ public class QueryShapeGenerator {
                     aggBuilder.getPipelineAggregations(),
                     stringBuilder,
                     baseIndent.append(ONE_SPACE_INDENT.repeat(4)),
-                    showFields
+                    showFields,
+                    metadata,
+                    searchIndices
                 );
                 baseIndent.delete(0, 4);
             }
@@ -167,7 +197,7 @@ public class QueryShapeGenerator {
      * @param showFields whether to append field data
      * @return Sort shape as String
      */
-    static String buildSortShape(List<SortBuilder<?>> sortBuilderList, Boolean showFields) {
+    static String buildSortShape(List<SortBuilder<?>> sortBuilderList, Boolean showFields, Metadata metadata, Set<String> searchIndices) {
         if (sortBuilderList == null || sortBuilderList.isEmpty()) {
             return EMPTY_STRING;
         }
@@ -179,7 +209,7 @@ public class QueryShapeGenerator {
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append(ONE_SPACE_INDENT.repeat(2)).append(sortBuilder.order());
             if (showFields) {
-                stringBuilder.append(buildFieldDataString(sortBuilder));
+                stringBuilder.append(buildFieldDataString(sortBuilder, metadata, searchIndices));
             }
             shapeStrings.add(stringBuilder.toString());
         }
@@ -195,11 +225,60 @@ public class QueryShapeGenerator {
      * @return String: comma separated list with leading space in square brackets
      * Ex: " [my_field, width:5]"
      */
-    static String buildFieldDataString(NamedWriteable builder) {
+    static String buildFieldDataString(NamedWriteable builder, Metadata metadata, Set<String> searchIndices) {
         List<String> fieldDataList = new ArrayList<>();
         if (builder instanceof WithFieldName) {
-            fieldDataList.add(((WithFieldName) builder).fieldName());
+            String fieldName = ((WithFieldName) builder).fieldName();
+            fieldDataList.add(fieldName);
+            String fieldType = getFieldType(fieldName, metadata, searchIndices);
+            if (fieldType != null) {
+                fieldDataList.add(fieldType);
+            }
         }
         return " [" + String.join(", ", fieldDataList) + "]";
+    }
+
+    /**
+     * Method to get a field's type
+     * @return String field type
+     */
+    static String getFieldType(String fieldName, Metadata metadata, Set<String> searchIndices) {
+        if (metadata == null) {
+            return null;
+        }
+        for (String searchIndex : searchIndices) {
+            IndexMetadata indexMetadata = metadata.index(searchIndex);
+            if (indexMetadata == null) {
+                continue;
+            }
+            MappingMetadata mappingMetadata = indexMetadata.mapping();
+            if (mappingMetadata == null) {
+                continue;
+            }
+            Map<String, Object> sourceMap = mappingMetadata.getSourceAsMap();
+
+            String fieldType = findFieldType((Map<String, Object>) sourceMap.get("properties"), fieldName);
+            if (fieldType != null) {
+                return fieldType;
+            }
+        }
+        return null;
+    }
+
+    public static String findFieldType(Map<String, Object> properties, String fieldName) {
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            Map<String, Object> field = (Map<String, Object>) entry.getValue();
+            if (entry.getKey().equals(fieldName)) {
+                return (String) field.get("type");
+            }
+            // TODO: Add support for multi-fields
+            // if (field.containsKey("fields")) {
+            // String type = findFieldType((Map<String, Object>) field.get("fields"), fieldName);
+            // if (type != null) {
+            // return type;
+            // }
+            // }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
@@ -87,11 +87,6 @@ public final class SearchQueryCategorizer {
         incrementQueryTypeCounters(source.query(), measurements);
         incrementQueryAggregationCounters(source.aggregations(), measurements);
         incrementQuerySortCounters(source.sorts(), measurements);
-
-        if (logger.isTraceEnabled()) {
-            String searchShape = QueryShapeGenerator.buildShape(source, true);
-            logger.trace(searchShape);
-        }
     }
 
     private void incrementQuerySortCounters(List<SortBuilder<?>> sorts, Map<MetricType, Measurement> measurements) {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -8,17 +8,113 @@
 
 package org.opensearch.plugin.insights.core.service.categorizer;
 
+import static org.opensearch.plugin.insights.core.service.categorizer.QueryShapeGenerator.findFieldType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.common.hash.MurmurHash3;
 import org.opensearch.plugin.insights.SearchSourceBuilderUtils;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 
 public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
+    static Set<String> SEARCH_SHARD_INDICES = Set.of("index1", "index2", "index3");
+    static Metadata mockMetadata;
+
+    /**
+     * Helper function to return flat index map.
+     *
+     * <pre>
+     * {
+     *   properties = {
+     *     field1 = { type = long },
+     *     field2 = { type = text },
+     *     field3 = { type = boolean }
+     *   }
+     * }
+     * </pre>
+     */
+    private static Map<String, Object> getFlatIndexMapping() {
+        return new HashMap<>() {
+            {
+                put("properties", new HashMap<>() {
+                    {
+                        put("field1", new HashMap<>() {
+                            {
+                                put("type", "long");
+                            }
+                        });
+                        put("field2", new HashMap<>() {
+                            {
+                                put("type", "text");
+                            }
+                        });
+                        put("field3", new HashMap<>() {
+                            {
+                                put("type", "boolean");
+                            }
+                        });
+                    }
+                });
+            }
+        };
+    }
+
+    /**
+     * Helper function to return nested index map.
+     *
+     * <pre>
+     * {
+     *   properties = {
+     *     field1 = { type = long, fields = {
+     *       field2 = { type = text, fields = {
+     *         field3 = { type = keyword, ignore_above = 256 }
+     *     } } }
+     *   }
+     * }
+     * </pre>
+     */
+    private static Map<String, Object> getNestedIndexMapping() {
+        return new HashMap<>() {
+            {
+                put("properties", new HashMap<>() {
+                    {
+                        put("field1", new HashMap<>() {
+                            {
+                                put("type", "long");
+                                put("fields", new HashMap<>() {
+                                    {
+                                        put("field2", new HashMap<>() {
+                                            {
+                                                put("type", "text");
+                                                put("fields", new HashMap<>() {
+                                                    {
+                                                        put("field3", new HashMap<>() {
+                                                            {
+                                                                put("type", "boolean");
+                                                                put("ignore_above", 256);
+                                                            }
+                                                        });
+                                                    }
+                                                });
+                                            }
+                                        });
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+            }
+        };
+    }
 
     public void testComplexSearch() {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createDefaultSearchSourceBuilder();
 
-        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true);
+        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true, mockMetadata, SEARCH_SHARD_INDICES);
         String expectedShowFieldsTrue = "bool []\n"
             + "  must:\n"
             + "    term [field1]\n"
@@ -53,7 +149,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
             + "  asc [album]\n";
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
 
-        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false);
+        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false, mockMetadata, SEARCH_SHARD_INDICES);
         String expectedShowFieldsFalse = "bool\n"
             + "  must:\n"
             + "    term\n"
@@ -92,7 +188,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
     public void testQueryShape() {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder();
 
-        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true);
+        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true, mockMetadata, SEARCH_SHARD_INDICES);
         String expectedShowFieldsTrue = "bool []\n"
             + "  must:\n"
             + "    term [field1]\n"
@@ -103,7 +199,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
             + "    regexp [field3]\n";
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
 
-        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false);
+        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false, mockMetadata, SEARCH_SHARD_INDICES);
         String expectedShowFieldsFalse = "bool\n"
             + "  must:\n"
             + "    term\n"
@@ -118,7 +214,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
     public void testAggregationShape() {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createAggregationSearchSourceBuilder();
 
-        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true);
+        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true, mockMetadata, SEARCH_SHARD_INDICES);
         String expectedShowFieldsTrue = "aggregation:\n"
             + "  significant_text []\n"
             + "  terms [key]\n"
@@ -140,7 +236,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
             + "    max_bucket\n";
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
 
-        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false);
+        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false, mockMetadata, SEARCH_SHARD_INDICES);
         String expectedShowFieldsFalse = "aggregation:\n"
             + "  significant_text\n"
             + "  terms\n"
@@ -166,11 +262,11 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
     public void testSortShape() {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createSortSearchSourceBuilder();
 
-        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true);
+        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true, mockMetadata, SEARCH_SHARD_INDICES);
         String expectedShowFieldsTrue = "sort:\n" + "  desc [color]\n" + "  desc [vendor]\n" + "  asc [price]\n" + "  asc [album]\n";
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
 
-        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false);
+        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false, mockMetadata, SEARCH_SHARD_INDICES);
         String expectedShowFieldsFalse = "sort:\n" + "  desc\n" + "  desc\n" + "  asc\n" + "  asc\n";
         assertEquals(expectedShowFieldsFalse, shapeShowFieldsFalse);
     }
@@ -181,21 +277,58 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
         SearchSourceBuilder querySourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder();
 
         // showFields true
-        MurmurHash3.Hash128 defaultHashTrue = QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, true);
-        MurmurHash3.Hash128 queryHashTrue = QueryShapeGenerator.getShapeHashCode(querySourceBuilder, true);
-        assertEquals(defaultHashTrue, QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, true));
-        assertEquals(queryHashTrue, QueryShapeGenerator.getShapeHashCode(querySourceBuilder, true));
+        MurmurHash3.Hash128 defaultHashTrue = QueryShapeGenerator.getShapeHashCode(
+            defaultSourceBuilder,
+            true,
+            mockMetadata,
+            SEARCH_SHARD_INDICES
+        );
+        MurmurHash3.Hash128 queryHashTrue = QueryShapeGenerator.getShapeHashCode(
+            querySourceBuilder,
+            true,
+            mockMetadata,
+            SEARCH_SHARD_INDICES
+        );
+        assertEquals(defaultHashTrue, QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, true, mockMetadata, SEARCH_SHARD_INDICES));
+        assertEquals(queryHashTrue, QueryShapeGenerator.getShapeHashCode(querySourceBuilder, true, mockMetadata, SEARCH_SHARD_INDICES));
         assertNotEquals(defaultHashTrue, queryHashTrue);
 
         // showFields false
-        MurmurHash3.Hash128 defaultHashFalse = QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, false);
-        MurmurHash3.Hash128 queryHashFalse = QueryShapeGenerator.getShapeHashCode(querySourceBuilder, false);
-        assertEquals(defaultHashFalse, QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, false));
-        assertEquals(queryHashFalse, QueryShapeGenerator.getShapeHashCode(querySourceBuilder, false));
+        MurmurHash3.Hash128 defaultHashFalse = QueryShapeGenerator.getShapeHashCode(
+            defaultSourceBuilder,
+            false,
+            mockMetadata,
+            SEARCH_SHARD_INDICES
+        );
+        MurmurHash3.Hash128 queryHashFalse = QueryShapeGenerator.getShapeHashCode(
+            querySourceBuilder,
+            false,
+            mockMetadata,
+            SEARCH_SHARD_INDICES
+        );
+        assertEquals(
+            defaultHashFalse,
+            QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, false, mockMetadata, SEARCH_SHARD_INDICES)
+        );
+        assertEquals(queryHashFalse, QueryShapeGenerator.getShapeHashCode(querySourceBuilder, false, mockMetadata, SEARCH_SHARD_INDICES));
         assertNotEquals(defaultHashFalse, queryHashFalse);
 
         // Compare field data on vs off
         assertNotEquals(defaultHashTrue, defaultHashFalse);
         assertNotEquals(queryHashTrue, queryHashFalse);
+    }
+
+    public void testFindFieldType() {
+        Map<String, Object> properties = (Map<String, Object>) getFlatIndexMapping().get("properties");
+        String fieldType1 = findFieldType(properties, "field1");
+        String fieldType2 = findFieldType(properties, "field2");
+        String fieldType3 = findFieldType(properties, "field3");
+        assertEquals("long", fieldType1);
+        assertEquals("text", fieldType2);
+        assertEquals("boolean", fieldType3);
+
+        properties = (Map<String, Object>) getNestedIndexMapping().get("properties");
+        fieldType1 = findFieldType(properties, "field1");
+        assertEquals("long", fieldType1);
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitorTests.java
@@ -8,6 +8,10 @@
 
 package org.opensearch.plugin.insights.core.service.categorizer;
 
+import static org.mockito.Mockito.mock;
+
+import java.util.Set;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
@@ -27,7 +31,7 @@ public final class QueryShapeVisitorTests extends OpenSearchTestCase {
                     .mustNot(new RegexpQueryBuilder("color", "red.*"))
             )
             .must(new TermsQueryBuilder("genre", "action", "drama", "romance"));
-        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor();
+        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor(mock(Metadata.class), Set.of());
         builder.visit(shapeVisitor);
         assertEquals(
             "{\"type\":\"bool\",\"must\"[{\"type\":\"term\"},{\"type\":\"terms\"}],\"filter\"[{\"type\":\"constant_score\",\"filter\"[{\"type\":\"range\"}]}],\"should\"[{\"type\":\"bool\",\"must\"[{\"type\":\"match\"}],\"must_not\"[{\"type\":\"regexp\"}]}]}",


### PR DESCRIPTION
### Description
Add field type to query shape

### Issues Resolved
Field type RFC https://github.com/opensearch-project/query-insights/issues/69

### Testing
```
% curl -X POST "localhost:9200/my_index/_search?pretty" -H 'Content-Type: application/json' -d '{
  "query": {
    "range": {
      "age": {
        "gte": 25,
        "lte": 40
      }
    }
  },
  "aggs": {
    "average_age": {
      "avg": {
        "field": "age"
      }
    }
  },
  "sort": [
    {
      "name": {
        "order": "asc"
      }
    }
  ],
  "size": 100
}'
```
```
[2024-09-26T17:07:32,230][INFO ][stdout                   ] [integTest-0] ========== SEARCH SHAPE ==========
[2024-09-26T17:07:32,230][INFO ][stdout                   ] [integTest-0] range [age, integer]
[2024-09-26T17:07:32,231][INFO ][stdout                   ] [integTest-0] aggregation:
[2024-09-26T17:07:32,231][INFO ][stdout                   ] [integTest-0]   avg [age, integer]
[2024-09-26T17:07:32,231][INFO ][stdout                   ] [integTest-0] sort:
[2024-09-26T17:07:32,232][INFO ][stdout                   ] [integTest-0]   asc [name, keyword]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
