### PR TITLE
Top N indices auto deletion config & functionality

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -82,7 +82,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
         OperationalMetricsCounter.initialize(clusterService.getClusterName().toString(), metricsRegistry);
         // create top n queries service
         final QueryInsightsService queryInsightsService = new QueryInsightsService(
-            clusterService.getClusterSettings(),
+            clusterService,
             threadPool,
             client,
             metricsRegistry,
@@ -145,6 +145,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME,
             QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE,
             QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
+            QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER,
             QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
         );
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -8,22 +8,31 @@
 
 package org.opensearch.plugin.insights.core.exporter;
 
+import static org.opensearch.plugin.insights.core.service.TopQueriesService.isTopQueriesIndex;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_DELETE_AFTER_VALUE;
+
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
+import org.opensearch.plugin.insights.core.service.TopQueriesService;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 
 /**
@@ -36,6 +45,7 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
     private final Logger logger = LogManager.getLogger();
     private final Client client;
     private DateTimeFormatter indexPattern;
+    private int deleteAfter;
 
     /**
      * Constructor of LocalIndexExporter
@@ -46,6 +56,7 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
     public LocalIndexExporter(final Client client, final DateTimeFormatter indexPattern) {
         this.indexPattern = indexPattern;
         this.client = client;
+        this.deleteAfter = DEFAULT_DELETE_AFTER_VALUE;
     }
 
     /**
@@ -61,11 +72,9 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
      * Setter of indexPattern
      *
      * @param indexPattern index pattern
-     * @return the current LocalIndexExporter
      */
