### PR TITLE
Add field type to query shape and extensive unit tests

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -58,6 +58,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     private final ClusterService clusterService;
     private boolean groupingFieldNameEnabled;
     private boolean groupingFieldTypeEnabled;
+    private final QueryShapeGenerator queryShapeGenerator;
 
     /**
      * Constructor for QueryInsightsListener
@@ -87,6 +88,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         super(initiallyEnabled);
         this.clusterService = clusterService;
         this.queryInsightsService = queryInsightsService;
+        this.queryShapeGenerator = new QueryShapeGenerator(clusterService);
 
         // Setting endpoints set up for top n queries, including enabling top n queries, window size, and top n size
         // Expected metricTypes are Latency, CPU, and Memory.
@@ -271,7 +273,12 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
             attributes.put(Attribute.TASK_RESOURCE_USAGES, tasksResourceUsages);
 
             if (queryInsightsService.isGroupingEnabled()) {
-                String hashcode = QueryShapeGenerator.getShapeHashCodeAsString(request.source(), groupingFieldNameEnabled);
+                String hashcode = queryShapeGenerator.getShapeHashCodeAsString(
+                    request.source(),
+                    groupingFieldNameEnabled,
+                    groupingFieldTypeEnabled,
+                    searchRequestContext.getSuccessfulSearchShardIndices()
+                );
                 attributes.put(Attribute.QUERY_HASHCODE, hashcode);
             }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -274,7 +274,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
 
             if (queryInsightsService.isGroupingEnabled() || log.isTraceEnabled()) {
                 // Generate the query shape only if grouping is enabled or trace logging is enabled
-                String queryShape = queryShapeGenerator.buildShape(
+                final String queryShape = queryShapeGenerator.buildShape(
                     request.source(),
                     groupingFieldNameEnabled,
                     groupingFieldTypeEnabled,

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -272,14 +272,25 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
             attributes.put(Attribute.PHASE_LATENCY_MAP, searchRequestContext.phaseTookMap());
             attributes.put(Attribute.TASK_RESOURCE_USAGES, tasksResourceUsages);
 
-            if (queryInsightsService.isGroupingEnabled()) {
-                String hashcode = queryShapeGenerator.getShapeHashCodeAsString(
+            if (queryInsightsService.isGroupingEnabled() || log.isTraceEnabled()) {
+                // Generate the query shape only if grouping is enabled or trace logging is enabled
+                String queryShape = queryShapeGenerator.buildShape(
                     request.source(),
                     groupingFieldNameEnabled,
                     groupingFieldTypeEnabled,
                     searchRequestContext.getSuccessfulSearchShardIndices()
                 );
-                attributes.put(Attribute.QUERY_HASHCODE, hashcode);
+
+                // Print the query shape if tracer is enabled
+                if (log.isTraceEnabled()) {
+                    log.trace("Query Shape:\n{}", queryShape);
+                }
+
+                // Add hashcode attribute when grouping is enabled
+                if (queryInsightsService.isGroupingEnabled()) {
+                    String hashcode = queryShapeGenerator.getShapeHashCodeAsString(queryShape);
+                    attributes.put(Attribute.QUERY_HASHCODE, hashcode);
+                }
             }
 
             Map<String, Object> labels = new HashMap<>();

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGenerator.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGenerator.java
@@ -88,6 +88,18 @@ public class QueryShapeGenerator {
     }
 
     /**
+     * Gets the hash code of the query shape as a string.
+     *
+     * @param queryShape            query shape as input
+     * @return Hash code of the query shape as a string
+     */
+    public String getShapeHashCodeAsString(String queryShape) {
+        final BytesRef shapeBytes = new BytesRef(queryShape);
+        MurmurHash3.Hash128 hashcode = MurmurHash3.hash128(shapeBytes.bytes, 0, shapeBytes.length, 0, new MurmurHash3.Hash128());
+        return Long.toHexString(hashcode.h1) + Long.toHexString(hashcode.h2);
+    }
+
+    /**
      * Builds the search query shape given a source.
      *
      * @param source                search request source
@@ -300,6 +312,9 @@ public class QueryShapeGenerator {
     }
 
     String getFieldType(String fieldName, Set<Index> successfulSearchShardIndices) {
+        if (successfulSearchShardIndices == null) {
+            return null;
+        }
         String fieldType = getFieldTypeFromCache(fieldName, successfulSearchShardIndices);
         if (fieldType != null) {
             if (fieldType.equals(NO_FIELD_TYPE_VALUE)) {

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitor.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitor.java
@@ -9,15 +9,16 @@
 package org.opensearch.plugin.insights.core.service.categorizer;
 
 import static org.opensearch.plugin.insights.core.service.categorizer.QueryShapeGenerator.ONE_SPACE_INDENT;
-import static org.opensearch.plugin.insights.core.service.categorizer.QueryShapeGenerator.buildFieldDataString;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.apache.lucene.search.BooleanClause;
 import org.opensearch.common.SetOnce;
+import org.opensearch.core.index.Index;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
 
@@ -28,11 +29,15 @@ public final class QueryShapeVisitor implements QueryBuilderVisitor {
     private final SetOnce<String> queryType = new SetOnce<>();
     private final SetOnce<String> fieldData = new SetOnce<>();
     private final Map<BooleanClause.Occur, List<QueryShapeVisitor>> childVisitors = new EnumMap<>(BooleanClause.Occur.class);
+    private final QueryShapeGenerator queryShapeGenerator;
+    private final Set<Index> successfulSearchShardIndices;
+    private final Boolean showFieldName;
+    private final Boolean showFieldType;
 
     @Override
     public void accept(QueryBuilder queryBuilder) {
         queryType.set(queryBuilder.getName());
-        fieldData.set(buildFieldDataString(queryBuilder));
+        fieldData.set(queryShapeGenerator.buildFieldDataString(queryBuilder, successfulSearchShardIndices, showFieldName, showFieldType));
     }
 
     @Override
@@ -47,7 +52,7 @@ public final class QueryShapeVisitor implements QueryBuilderVisitor {
 
             @Override
             public void accept(QueryBuilder qb) {
-                currentChild = new QueryShapeVisitor();
+                currentChild = new QueryShapeVisitor(queryShapeGenerator, successfulSearchShardIndices, showFieldName, showFieldType);
                 childVisitorList.add(currentChild);
                 currentChild.accept(qb);
             }
@@ -85,13 +90,15 @@ public final class QueryShapeVisitor implements QueryBuilderVisitor {
 
     /**
      * Pretty print the query builder tree
-     * @param indent indent size
-     * @param showFields whether to print field data
+     *
+     * @param indent        indent size
+     * @param showFieldName    whether to print field name
+     * @param showFieldType
      * @return Query builder tree as a pretty string
      */
