### PR TITLE
Adding cache eviction and listener for invalidating index field type …

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -31,7 +31,6 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.plugin.insights.core.listener.QueryInsightsListener;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
-import org.opensearch.plugin.insights.core.service.categorizer.IndicesFieldTypeCache;
 import org.opensearch.plugin.insights.rules.action.health_stats.HealthStatsAction;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
 import org.opensearch.plugin.insights.rules.resthandler.health_stats.RestHealthStatsAction;
@@ -146,7 +145,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME,
             QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE,
             QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
-            IndicesFieldTypeCache.INDICES_FIELD_TYPE_CACHE_SIZE_KEY
+            QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
         );
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -31,6 +31,7 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.plugin.insights.core.listener.QueryInsightsListener;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
+import org.opensearch.plugin.insights.core.service.categorizer.IndicesFieldTypeCache;
 import org.opensearch.plugin.insights.rules.action.health_stats.HealthStatsAction;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
 import org.opensearch.plugin.insights.rules.resthandler.health_stats.RestHealthStatsAction;
@@ -144,7 +145,8 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             QueryInsightsSettings.TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N,
             QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME,
             QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE,
-            QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING
+            QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
+            IndicesFieldTypeCache.INDICES_FIELD_TYPE_CACHE_SIZE_KEY
         );
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCache.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCache.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.plugin.insights.core.service.categorizer;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -8,23 +16,21 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.common.cache.Cache;
 import org.opensearch.common.cache.CacheBuilder;
 import org.opensearch.common.metrics.CounterMetric;
-import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.index.Index;
+import org.opensearch.plugin.insights.settings.QueryCategorizationSettings;
 