-    public LocalIndexExporter setIndexPattern(DateTimeFormatter indexPattern) {
+    void setIndexPattern(DateTimeFormatter indexPattern) {
         this.indexPattern = indexPattern;
-        return this;
     }
 
     /**
@@ -75,15 +84,15 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
      */
     @Override
     public void export(final List<SearchQueryRecord> records) {
-        if (records == null || records.size() == 0) {
+        if (records == null || records.isEmpty()) {
             return;
         }
         try {
-            final String index = getDateTimeFromFormat();
+            final String indexName = buildLocalIndexName();
             final BulkRequestBuilder bulkRequestBuilder = client.prepareBulk().setTimeout(TimeValue.timeValueMinutes(1));
             for (SearchQueryRecord record : records) {
                 bulkRequestBuilder.add(
-                    new IndexRequest(index).source(record.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
+                    new IndexRequest(indexName).source(record.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
                 );
             }
             bulkRequestBuilder.execute(new ActionListener<BulkResponse>() {
@@ -110,7 +119,52 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
         logger.debug("Closing the LocalIndexExporter..");
     }
 
-    private String getDateTimeFromFormat() {
-        return indexPattern.format(ZonedDateTime.now(ZoneOffset.UTC));
+    /**
+     * Builds the local index name using the current UTC datetime
+     *
+     * @return A string representing the index name in the format "top_queries-YYYY.MM.dd-01234".
+     */
+    String buildLocalIndexName() {
+        return indexPattern.format(ZonedDateTime.now(ZoneOffset.UTC)) + "-" + generateLocalIndexDateHash();
+    }
+
+    /**
+     * Set local index exporter data retention period
+     *
+     * @param deleteAfter the number of days after which Top N local indices should be deleted
+     */
+    public void setDeleteAfter(final int deleteAfter) {
+        this.deleteAfter = deleteAfter;
+    }
+
+    /**
+     * Delete Top N local indices older than the configured data retention period
+     *
+     * @param indexMetadataMap Map of index name {@link String} to {@link IndexMetadata}
+     */
+    public void deleteExpiredTopNIndices(final Map<String, IndexMetadata> indexMetadataMap) {
+        long expirationMillisLong = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(deleteAfter);
+        for (Map.Entry<String, IndexMetadata> entry : indexMetadataMap.entrySet()) {
+            String indexName = entry.getKey();
+            if (isTopQueriesIndex(indexName) && entry.getValue().getCreationDate() <= expirationMillisLong) {
+                // delete this index
+                TopQueriesService.deleteSingleIndex(indexName, client);
+            }
+        }
+    }
+
+    /**
+     * Generates a consistent 5-digit numeric hash based on the current UTC date.
+     * The generated hash is deterministic, meaning it will return the same result for the same date.
+     *
+     * @return A 5-digit numeric string representation of the current date's hash.
+     */
+    public static String generateLocalIndexDateHash() {
+        // Get the current date in UTC (yyyy-MM-dd format)
+        String currentDate = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT)
+            .format(Instant.now().atOffset(ZoneOffset.UTC).toLocalDate());
+
+        // Generate a 5-digit numeric hash from the date's hashCode
+        return String.format(Locale.ROOT, "%05d", (currentDate.hashCode() % 100000 + 100000) % 100000);
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/metrics/OperationalMetric.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/metrics/OperationalMetric.java
@@ -13,9 +13,9 @@ import java.util.Locale;
 public enum OperationalMetric {
     LOCAL_INDEX_READER_PARSING_EXCEPTIONS("Number of errors when parsing with LocalIndexReader"),
     LOCAL_INDEX_EXPORTER_BULK_FAILURES("Number of failures when ingesting Query Insights data to local indices"),
+    LOCAL_INDEX_EXPORTER_DELETE_FAILURES("Number of failures when deleting local indices"),
     LOCAL_INDEX_EXPORTER_EXCEPTIONS("Number of exceptions in Query Insights LocalIndexExporter"),
     INVALID_EXPORTER_TYPE_FAILURES("Number of invalid exporter type failures"),
-    INVALID_INDEX_PATTERN_EXCEPTIONS("Number of invalid index pattern exceptions"),
     DATA_INGEST_EXCEPTIONS("Number of exceptions during data ingest in Query Insights"),
     QUERY_CATEGORIZE_EXCEPTIONS("Number of exceptions when categorizing the queries"),
     EXPORTER_FAIL_TO_CLOSE_EXCEPTION("Number of failures when closing the exporter"),

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.plugin.insights.core.reader;
 
+import static org.opensearch.plugin.insights.core.exporter.LocalIndexExporter.generateLocalIndexDateHash;
+
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -99,8 +101,8 @@ public final class LocalIndexReader implements QueryInsightsReader {
         }
         ZonedDateTime curr = start;
         while (curr.isBefore(end.plusDays(1).toLocalDate().atStartOfDay(end.getZone()))) {
-            String index = getDateTimeFromFormat(curr);
-            SearchRequest searchRequest = new SearchRequest(index);
+            String indexName = buildLocalIndexName(curr);
+            SearchRequest searchRequest = new SearchRequest(indexName);
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
             MatchQueryBuilder excludeQuery = QueryBuilders.matchQuery("indices", "top_queries*");
             RangeQueryBuilder rangeQuery = QueryBuilders.rangeQuery("timestamp")
@@ -135,7 +137,7 @@ public final class LocalIndexReader implements QueryInsightsReader {
         logger.debug("Closing the LocalIndexReader..");
     }
 
-    private String getDateTimeFromFormat(ZonedDateTime current) {
-        return current.format(indexPattern);
+    private String buildLocalIndexName(ZonedDateTime current) {
+        return current.format(indexPattern) + "-" + generateLocalIndexDateHash();
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -239,6 +239,31 @@ public class QueryInsightsSettings {
      * Default exporter type of top queries
      */
     public static final String DEFAULT_TOP_QUERIES_EXPORTER_TYPE = SinkType.LOCAL_INDEX.toString();
+    /**
+     * Default Top N local indices retention period in days
+     */
+    public static final int DEFAULT_DELETE_AFTER_VALUE = 7;
+    /**
+     * Minimum Top N local indices retention period in days
+     */
+    public static final int MIN_DELETE_AFTER_VALUE = 1;
+    /**
+     * Maximum Top N local indices retention period in days
+     */
+    public static final int MAX_DELETE_AFTER_VALUE = 180;
+
+    /**
+     * Setting for Top N local indices retention period
+     * <p>
+     * Note: This setting is only applicable when sink type is "local_index"
+     * and it applies to exporters of all metric types
+     */
+    public static final Setting<Integer> TOP_N_EXPORTER_DELETE_AFTER = Setting.intSetting(
+        TOP_N_QUERIES_SETTING_PREFIX + ".delete_after_days",
+        DEFAULT_DELETE_AFTER_VALUE,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
 
     /**
      * Settings for the exporter of top latency queries

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -82,6 +82,7 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
                 QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME,
                 QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE,
                 QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
+                QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER,
                 QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
             ),
             queryInsightsPlugin.getSettings()

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -339,6 +339,7 @@ final public class QueryInsightsTestUtils {
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER);
         clusterSettings.registerSetting(QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING);
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
@@ -8,21 +8,36 @@
 
 package org.opensearch.plugin.insights.core.exporter;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
+import static org.opensearch.plugin.insights.core.exporter.LocalIndexExporter.generateLocalIndexDateHash;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
 
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.junit.Before;
+import org.opensearch.Version;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.client.AdminClient;
 import org.opensearch.client.Client;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.test.OpenSearchTestCase;
@@ -33,11 +48,16 @@ import org.opensearch.test.OpenSearchTestCase;
 public class LocalIndexExporterTests extends OpenSearchTestCase {
     private final DateTimeFormatter format = DateTimeFormatter.ofPattern("YYYY.MM.dd", Locale.ROOT);
     private final Client client = mock(Client.class);
+    private final AdminClient adminClient = mock(AdminClient.class);
+    private final IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
     private LocalIndexExporter localIndexExporter;
 
     @Before
     public void setup() {
         localIndexExporter = new LocalIndexExporter(client, format);
+
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
     }
 
     public void testExportEmptyRecords() {
@@ -94,5 +114,34 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
         final DateTimeFormatter newFormatter = DateTimeFormatter.ofPattern("YYYY-MM-dd", Locale.ROOT);
         localIndexExporter.setIndexPattern(newFormatter);
         assert (localIndexExporter.getIndexPattern() == newFormatter);
+    }
+
+    public void testDeleteExpiredTopNIndices() {
+        // Reset exporter index pattern to default
+        localIndexExporter.setIndexPattern(DateTimeFormatter.ofPattern(DEFAULT_TOP_N_QUERIES_INDEX_PATTERN, Locale.ROOT));
+
+        // Create 9 top_queries-* indices
+        Map<String, IndexMetadata> indexMetadataMap = new HashMap<>();
+        for (int i = 1; i < 10; i++) {
+            String indexName = "top_queries-2024.01.0" + i + "-" + generateLocalIndexDateHash();
+            long creationTime = Instant.now().minus(i, ChronoUnit.DAYS).toEpochMilli();
+
+            IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+                .settings(
+                    Settings.builder()
+                        .put("index.version.created", Version.CURRENT.id)
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 1)
+                        .put(SETTING_CREATION_DATE, creationTime)
+                )
+                .build();
+            indexMetadataMap.put(indexName, indexMetadata);
+        }
+        localIndexExporter.deleteExpiredTopNIndices(indexMetadataMap);
+        // Default retention is 7 days
+        // Oldest 3 of 10 indices should be deleted
+        verify(client, times(3)).admin();
+        verify(adminClient, times(3)).indices();
+        verify(indicesAdminClient, times(3)).delete(any(), any());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
@@ -59,7 +60,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
             new ScalingExecutorBuilder(QueryInsightsSettings.QUERY_INSIGHTS_EXECUTOR, 1, 5, TimeValue.timeValueMinutes(5))
         );
         queryInsightsService = new QueryInsightsService(
-            clusterSettings,
+            new ClusterService(settings, clusterSettings, threadPool),
             threadPool,
             client,
             NoopMetricsRegistry.INSTANCE,

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -10,12 +10,28 @@ package org.opensearch.plugin.insights.core.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
+import static org.opensearch.plugin.insights.core.exporter.LocalIndexExporter.generateLocalIndexDateHash;
+import static org.opensearch.plugin.insights.core.service.TopQueriesService.isTopQueriesIndex;
+import static org.opensearch.plugin.insights.core.service.TopQueriesService.validateExporterDeleteAfter;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
+import org.opensearch.Version;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.Client;
+import org.opensearch.client.IndicesAdminClient;
 import org.opensearch.cluster.coordination.DeterministicTaskQueue;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
 import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporterFactory;
@@ -36,23 +52,34 @@ import org.opensearch.threadpool.ThreadPool;
  */
 public class TopQueriesServiceTests extends OpenSearchTestCase {
     private TopQueriesService topQueriesService;
+    private final Client client = mock(Client.class);
     private final ThreadPool threadPool = mock(ThreadPool.class);
     private final QueryInsightsExporterFactory queryInsightsExporterFactory = mock(QueryInsightsExporterFactory.class);
     private final QueryInsightsReaderFactory queryInsightsReaderFactory = mock(QueryInsightsReaderFactory.class);
-    private MetricsRegistry metricsRegistry;
+    private final AdminClient adminClient = mock(AdminClient.class);
+    private final IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
 
     @Before
     public void setup() {
-        topQueriesService = new TopQueriesService(MetricType.LATENCY, threadPool, queryInsightsExporterFactory, queryInsightsReaderFactory);
+        topQueriesService = new TopQueriesService(
+            client,
+            MetricType.LATENCY,
+            threadPool,
+            queryInsightsExporterFactory,
+            queryInsightsReaderFactory
+        );
         topQueriesService.setTopNSize(Integer.MAX_VALUE);
         topQueriesService.setWindowSize(new TimeValue(Long.MAX_VALUE));
         topQueriesService.setEnabled(true);
 
-        metricsRegistry = mock(MetricsRegistry.class);
+        MetricsRegistry metricsRegistry = mock(MetricsRegistry.class);
         when(metricsRegistry.createCounter(any(String.class), any(String.class), any(String.class))).thenAnswer(
             invocation -> mock(Counter.class)
         );
         OperationalMetricsCounter.initialize("cluster", metricsRegistry);
+
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
     }
 
     public void testIngestQueryDataWithLargeWindow() {
@@ -179,5 +206,73 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         assertNotNull(healthStats.getQueryGrouperHealthStats());
         // Assuming no grouping by default, expect QueryGroupCount to be 0
         assertEquals(0, healthStats.getQueryGrouperHealthStats().getQueryGroupCount());
+    }
+
+    public void testValidateExporterDeleteAfter() {
+        validateExporterDeleteAfter(7);
+        validateExporterDeleteAfter(180);
+        validateExporterDeleteAfter(1);
+        assertThrows(IllegalArgumentException.class, () -> { validateExporterDeleteAfter(-1); });
+        assertThrows(IllegalArgumentException.class, () -> { validateExporterDeleteAfter(0); });
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> { validateExporterDeleteAfter(181); });
+        assertEquals(
+            "Invalid exporter delete_after_days setting [181], value should be an integer between 1 and 180.",
+            exception.getMessage()
+        );
+    }
+
+    public void testDeleteAllTopNIndices() {
+        // Create 9 top_queries-* indices
+        Map<String, IndexMetadata> indexMetadataMap = new HashMap<>();
+        for (int i = 1; i < 10; i++) {
+            String indexName = "top_queries-2024.01.0" + i + "-" + generateLocalIndexDateHash();
+            long creationTime = Instant.now().minus(i, ChronoUnit.DAYS).toEpochMilli();
+
+            IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+                .settings(
+                    Settings.builder()
+                        .put("index.version.created", Version.CURRENT.id)
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 1)
+                        .put(SETTING_CREATION_DATE, creationTime)
+                )
+                .build();
+            indexMetadataMap.put(indexName, indexMetadata);
+        }
+        // Create 5 user indices
+        for (int i = 0; i < 5; i++) {
+            String indexName = "my_index-" + i;
+            long creationTime = Instant.now().minus(i, ChronoUnit.DAYS).toEpochMilli();
+
+            IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
+                .settings(
+                    Settings.builder()
+                        .put("index.version.created", Version.CURRENT.id)
+                        .put("index.number_of_shards", 1)
+                        .put("index.number_of_replicas", 1)
+                        .put(SETTING_CREATION_DATE, creationTime)
+                )
+                .build();
+            indexMetadataMap.put(indexName, indexMetadata);
+        }
+
+        topQueriesService.deleteAllTopNIndices(indexMetadataMap);
+        // All 10 indices should be deleted
+        verify(client, times(9)).admin();
+        verify(adminClient, times(9)).indices();
+        verify(indicesAdminClient, times(9)).delete(any(), any());
+    }
+
+    public void testIsTopQueriesIndex() {
+        assertTrue(isTopQueriesIndex("top_queries-2024.01.01-01234"));
+        assertTrue(isTopQueriesIndex("top_queries-2025.12.12-99999"));
+
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-012345"));
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-0123w"));
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.01"));
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-01234"));
+        assertFalse(isTopQueriesIndex("top_queries-01234"));
+        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-01234"));
+        assertFalse(isTopQueriesIndex("2024.01.01-01234"));
     }
 }


### PR DESCRIPTION
### Description
This PR introduces two features related to the retention of Top N historical data:

1. New Cluster Setting: `search.insights.top_queries.delete_after_days`
2. Scheduled job to automatically deletes expired indices

Details:
- `search.insights.top_queries.delete_after_days`: This integer setting determines the retention period in days for Top N indices. Default value is 7 days. Acceptable range is 1 to 180 days.
- Setting is only applicable when `exporter.type` is `local_index`
- Single setting applies to all metric types
- Deletion job runs when `delete_after_days` setting is updated and once per day, in line with the top_queries index rollover period (1 day). Looks for indices that match the naming pattern `top_queries-YYYY.MM.dd-xxxxx`
- Any time `exporter.type` is changed from `local_index`, all existing local indices are deleted. This is so that indices do not linger when sink type is not `local_index`.

### Testing
```
% curl -X GET "localhost:9200/_cat/indices?v&s=index"                                                               
health status index                        uuid                   pri rep docs.count docs.deleted store.size pri.store.size
yellow open   test2                        I4DeK5ALSOizWRYLbpTGBQ   1   1          4            0      9.2kb          9.2kb
yellow open   top_queries-2025.01.04-62052 kKOZP1ivRlGTtaMP0sXQdw   1   1          7            0     58.1kb         58.1kb
```
```
% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2025-01-05T00:00:00.000Z"
{
  "top_queries" : [
    {
      "timestamp" : 1735954349215,
      "total_shards" : 1,
      "indices" : [ ],
      "phase_latency_map" : {
        "expand" : 0,
        "query" : 42,
        "fetch" : 2
      },
...
```

`search.insights.top_queries.delete_after_days` validation:
```
% curl -XPUT "http://localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'          
{
  "persistent" : {
    "search.insights.top_queries.delete_after_days" : "999" 
  }
}
'
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "illegal value can't update [search.insights.top_queries.delete_after_days] from [1] to [999]"
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "illegal value can't update [search.insights.top_queries.delete_after_days] from [1] to [999]",
    "caused_by" : {
      "type" : "illegal_argument_exception",
      "reason" : "Invalid exporter delete_after_days setting [999], value should be an integer between 1 and 180."
    },
    "suppressed" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "illegal value can't update [search.insights.top_queries.delete_after_days] from [1] to [999]",
        "caused_by" : {
          "type" : "illegal_argument_exception",
          "reason" : "Invalid exporter delete_after_days setting [999], value should be an integer between 1 and 180."
        }
      },
      {
        "type" : "illegal_argument_exception",
        "reason" : "illegal value can't update [search.insights.top_queries.delete_after_days] from [1] to [999]",
        "caused_by" : {
          "type" : "illegal_argument_exception",
          "reason" : "Invalid exporter delete_after_days setting [999], value should be an integer between 1 and 180."
        }
      }
    ]
  },
  "status" : 400
}
```

### Issues Resolved
Resolves https://github.com/opensearch-project/query-insights/issues/165

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