-    public String prettyPrintTree(String indent, Boolean showFields) {
+    public String prettyPrintTree(String indent, Boolean showFieldName, Boolean showFieldType) {
         StringBuilder outputBuilder = new StringBuilder(indent).append(queryType.get());
-        if (showFields) {
+        if (showFieldName || showFieldType) {
             outputBuilder.append(fieldData.get());
         }
         outputBuilder.append("\n");
@@ -101,7 +108,7 @@ public final class QueryShapeVisitor implements QueryBuilderVisitor {
                 .append(entry.getKey().name().toLowerCase(Locale.ROOT))
                 .append(":\n");
             for (QueryShapeVisitor child : entry.getValue()) {
-                outputBuilder.append(child.prettyPrintTree(indent + ONE_SPACE_INDENT.repeat(4), showFields));
+                outputBuilder.append(child.prettyPrintTree(indent + ONE_SPACE_INDENT.repeat(4), showFieldName, showFieldType));
             }
         }
         return outputBuilder.toString();
@@ -110,5 +117,15 @@ public final class QueryShapeVisitor implements QueryBuilderVisitor {
     /**
      * Default constructor
      */
-    public QueryShapeVisitor() {}
+    public QueryShapeVisitor(
+        QueryShapeGenerator queryShapeGenerator,
+        Set<Index> successfulSearchShardIndices,
+        Boolean showFieldName,
+        Boolean showFieldType
+    ) {
+        this.queryShapeGenerator = queryShapeGenerator;
+        this.successfulSearchShardIndices = successfulSearchShardIndices;
+        this.showFieldName = showFieldName;
+        this.showFieldType = showFieldType;
+    }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
@@ -87,11 +87,6 @@ public final class SearchQueryCategorizer {
         incrementQueryTypeCounters(source.query(), measurements);
         incrementQueryAggregationCounters(source.aggregations(), measurements);
         incrementQuerySortCounters(source.sorts(), measurements);
-
-        if (logger.isTraceEnabled()) {
-            String searchShape = QueryShapeGenerator.buildShape(source, true);
-            logger.trace(searchShape);
-        }
     }
 
     private void incrementQuerySortCounters(List<SortBuilder<?>> sorts, Map<MetricType, Measurement> measurements) {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -53,10 +53,7 @@ import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchTestCase;
 
 public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
-    final Set<Index> successfulSearchShardIndices = Set.of(
-        new Index("index1", UUID.randomUUID().toString()),
-        new Index("index2", UUID.randomUUID().toString())
-    );
+    final Set<Index> successfulSearchShardIndices = Set.of(new Index("index1", UUID.randomUUID().toString()));
     final QueryShapeGenerator queryShapeGenerator;
 
     private ClusterService mockClusterService;
@@ -174,9 +171,9 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
 
     // Field type should be inferred from both the mappings
     public void testMultipleIndexMappings() throws IOException {
-        setUpMockMappings("index1", Map.of("properties", Map.of("field1", Map.of("type", "keyword"))));
+        setUpMockMappings("index2", Map.of("properties", Map.of("field1", Map.of("type", "keyword"))));
 
-        setUpMockMappings("index2", Map.of("properties", Map.of("field2", Map.of("type", "text"), "field4", Map.of("type", "long"))));
+        setUpMockMappings("index1", Map.of("properties", Map.of("field2", Map.of("type", "text"), "field4", Map.of("type", "long"))));
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder();
 
@@ -188,7 +185,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
             + "    match [field2, text]\n"
             + "    range [field4, long]\n"
             + "  should:\n"
-            + "    regexp [field3]\n"; // No field type found
+            + "    regexp [field3]\n";
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
     }
 
@@ -598,14 +595,14 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
 
         queryShapeGeneratorSpy.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
 
-        verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromCache(eq(nonExistentField), eq(successfulSearchShardIndices));
+        verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromCache(eq(nonExistentField), any(Index.class));
 
         verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromMapping(any(Index.class), eq(nonExistentField), any());
 
         queryShapeGeneratorSpy.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
 
-        verify(queryShapeGeneratorSpy, times(4)).getFieldTypeFromMapping(any(Index.class), eq(nonExistentField), any());
-        verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromCache(eq(nonExistentField), eq(successfulSearchShardIndices));
+        verify(queryShapeGeneratorSpy, times(2)).getFieldTypeFromMapping(any(Index.class), eq(nonExistentField), any());
+        verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromCache(eq(nonExistentField), any(Index.class));
     }
 
     public void testMultifieldQueryCombined() throws IOException {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -13,7 +13,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
@@ -597,11 +596,8 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
 
         verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromCache(eq(nonExistentField), any(Index.class));
 
-        verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromMapping(any(Index.class), eq(nonExistentField), any());
-
         queryShapeGeneratorSpy.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
 
-        verify(queryShapeGeneratorSpy, times(2)).getFieldTypeFromMapping(any(Index.class), eq(nonExistentField), any());
         verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromCache(eq(nonExistentField), any(Index.class));
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -8,17 +8,610 @@
 
 package org.opensearch.plugin.insights.core.service.categorizer;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensearch.index.query.QueryBuilders.boolQuery;
+import static org.opensearch.index.query.QueryBuilders.geoDistanceQuery;
+import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
+import static org.opensearch.index.query.QueryBuilders.matchQuery;
+import static org.opensearch.index.query.QueryBuilders.nestedQuery;
+import static org.opensearch.index.query.QueryBuilders.rangeQuery;
+import static org.opensearch.index.query.QueryBuilders.regexpQuery;
+import static org.opensearch.index.query.QueryBuilders.termQuery;
+import static org.opensearch.index.query.QueryBuilders.termsQuery;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.hash.MurmurHash3;
+import org.opensearch.common.unit.DistanceUnit;
+import org.opensearch.core.compress.CompressorRegistry;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.query.ScriptQueryBuilder;
 import org.opensearch.plugin.insights.SearchSourceBuilderUtils;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptType;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.PipelineAggregatorBuilders;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.FieldSortBuilder;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchTestCase;
 
 public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
+    final Set<Index> successfulSearchShardIndices = Set.of(
+        new Index("index1", UUID.randomUUID().toString()),
+        new Index("index2", UUID.randomUUID().toString())
+    );
+    final QueryShapeGenerator queryShapeGenerator;
+
+    private ClusterService mockClusterService;
+    private ClusterState mockClusterState;
+    private Metadata mockMetaData;
+
+    public QueryShapeGeneratorTests() {
+        CompressorRegistry.defaultCompressor();
+        this.mockClusterService = mock(ClusterService.class);
+        this.mockClusterState = mock(ClusterState.class);
+        this.mockMetaData = mock(Metadata.class);
+        this.queryShapeGenerator = new QueryShapeGenerator(mockClusterService);
+
+        when(mockClusterService.state()).thenReturn(mockClusterState);
+        when(mockClusterState.metadata()).thenReturn(mockMetaData);
+    }
+
+    public void setUpMockMappings(String indexName, Map<String, Object> mappingProperties) throws IOException {
+        MappingMetadata mockMappingMetadata = mock(MappingMetadata.class);
+
+        when(mockMappingMetadata.getSourceAsMap()).thenReturn(mappingProperties);
+
+        final Map<String, MappingMetadata> indexMappingMap = Map.of(indexName, mockMappingMetadata);
+        when(mockMetaData.findMappings(any(), any())).thenReturn(indexMappingMap);
+    }
+
+    public void testBasicSearchWithFieldNameAndType() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of(
+                    "field1",
+                    Map.of("type", "keyword"),
+                    "field2",
+                    Map.of("type", "text"),
+                    "field3",
+                    Map.of("type", "text"),
+                    "field4",
+                    Map.of("type", "long")
+                )
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder();
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [field1, keyword]\n"
+            + "  filter:\n"
+            + "    match [field2, text]\n"
+            + "    range [field4, long]\n"
+            + "  should:\n"
+            + "    regexp [field3, text]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    // If field type is not found we leave the field type blank
+    public void testFieldTypeNotFound() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("field1", Map.of("type", "keyword"))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(
+                boolQuery().must(termQuery("field1", "value1"))
+                    .filter(matchQuery("field2", "value2"))
+                    .filter(rangeQuery("field4").gte(10).lte(20))
+                    .should(regexpQuery("field3", ".*pattern.*"))
+            );
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [field1, keyword]\n"
+            + "  filter:\n"
+            + "    match [field2]\n"
+            + "    range [field4]\n"
+            + "  should:\n"
+            + "    regexp [field3]\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testEmptyMappings() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of() // No fields defined
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(
+                boolQuery().must(termQuery("field1", "value1"))
+                    .filter(matchQuery("field2", "value2"))
+                    .filter(rangeQuery("field4").gte(10).lte(20))
+                    .should(regexpQuery("field3", ".*pattern.*"))
+            );
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [field1]\n"
+            + "  filter:\n"
+            + "    match [field2]\n"
+            + "    range [field4]\n"
+            + "  should:\n"
+            + "    regexp [field3]\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    // Field type should be inferred from both the mappings
+    public void testMultipleIndexMappings() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("field1", Map.of("type", "keyword"))));
+
+        setUpMockMappings("index2", Map.of("properties", Map.of("field2", Map.of("type", "text"), "field4", Map.of("type", "long"))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder();
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [field1]\n"
+            + "  filter:\n"
+            + "    match [field2, text]\n"
+            + "    range [field4, long]\n"
+            + "  should:\n"
+            + "    regexp [field3]\n"; // No field type found
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testDifferentFieldTypes() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of(
+                    "field1",
+                    Map.of("type", "keyword"),
+                    "field2",
+                    Map.of("type", "text"),
+                    "field3",
+                    Map.of("type", "integer"),
+                    "field4",
+                    Map.of("type", "boolean")
+                )
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder();
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [field1, keyword]\n"
+            + "  filter:\n"
+            + "    match [field2, text]\n"
+            + "    range [field4, boolean]\n"
+            + "  should:\n"
+            + "    regexp [field3, integer]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithNestedProperties() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of(
+                    "nestedField",
+                    Map.of(
+                        "type",
+                        "nested",
+                        "properties",
+                        Map.of("subField1", Map.of("type", "keyword"), "subField2", Map.of("type", "text"))
+                    )
+                )
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(boolQuery().must(termQuery("nestedField.subField1", "value1")).filter(matchQuery("nestedField.subField2", "value2")));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [nestedField.subField1, keyword]\n"
+            + "  filter:\n"
+            + "    match [nestedField.subField2, text]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithArrayType() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of("field1", Map.of("type", "keyword"), "field2", Map.of("type", "text"), "field3", Map.of("type", "keyword"))
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(
+                boolQuery().must(termQuery("field1", "value1"))
+                    .filter(matchQuery("field2", "value2"))
+                    .should(termsQuery("field3", "value3a", "value3b"))
+            );
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [field1, keyword]\n"
+            + "  filter:\n"
+            + "    match [field2, text]\n"
+            + "  should:\n"
+            + "    terms [field3, keyword]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithDateType() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("dateField", Map.of("type", "date"))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(boolQuery().filter(rangeQuery("dateField").gte("2024-01-01").lte("2024-12-31")));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n" + "  filter:\n" + "    range [dateField, date]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithGeoPointType() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("location", Map.of("type", "geo_point"))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(boolQuery().filter(geoDistanceQuery("location").point(40.73, -74.1).distance(200, DistanceUnit.KILOMETERS)));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n" + "  filter:\n" + "    geo_distance [location, geo_point]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithBinaryType() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("binaryField", Map.of("type", "binary"))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(boolQuery().must(termQuery("binaryField", "base64EncodedString")));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n" + "  must:\n" + "    term [binaryField, binary]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithMixedTypes() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of(
+                    "mixedField",
+                    Map.of(
+                        "type",
+                        "object",
+                        "properties",
+                        Map.of("subField1", Map.of("type", "keyword"), "subField2", Map.of("type", "text"))
+                    )
+                )
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(boolQuery().must(termQuery("mixedField.subField1", "value1")).filter(matchQuery("mixedField.subField2", "value2")));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [mixedField.subField1, keyword]\n"
+            + "  filter:\n"
+            + "    match [mixedField.subField2, text]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithInvalidQueries() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("field1", Map.of("type", "keyword"))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(
+                boolQuery().must(termQuery("invalidField", "value1")) // Invalid field
+            );
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n" + "  must:\n" + "    term [invalidField]\n"; // No type info, just the invalid field
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithDeeplyNestedStructure() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of(
+                    "level1",
+                    Map.of(
+                        "type",
+                        "nested",
+                        "properties",
+                        Map.of("level2", Map.of("type", "nested", "properties", Map.of("level3", Map.of("type", "keyword"))))
+                    )
+                )
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(boolQuery().must(termQuery("level1.level2.level3", "value1")));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n" + "  must:\n" + "    term [level1.level2.level3, keyword]\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    // We are not parsing fields for scripts
+    public void testFieldWithScriptedQuery() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("scriptedField", Map.of("type", "long"))));
+
+        Script script = new Script(
+            ScriptType.INLINE,
+            "p.params.threshold < doc['scriptedField'].value",
+            "mockscript",
+            Map.of("threshold", 100)
+        );
+
+        ScriptQueryBuilder scriptedQuery = new ScriptQueryBuilder(script);
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder().query(scriptedQuery);
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "script []\n";
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testDynamicTemplateMappingWithTypeInference() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "dynamic_templates",
+                List.of(
+                    Map.of("fields", Map.of("mapping", Map.of("type", "short"), "match_mapping_type", "string", "path_match", "status*"))
+                ),
+                "properties",
+                Map.of("status_code", Map.of("type", "short"), "other_field", Map.of("type", "text"))
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(boolQuery().must(termQuery("status_code", "200")).filter(matchQuery("other_field", "value")));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [status_code, short]\n"
+            + "  filter:\n"
+            + "    match [other_field, text]\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFieldWithIpAddressType() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("ip_address", Map.of("type", "ip", "ignore_malformed", true))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(boolQuery().must(termQuery("ip_address", "192.168.1.1")).filter(termQuery("ip_address", "invalid_ip")));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+        String expectedShowFieldsTrue = "bool []\n"
+            + "  must:\n"
+            + "    term [ip_address, ip]\n"
+            + "  filter:\n"
+            + "    term [ip_address, ip]\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    // Nested query not working as expected
+    public void testNestedQueryType() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of(
+                    "patients",
+                    Map.of(
+                        "type",
+                        "nested",
+                        "properties",
+                        Map.of("name", Map.of("type", "text"), "age", Map.of("type", "integer"), "smoker", Map.of("type", "boolean"))
+                    )
+                )
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(
+                nestedQuery(
+                    "patients",
+                    boolQuery().should(termQuery("patients.smoker", true)).should(rangeQuery("patients.age").gte(75)),
+                    ScoreMode.Avg
+                )
+            );
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        String expectedShowFieldsTrue = "nested []\n" + "  must:\n" + "    bool []\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testFlatObjectQueryType() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of(
+                    "issue",
+                    Map.of(
+                        "type",
+                        "flat_object",
+                        "properties",
+                        Map.of(
+                            "number",
+                            Map.of("type", "keyword"),
+                            "labels",
+                            Map.of(
+                                "properties",
+                                Map.of(
+                                    "version",
+                                    Map.of("type", "keyword"),
+                                    "category",
+                                    Map.of("properties", Map.of("type", Map.of("type", "keyword"), "level", Map.of("type", "keyword")))
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(matchQuery("issue.labels.category.level", "bug"));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        String expectedShowFieldsTrue = "match [issue.labels.category.level, keyword]\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testQueryTypeWithSorting() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of("age", Map.of("type", "integer"), "name", Map.of("type", "keyword"), "score", Map.of("type", "float"))
+            )
+        );
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(matchQuery("name", "John"))
+            .sort(new FieldSortBuilder("age").order(SortOrder.ASC))
+            .sort(new FieldSortBuilder("score").order(SortOrder.DESC));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        String expectedShowFieldsTrue = "match [name, keyword]\n" + "sort:\n" + "  asc [age, integer]\n" + "  desc [score, float]\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    public void testQueryTypeWithAggregations() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("price", Map.of("type", "double"), "category", Map.of("type", "keyword"))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(matchAllQuery())
+            .aggregation(AggregationBuilders.terms("categories").field("category"))
+            .aggregation(AggregationBuilders.avg("average_price").field("price"));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        String expectedShowFieldsTrue = "match_all []\n" + "aggregation:\n" + "  avg [price, double]\n" + "  terms [category, keyword]\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    // No field name and type being parsed for pipeline aggregations
+    public void testQueryTypeWithPipelineAggregation() throws IOException {
+        setUpMockMappings("index1", Map.of("properties", Map.of("sales", Map.of("type", "double"), "timestamp", Map.of("type", "date"))));
+
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(matchAllQuery())
+            .aggregation(
+                AggregationBuilders.dateHistogram("sales_over_time")
+                    .field("timestamp")
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .subAggregation(AggregationBuilders.sum("total_sales").field("sales"))
+            )
+            .aggregation(PipelineAggregatorBuilders.derivative("sales_derivative", "total_sales"));
+
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        String expectedShowFieldsTrue = "match_all []\n"
+            + "aggregation:\n"
+            + "  date_histogram [timestamp, date]\n"
+            + "    aggregation:\n"
+            + "      sum [sales, double]\n"
+            + "  pipeline aggregation:\n"
+            + "    derivative\n";
+
+        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
+    }
+
+    // Should cache empty value when we do not find a field type to avoid doing the search again
+    public void testFieldTypeCachingForNonExistentField() throws IOException {
+        setUpMockMappings(
+            "index1",
+            Map.of(
+                "properties",
+                Map.of("age", Map.of("type", "integer"), "name", Map.of("type", "keyword"), "score", Map.of("type", "float"))
+            )
+        );
+
+        QueryShapeGenerator queryShapeGeneratorSpy = spy(queryShapeGenerator);
+
+        String nonExistentField = "nonExistentField";
+        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
+            .query(matchQuery(nonExistentField, "value"));
+
+        queryShapeGeneratorSpy.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromCache(eq(nonExistentField), eq(successfulSearchShardIndices));
+
+        verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromMapping(any(Index.class), eq(nonExistentField), any());
+
+        queryShapeGeneratorSpy.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
+
+        verify(queryShapeGeneratorSpy, times(2)).getFieldTypeFromMapping(any(Index.class), eq(nonExistentField), any());
+        verify(queryShapeGeneratorSpy, atLeastOnce()).getFieldTypeFromCache(eq(nonExistentField), eq(successfulSearchShardIndices));
+    }
 
     public void testComplexSearch() {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createDefaultSearchSourceBuilder();
 
-        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true);
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, false, successfulSearchShardIndices);
         String expectedShowFieldsTrue = "bool []\n"
             + "  must:\n"
             + "    term [field1]\n"
@@ -53,7 +646,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
             + "  asc [album]\n";
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
 
-        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false);
+        String shapeShowFieldsFalse = queryShapeGenerator.buildShape(sourceBuilder, false, false, successfulSearchShardIndices);
         String expectedShowFieldsFalse = "bool\n"
             + "  must:\n"
             + "    term\n"