+/**
+ * Cache implementation specifically for maintaining the field name type mappings
+ * for indices that are part of successful search requests
+ */
 public class IndicesFieldTypeCache {
 
     private static final Logger logger = LogManager.getLogger(IndicesFieldTypeCache.class);
-    public static final Setting<ByteSizeValue> INDICES_FIELD_TYPE_CACHE_SIZE_KEY = Setting.memorySizeSetting(
-        "search.insights.indices.fieldtype.cache.size",
-        new ByteSizeValue(-1),
-        Setting.Property.NodeScope
-    );
     private final Cache<Index, IndexFieldMap> cache;
 
     public IndicesFieldTypeCache(Settings settings) {
-        final long sizeInBytes = -1; // TODO: INDICES_FIELD_TYPE_CACHE_SIZE_KEY.get(settings).getBytes();
+        final long sizeInBytes = QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY.get(settings).getBytes();
         CacheBuilder<Index, IndexFieldMap> cacheBuilder = CacheBuilder.<Index, IndexFieldMap>builder();
         if (sizeInBytes > 0) {
             cacheBuilder.setMaximumWeight(sizeInBytes).weigher((k, v) -> RamUsageEstimator.sizeOfObject(k) + v.weight());
@@ -39,6 +45,9 @@ public class IndicesFieldTypeCache {
             logger.error("Unexpected execution exception while initializing for index " + index);
         }
 
+        // Should never return null as the ExecutionException is only thrown
+        // if loader throws an exception or returns a null value, which cannot
+        // be the case in this scenario
         return null;
     }
 
@@ -64,7 +73,7 @@ public class IndicesFieldTypeCache {
         }
 
         public void putIfAbsent(String key, String value) {
-            // Increment the weight only if the key value got added to the Map
+            // Increment the weight only if the key value pair added to the Map
             if (fieldTypeMap.putIfAbsent(key, value) == null) {
                 weight.inc(RamUsageEstimator.sizeOf(key) + RamUsageEstimator.sizeOf(value));
             }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCache.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCache.java
@@ -1,0 +1,78 @@
+package org.opensearch.plugin.insights.core.service.categorizer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.opensearch.common.cache.Cache;
+import org.opensearch.common.cache.CacheBuilder;
+import org.opensearch.common.metrics.CounterMetric;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.core.index.Index;
+import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+
+public class IndicesFieldTypeCache {
+
+    private static final Logger logger = LogManager.getLogger(IndicesFieldTypeCache.class);
+    public static final Setting<ByteSizeValue> INDICES_FIELD_TYPE_CACHE_SIZE_KEY = Setting.memorySizeSetting(
+        "search.insights.indices.fieldtype.cache.size",
+        new ByteSizeValue(-1),
+        Setting.Property.NodeScope
+    );
+    private final Cache<Index, IndexFieldMap> cache;
+
+    public IndicesFieldTypeCache(Settings settings) {
+        final long sizeInBytes = -1; //TODO: INDICES_FIELD_TYPE_CACHE_SIZE_KEY.get(settings).getBytes();
+        CacheBuilder<Index, IndexFieldMap> cacheBuilder = CacheBuilder.<Index, IndexFieldMap>builder();
+        if (sizeInBytes > 0) {
+            cacheBuilder.setMaximumWeight(sizeInBytes).weigher((k, v) -> RamUsageEstimator.sizeOfObject(k) + v.weight());
+        }
+        cache = cacheBuilder.build();
+    }
+
+    public IndexFieldMap getOrInitialize(Index index) {
+        try {
+            return cache.computeIfAbsent(index, k -> new IndexFieldMap());
+        } catch (ExecutionException ex) {
+            logger.error("Unexpected execution exception while initializing for index " + index);
+        }
+
+        return null;
+    }
+
+    public void invalidate(Index index) {
+        cache.invalidate(index);
+    }
+
+    public Iterable<Index> keySet() {
+        return cache.keys();
+    }
+
+    static class IndexFieldMap {
+        private ConcurrentHashMap<String, String> fieldTypeMap;
+        private CounterMetric weight;
+        IndexFieldMap() {
+            fieldTypeMap = new ConcurrentHashMap<>();
+            weight = new CounterMetric();
+        }
+
+        public String get(String fieldName) {
+            return fieldTypeMap.get(fieldName);
+        }
+
+        public void putIfAbsent(String key, String value) {
+            // Increment the weight only if the key value got added to the Map
+            if (fieldTypeMap.putIfAbsent(key, value) == null) {
+                weight.inc(RamUsageEstimator.sizeOf(key) + RamUsageEstimator.sizeOf(value));
+            }
+        }
+        public long weight() {
+            return weight.count();
+        }
+    }
+}
+

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCache.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCache.java
@@ -1,5 +1,7 @@
 package org.opensearch.plugin.insights.core.service.categorizer;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -10,10 +12,6 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.index.Index;
-import org.opensearch.indices.fielddata.cache.IndicesFieldDataCache;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 
 public class IndicesFieldTypeCache {
 
@@ -26,7 +24,7 @@ public class IndicesFieldTypeCache {
     private final Cache<Index, IndexFieldMap> cache;
 
     public IndicesFieldTypeCache(Settings settings) {
-        final long sizeInBytes = -1; //TODO: INDICES_FIELD_TYPE_CACHE_SIZE_KEY.get(settings).getBytes();
+        final long sizeInBytes = -1; // TODO: INDICES_FIELD_TYPE_CACHE_SIZE_KEY.get(settings).getBytes();
         CacheBuilder<Index, IndexFieldMap> cacheBuilder = CacheBuilder.<Index, IndexFieldMap>builder();
         if (sizeInBytes > 0) {
             cacheBuilder.setMaximumWeight(sizeInBytes).weigher((k, v) -> RamUsageEstimator.sizeOfObject(k) + v.weight());
@@ -55,6 +53,7 @@ public class IndicesFieldTypeCache {
     static class IndexFieldMap {
         private ConcurrentHashMap<String, String> fieldTypeMap;
         private CounterMetric weight;
+
         IndexFieldMap() {
             fieldTypeMap = new ConcurrentHashMap<>();
             weight = new CounterMetric();
@@ -70,9 +69,9 @@ public class IndicesFieldTypeCache {
                 weight.inc(RamUsageEstimator.sizeOf(key) + RamUsageEstimator.sizeOf(value));
             }
         }
+
         public long weight() {
             return weight.count();
         }
     }
 }
-

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGenerator.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGenerator.java
@@ -15,9 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterStateListener;
@@ -388,8 +385,7 @@ public class QueryShapeGenerator implements ClusterStateListener {
         fieldType = getFieldTypeFromProperties(fieldName, propertiesAsMap);
 
         // Cache field type or NO_FIELD_TYPE_VALUE if not found
-        indicesFieldTypeCache.getOrInitialize(index)
-            .putIfAbsent(fieldName, fieldType != null ? fieldType : NO_FIELD_TYPE_VALUE);
+        indicesFieldTypeCache.getOrInitialize(index).putIfAbsent(fieldName, fieldType != null ? fieldType : NO_FIELD_TYPE_VALUE);
 
         return fieldType;
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGenerator.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGenerator.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.plugin.insights.core.service.categorizer;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,7 +17,7 @@ import java.util.Set;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterStateListener;
-import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.hash.MurmurHash3;
@@ -149,20 +148,12 @@ public class QueryShapeGenerator implements ClusterStateListener {
     }
 
     private Map<String, Object> getPropertiesMapForIndex(Index index) {
-        Map<String, MappingMetadata> indexMapping;
-        try {
-            indexMapping = clusterService.state().metadata().findMappings(new String[] { index.getName() }, input -> str -> true);
-        } catch (IOException e) {
-            // If an error occurs while retrieving mappings, return an empty map
+        IndexMetadata indexMetadata = clusterService.state().metadata().index(index);
+        if (indexMetadata == null) {
             return Collections.emptyMap();
         }
 
-        MappingMetadata mappingMetadata = indexMapping.get(index.getName());
-        if (mappingMetadata == null) {
-            return Collections.emptyMap();
-        }
-
-        Map<String, Object> propertiesMap = (Map<String, Object>) mappingMetadata.getSourceAsMap().get("properties");
+        Map<String, Object> propertiesMap = (Map<String, Object>) indexMetadata.mapping().getSourceAsMap().get("properties");
         if (propertiesMap == null) {
             return Collections.emptyMap();
         }

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryCategorizationSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryCategorizationSettings.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugin.insights.settings;
 
 import org.opensearch.common.settings.Setting;
+import org.opensearch.core.common.unit.ByteSizeValue;
 
 /**
  * Settings for Query Categorization
@@ -22,6 +23,12 @@ public class QueryCategorizationSettings {
         false,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
+    );
+
+    public static final Setting<ByteSizeValue> SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY = Setting.memorySizeSetting(
+        "search.query.fieldtype.cache.size",
+        "0.1%",
+        Setting.Property.NodeScope
     );
 
     /**

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -81,7 +81,8 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
                 QueryInsightsSettings.TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N,
                 QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME,
                 QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE,
-                QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING
+                QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
+                QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
             ),
             queryInsightsPlugin.getSettings()
         );

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -37,6 +37,7 @@ import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.hash.MurmurHash3;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.DistanceUnit;
 import org.opensearch.core.compress.CompressorRegistry;
 import org.opensearch.core.index.Index;
@@ -65,6 +66,7 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
     public QueryShapeGeneratorTests() {
         CompressorRegistry.defaultCompressor();
         this.mockClusterService = mock(ClusterService.class);
+        when(mockClusterService.getSettings()).thenReturn(Settings.EMPTY);
         this.mockClusterState = mock(ClusterState.class);
         this.mockMetaData = mock(Metadata.class);
         this.queryShapeGenerator = new QueryShapeGenerator(mockClusterService);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -36,7 +36,6 @@ import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.hash.MurmurHash3;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.DistanceUnit;
 import org.opensearch.core.compress.CompressorRegistry;
 import org.opensearch.core.index.Index;

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -36,6 +36,7 @@ import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.hash.MurmurHash3;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.DistanceUnit;
 import org.opensearch.core.compress.CompressorRegistry;
 import org.opensearch.core.index.Index;

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -301,7 +301,10 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
     }
 
     public void testFieldWithBinaryType() throws IOException {
-        setUpMockMappings(successfulSearchShardIndices.iterator().next(), Map.of("properties", Map.of("binaryField", Map.of("type", "binary"))));
+        setUpMockMappings(
+            successfulSearchShardIndices.iterator().next(),
+            Map.of("properties", Map.of("binaryField", Map.of("type", "binary")))
+        );
 
         SearchSourceBuilder sourceBuilder = SearchSourceBuilderUtils.createQuerySearchSourceBuilder()
             .query(boolQuery().must(termQuery("binaryField", "base64EncodedString")));

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeVisitorTests.java
@@ -9,9 +9,11 @@
 package org.opensearch.plugin.insights.core.service.categorizer;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
@@ -31,8 +33,10 @@ public final class QueryShapeVisitorTests extends OpenSearchTestCase {
                     .mustNot(new RegexpQueryBuilder("color", "red.*"))
             )
             .must(new TermsQueryBuilder("genre", "action", "drama", "romance"));
+        final ClusterService mockClusterService = mock(ClusterService.class);
+        when(mockClusterService.getSettings()).thenReturn(Settings.EMPTY);
         QueryShapeVisitor shapeVisitor = new QueryShapeVisitor(
-            new QueryShapeGenerator(mock(ClusterService.class)),
+            new QueryShapeGenerator(mockClusterService),
             new HashMap<>(),
             null,
             false,


### PR DESCRIPTION
…mappings on index deletion/update

### Description
This change primarily achieves 2 things:
* Introduces cache eviction logic for ensuring that the field data cache stays bounded
* Adds cluster state listener for invalidating index field type mappings on index deletion/update

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
