### PR TITLE
Remove local index custom name setting

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
@@ -8,10 +8,8 @@
 
 package org.opensearch.plugin.insights.core.exporter;
 
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_QUERIES_EXPORTER_TYPE;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORTER_TYPE;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -70,21 +68,6 @@ public class QueryInsightsExporterFactory {
                     SinkType.allSinkTypes()
                 )
             );
-        }
-        switch (type) {
-            case LOCAL_INDEX:
-                final String indexPattern = settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN);
-                if (indexPattern.length() == 0) {
-                    throw new IllegalArgumentException("Empty index pattern configured for the exporter");
-                }
-                try {
-                    DateTimeFormat.forPattern(indexPattern);
-                } catch (Exception e) {
-                    OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.INVALID_INDEX_PATTERN_EXCEPTIONS);
-                    throw new IllegalArgumentException(
-                        String.format(Locale.ROOT, "Invalid index pattern [%s] configured for the exporter", indexPattern)
-                    );
-                }
         }
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
@@ -8,21 +8,14 @@
 
 package org.opensearch.plugin.insights.core.reader;
 
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
-
 import java.io.IOException;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joda.time.format.DateTimeFormat;
 import org.opensearch.client.Client;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
-import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
-import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 
 /**
  * Factory class for validating and creating Readers based on provided settings
@@ -43,27 +36,6 @@ public class QueryInsightsReaderFactory {
     public QueryInsightsReaderFactory(final Client client) {
         this.client = client;
         this.Readers = new HashSet<>();
-    }
-
-    /**
-     * Validate Reader sink config
-     *
-     * @param settings Reader sink config {@link Settings}
-     * @throws IllegalArgumentException if provided Reader sink config settings are invalid
-     */
-    public void validateReaderConfig(final Settings settings) throws IllegalArgumentException {
-        final String indexPattern = settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN);
-        if (indexPattern.isEmpty()) {
-            throw new IllegalArgumentException("Empty index pattern configured for the Reader");
-        }
-        try {
-            DateTimeFormat.forPattern(indexPattern);
-        } catch (Exception e) {
-            OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.INVALID_INDEX_PATTERN_EXCEPTIONS);
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "Invalid index pattern [%s] configured for the Reader", indexPattern)
-            );
-        }
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -11,7 +11,6 @@ package org.opensearch.plugin.insights.core.service;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_QUERIES_EXPORTER_TYPE;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORTER_TYPE;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.QUERY_INSIGHTS_EXECUTOR;
 
 import java.io.IOException;