@@ -89,36 +682,10 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
         assertEquals(expectedShowFieldsFalse, shapeShowFieldsFalse);
     }
 
-    public void testQueryShape() {
-        SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder();
-
-        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true);
-        String expectedShowFieldsTrue = "bool []\n"
-            + "  must:\n"
-            + "    term [field1]\n"
-            + "  filter:\n"
-            + "    match [field2]\n"
-            + "    range [field4]\n"
-            + "  should:\n"
-            + "    regexp [field3]\n";
-        assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
-
-        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false);
-        String expectedShowFieldsFalse = "bool\n"
-            + "  must:\n"
-            + "    term\n"
-            + "  filter:\n"
-            + "    match\n"
-            + "    range\n"
-            + "  should:\n"
-            + "    regexp\n";
-        assertEquals(expectedShowFieldsFalse, shapeShowFieldsFalse);
-    }
-
     public void testAggregationShape() {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createAggregationSearchSourceBuilder();
 
-        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true);
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, false, successfulSearchShardIndices);
         String expectedShowFieldsTrue = "aggregation:\n"
             + "  significant_text []\n"
             + "  terms [key]\n"
@@ -140,7 +707,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
             + "    max_bucket\n";
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
 
-        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false);
+        String shapeShowFieldsFalse = queryShapeGenerator.buildShape(sourceBuilder, false, false, successfulSearchShardIndices);
         String expectedShowFieldsFalse = "aggregation:\n"
             + "  significant_text\n"
             + "  terms\n"
