### PR TITLE
Make default window size valid for all metric types

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -62,7 +62,7 @@ public class QueryInsightsSettings {
     /** Default N size for top N queries */
     public static final int MAX_N_SIZE = 100;
     /** Default window size in seconds to keep the top N queries with latency data in query insight store */
-    public static final TimeValue DEFAULT_WINDOW_SIZE = new TimeValue(60, TimeUnit.SECONDS);
+    public static final TimeValue DEFAULT_WINDOW_SIZE = new TimeValue(1, TimeUnit.MINUTES);
     /** Default top N size to keep the data in query insight store */
     public static final int DEFAULT_TOP_N_SIZE = 3;
     /**


### PR DESCRIPTION
### Description
The default window size for latency, cpu and memory is 60s hardcoded on the backend:
```
public static final TimeValue DEFAULT_WINDOW_SIZE = new TimeValue(60, TimeUnit.SECONDS);
```
The valid window sizes are defined as:
```
public static final Set<TimeValue> VALID_WINDOW_SIZES_IN_MINUTES = new HashSet<>(
        Arrays.asList(
            new TimeValue(1, TimeUnit.MINUTES),
            new TimeValue(5, TimeUnit.MINUTES),
            new TimeValue(10, TimeUnit.MINUTES),
            new TimeValue(30, TimeUnit.MINUTES)
        )
    );
```
The default window size is not a valid window size based on the above.

This will break the QI dashboard since the dashboard only parses timeunit m and h:
https://github.com/opensearch-project/query-insights-dashboards/blob/main/public/pages/TopNQueries/TopNQueries.tsx#L192

### Issues Resolved
Closes: #155 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