@@ -266,7 +265,7 @@ public class TopQueriesService {
         if (settings.get(EXPORTER_TYPE) != null) {
             SinkType expectedType = SinkType.parse(settings.get(EXPORTER_TYPE, DEFAULT_TOP_QUERIES_EXPORTER_TYPE));
             if (exporter != null && expectedType == SinkType.getSinkTypeFromExporter(exporter)) {
-                queryInsightsExporterFactory.updateExporter(exporter, settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN));
+                queryInsightsExporterFactory.updateExporter(exporter, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN);
             } else {
                 try {
                     queryInsightsExporterFactory.closeExporter(this.exporter);
@@ -276,7 +275,7 @@ public class TopQueriesService {
                 }
                 this.exporter = queryInsightsExporterFactory.createExporter(
                     SinkType.parse(settings.get(EXPORTER_TYPE, DEFAULT_TOP_QUERIES_EXPORTER_TYPE)),
-                    settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN)
+                    DEFAULT_TOP_N_QUERIES_INDEX_PATTERN
                 );
             }
         } else {
@@ -298,11 +297,8 @@ public class TopQueriesService {
      * @param namedXContentRegistry NamedXContentRegistry for parsing purposes
      */
     public void setReader(final Settings settings, final NamedXContentRegistry namedXContentRegistry) {
-        this.reader = queryInsightsReaderFactory.createReader(
-            settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN),
-            namedXContentRegistry
-        );
-        queryInsightsReaderFactory.updateReader(reader, settings.get(EXPORT_INDEX, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN));
+        this.reader = queryInsightsReaderFactory.createReader(DEFAULT_TOP_N_QUERIES_INDEX_PATTERN, namedXContentRegistry);
+        queryInsightsReaderFactory.updateReader(reader, DEFAULT_TOP_N_QUERIES_INDEX_PATTERN);
     }
 
     /**
@@ -312,7 +308,6 @@ public class TopQueriesService {
      */
     public void validateExporterAndReaderConfig(Settings settings) {
         queryInsightsExporterFactory.validateExporterConfig(settings);
-        queryInsightsReaderFactory.validateReaderConfig(settings);
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -220,10 +220,6 @@ public class QueryInsightsSettings {
      */
     public static final String EXPORTER_TYPE = "type";
     /**
-     * Config key for export index
-     */
-    public static final String EXPORT_INDEX = "config.index";
-    /**
      * Settings and defaults for top queries exporters
      */
     private static final String TOP_N_LATENCY_QUERIES_EXPORTER_PREFIX = TOP_N_LATENCY_QUERIES_PREFIX + ".exporter.";

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactoryTests.java
@@ -11,9 +11,7 @@ package org.opensearch.plugin.insights.core.exporter;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_QUERIES_EXPORTER_TYPE;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORTER_TYPE;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
 
 import org.joda.time.format.DateTimeFormat;
 import org.junit.Before;
@@ -59,20 +57,6 @@ public class QueryInsightsExporterFactoryTests extends OpenSearchTestCase {
         Settings.Builder settingsBuilder = Settings.builder();
         Settings settings = settingsBuilder.put(EXPORTER_TYPE, "some_invalid_type").build();
         assertThrows(IllegalArgumentException.class, () -> { queryInsightsExporterFactory.validateExporterConfig(settings); });
-    }
-
-    public void testInvalidLocalIndexConfig() {
-        Settings.Builder settingsBuilder = Settings.builder();
-        assertThrows(IllegalArgumentException.class, () -> {
-            queryInsightsExporterFactory.validateExporterConfig(
-                settingsBuilder.put(EXPORTER_TYPE, DEFAULT_TOP_QUERIES_EXPORTER_TYPE).put(EXPORT_INDEX, "").build()
-            );
-        });
-        assertThrows(IllegalArgumentException.class, () -> {
-            queryInsightsExporterFactory.validateExporterConfig(
-                settingsBuilder.put(EXPORTER_TYPE, DEFAULT_TOP_QUERIES_EXPORTER_TYPE).put(EXPORT_INDEX, "some_invalid_pattern").build()
-            );
-        });
     }
 
     public void testCreateAndCloseExporter() {

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
@@ -12,12 +12,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORT_INDEX;
 
 import org.joda.time.format.DateTimeFormat;
 import org.junit.Before;
 import org.opensearch.client.Client;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.telemetry.metrics.Counter;
@@ -43,22 +41,6 @@ public class QueryInsightsReaderFactoryTests extends OpenSearchTestCase {
             invocation -> mock(Counter.class)
         );
         OperationalMetricsCounter.initialize("cluster", metricsRegistry);
-    }
-
-    public void testValidateConfigWhenResetReader() {
-        Settings.Builder settingsBuilder = Settings.builder();
-        Settings settings = settingsBuilder.build();
-        try {
-            queryInsightsReaderFactory.validateReaderConfig(settings);
-        } catch (Exception e) {
-            fail("No exception should be thrown when setting is null");
-        }
-    }
-
-    public void testInvalidReaderTypeConfig() {
-        Settings.Builder settingsBuilder = Settings.builder();
-        Settings settings = settingsBuilder.put(EXPORT_INDEX, "some_invalid_type").build();
-        assertThrows(IllegalArgumentException.class, () -> { queryInsightsReaderFactory.validateReaderConfig(settings); });
     }
 
     public void testCreateAndCloseReader() {


### PR DESCRIPTION
### Description
Query Insights allows users to specify a custom index name for storing Top N data via the `search.insights.top_queries.latency.exporter.config.index` cluster setting. However, this flexibility introduces ambiguity. If users change the local index naming pattern, Query Insights will lose track of previously created indices, preventing dashboards from accessing historical data and hindering retention management.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