@@ -166,11 +733,11 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
     public void testSortShape() {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createSortSearchSourceBuilder();
 
-        String shapeShowFieldsTrue = QueryShapeGenerator.buildShape(sourceBuilder, true);
+        String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, false, successfulSearchShardIndices);
         String expectedShowFieldsTrue = "sort:\n" + "  desc [color]\n" + "  desc [vendor]\n" + "  asc [price]\n" + "  asc [album]\n";
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
 
-        String shapeShowFieldsFalse = QueryShapeGenerator.buildShape(sourceBuilder, false);
+        String shapeShowFieldsFalse = queryShapeGenerator.buildShape(sourceBuilder, false, false, successfulSearchShardIndices);
         String expectedShowFieldsFalse = "sort:\n" + "  desc\n" + "  desc\n" + "  asc\n" + "  asc\n";
         assertEquals(expectedShowFieldsFalse, shapeShowFieldsFalse);
     }
@@ -181,17 +748,43 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
         SearchSourceBuilder querySourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder();
 
         // showFields true
-        MurmurHash3.Hash128 defaultHashTrue = QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, true);
-        MurmurHash3.Hash128 queryHashTrue = QueryShapeGenerator.getShapeHashCode(querySourceBuilder, true);
-        assertEquals(defaultHashTrue, QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, true));
-        assertEquals(queryHashTrue, QueryShapeGenerator.getShapeHashCode(querySourceBuilder, true));
+        MurmurHash3.Hash128 defaultHashTrue = queryShapeGenerator.getShapeHashCode(
+            defaultSourceBuilder,
+            true,
+            false,
+            successfulSearchShardIndices
+        );
+        MurmurHash3.Hash128 queryHashTrue = queryShapeGenerator.getShapeHashCode(
+            querySourceBuilder,
+            true,
+            false,
+            successfulSearchShardIndices
+        );
+        assertEquals(
+            defaultHashTrue,
+            queryShapeGenerator.getShapeHashCode(defaultSourceBuilder, true, false, successfulSearchShardIndices)
+        );
+        assertEquals(queryHashTrue, queryShapeGenerator.getShapeHashCode(querySourceBuilder, true, false, successfulSearchShardIndices));
         assertNotEquals(defaultHashTrue, queryHashTrue);
 
         // showFields false
-        MurmurHash3.Hash128 defaultHashFalse = QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, false);
-        MurmurHash3.Hash128 queryHashFalse = QueryShapeGenerator.getShapeHashCode(querySourceBuilder, false);
-        assertEquals(defaultHashFalse, QueryShapeGenerator.getShapeHashCode(defaultSourceBuilder, false));
-        assertEquals(queryHashFalse, QueryShapeGenerator.getShapeHashCode(querySourceBuilder, false));
+        MurmurHash3.Hash128 defaultHashFalse = queryShapeGenerator.getShapeHashCode(
+            defaultSourceBuilder,
+            false,
+            false,
+            successfulSearchShardIndices
+        );
+        MurmurHash3.Hash128 queryHashFalse = queryShapeGenerator.getShapeHashCode(
+            querySourceBuilder,
+            false,
+            false,
+            successfulSearchShardIndices
+        );
+        assertEquals(
+            defaultHashFalse,
+            queryShapeGenerator.getShapeHashCode(defaultSourceBuilder, false, false, successfulSearchShardIndices)
+        );
+        assertEquals(queryHashFalse, queryShapeGenerator.getShapeHashCode(querySourceBuilder, false, false, successfulSearchShardIndices));
         assertNotEquals(defaultHashFalse, queryHashFalse);
 
         // Compare field data on vs off

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitorTests.java
@@ -8,6 +8,10 @@
 
 package org.opensearch.plugin.insights.core.service.categorizer;
 
+import static org.mockito.Mockito.mock;
+
+import java.util.Set;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
@@ -27,7 +31,7 @@ public final class QueryShapeVisitorTests extends OpenSearchTestCase {
                     .mustNot(new RegexpQueryBuilder("color", "red.*"))
             )
             .must(new TermsQueryBuilder("genre", "action", "drama", "romance"));
-        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor();
+        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor(new QueryShapeGenerator(mock(ClusterService.class)), Set.of(), false, false);
         builder.visit(shapeVisitor);
         assertEquals(
             "{\"type\":\"bool\",\"must\"[{\"type\":\"term\"},{\"type\":\"terms\"}],\"filter\"[{\"type\":\"constant_score\",\"filter\"[{\"type\":\"range\"}]}],\"should\"[{\"type\":\"bool\",\"must\"[{\"type\":\"match\"}],\"must_not\"[{\"type\":\"regexp\"}]}]}",

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitorTests.java
@@ -10,7 +10,7 @@ package org.opensearch.plugin.insights.core.service.categorizer;
 
 import static org.mockito.Mockito.mock;
 
-import java.util.Set;
+import java.util.HashMap;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
@@ -31,7 +31,13 @@ public final class QueryShapeVisitorTests extends OpenSearchTestCase {
                     .mustNot(new RegexpQueryBuilder("color", "red.*"))
             )
             .must(new TermsQueryBuilder("genre", "action", "drama", "romance"));
-        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor(new QueryShapeGenerator(mock(ClusterService.class)), Set.of(), false, false);
+        QueryShapeVisitor shapeVisitor = new QueryShapeVisitor(
+            new QueryShapeGenerator(mock(ClusterService.class)),
+            new HashMap<>(),
+            null,
+            false,
+            false
+        );
         builder.visit(shapeVisitor);
         assertEquals(
             "{\"type\":\"bool\",\"must\"[{\"type\":\"term\"},{\"type\":\"terms\"}],\"filter\"[{\"type\":\"constant_score\",\"filter\"[{\"type\":\"range\"}]}],\"should\"[{\"type\":\"bool\",\"must\"[{\"type\":\"match\"}],\"must_not\"[{\"type\":\"regexp\"}]}]}",


### PR DESCRIPTION
### Description
Add field type to query shape and integrate with the setting changes for `field_name` and `field_type`: https://github.com/opensearch-project/query-insights/pull/135

**Example**

Field Mapping:
```
{
    "index1": {
        "mappings": {
            "properties": {
                "field1": { "type": "keyword" },
                "field2": { "type": "text" },
                "field3": { "type": "text" },
                "field4": { "type": "long" }
            }
        }
    }
}
```
Query:
```
{
    "query": {
        "bool": {
            "must": [
                {
                    "term": {
                        "field1": "example_value"
                    }
                }
            ],
            "filter": [
                {
                    "match": {
                        "field2": "search_text"
                    }
                },
                {
                    "range": {
                        "field4": {
                            "gte": 1,
                            "lte": 100
                        }
                    }
                }
            ],
            "should": [
                {
                    "regexp": {
                        "field3": ".*"
                    }
                }
            ]
        }
    }
}
```
Query Shape:
```
bool []
  must:
    term [field1, keyword]
  filter:
    match [field2, text]
    range [field4, long]
  should:
    regexp [field3, text]
```


**Local Sanity Testing Logs**
1. Tested all combinations of `field_type` and `field_name` enabled/disabled
2. Tested multiple types of search queries including complex queries with aggregation, sort, pipeline agg
3. Tested invalid fields not contained in the mapping
```
[2024-10-09T18:33:16,662][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: match [name, text]

[2024-10-09T18:33:18,673][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: term [email, keyword]

[2024-10-09T18:33:20,721][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: range [age, integer]

[2024-10-09T18:33:23,045][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: 
bool []
  must:
    match [name, text]
    range [age, integer]

[2024-10-09T18:33:25,295][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: 
wildcard [email, keyword]

[2024-10-09T18:33:27,630][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: 
aggregation:
  avg [age, integer]

[2024-10-09T18:33:30,132][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: 
nested []
  must:
    match [address.city]

[2024-10-09T18:35:43,292][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: 
bool []
  must:
    match [name, text]
  filter:
    range [age, integer]
aggregation:
  terms [age, integer]
    aggregation:
      max [join_date, date]
      pipeline aggregation:
        bucket_sort
sort:
  desc [join_date, date]

Updating [search.insights.top_queries.grouping.attributes.field_type] from [true] to [false]

[2024-10-09T18:39:14,158][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: 
bool []
  must:
    match [name]
  filter:
    range [age]
aggregation:
  terms [age]
    aggregation:
      max [join_date]
      pipeline aggregation:
        bucket_sort
sort:
  desc [join_date]

[2024-10-09T18:39:39,482][INFO ][o.o.c.s.ClusterSettings  ] [integTest-0] updating [search.insights.top_queries.grouping.attributes.field_name] from [true] to [false]
[2024-10-09T18:39:39,482][INFO ][o.o.c.s.ClusterSettings  ] [integTest-0] updating [search.insights.top_queries.grouping.attributes.field_type] from [false] to [true]
[2024-10-09T18:39:42,616][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: bool []
  must:
    match [text]
  filter:
    range [integer]
aggregation:
  terms [integer]
    aggregation:
      max [date]
      pipeline aggregation:
        bucket_sort
sort:
  desc [date]

[2024-10-09T18:39:48,314][INFO ][o.o.c.s.ClusterSettings  ] [integTest-0] updating [search.insights.top_queries.grouping.attributes.field_type] from [true] to [false]
[2024-10-09T18:39:50,451][INFO ][o.o.p.i.c.l.QueryInsightsListener] [integTest-0] Query Shape: bool
  must:
    match
  filter:
    range
aggregation:
  terms
    aggregation:
      max
      pipeline aggregation:
        bucket_sort
sort:
  desc
```

resolves: https://github.com/opensearch-project/query-insights/issues/69
