### PR TITLE
Migrate from Joda-Time to java.time API

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -8,12 +8,12 @@
 
 package org.opensearch.plugin.insights.core.exporter;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormatter;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexRequest;
@@ -111,6 +111,6 @@ public final class LocalIndexExporter implements QueryInsightsExporter {
     }
 
     private String getDateTimeFromFormat() {
-        return indexPattern.print(DateTime.now(DateTimeZone.UTC));
+        return indexPattern.format(ZonedDateTime.now(ZoneOffset.UTC));
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
@@ -12,12 +12,12 @@ import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFA
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORTER_TYPE;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joda.time.format.DateTimeFormat;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
@@ -80,7 +80,7 @@ public class QueryInsightsExporterFactory {
      */
     public QueryInsightsExporter createExporter(SinkType type, String indexPattern) {
         if (SinkType.LOCAL_INDEX.equals(type)) {
-            QueryInsightsExporter exporter = new LocalIndexExporter(client, DateTimeFormat.forPattern(indexPattern));
+            QueryInsightsExporter exporter = new LocalIndexExporter(client, DateTimeFormatter.ofPattern(indexPattern, Locale.ROOT));
             this.exporters.add(exporter);
             return exporter;
         }
@@ -96,7 +96,7 @@ public class QueryInsightsExporterFactory {
      */
     public QueryInsightsExporter updateExporter(QueryInsightsExporter exporter, String indexPattern) {
         if (exporter.getClass() == LocalIndexExporter.class) {
-            ((LocalIndexExporter) exporter).setIndexPattern(DateTimeFormat.forPattern(indexPattern));
+            ((LocalIndexExporter) exporter).setIndexPattern(DateTimeFormatter.ofPattern(indexPattern, Locale.ROOT));
         }
         return exporter;
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
@@ -9,11 +9,12 @@
 package org.opensearch.plugin.insights.core.reader;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joda.time.format.DateTimeFormat;
 import org.opensearch.client.Client;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 
@@ -46,7 +47,11 @@ public class QueryInsightsReaderFactory {
      * @return QueryInsightsReader the created Reader
      */
     public QueryInsightsReader createReader(String indexPattern, NamedXContentRegistry namedXContentRegistry) {
-        QueryInsightsReader Reader = new LocalIndexReader(client, DateTimeFormat.forPattern(indexPattern), namedXContentRegistry);
+        QueryInsightsReader Reader = new LocalIndexReader(
+            client,
+            DateTimeFormatter.ofPattern(indexPattern, Locale.ROOT),
+            namedXContentRegistry
+        );
         this.Readers.add(Reader);
         return Reader;
     }
@@ -60,7 +65,7 @@ public class QueryInsightsReaderFactory {
      */
     public QueryInsightsReader updateReader(QueryInsightsReader Reader, String indexPattern) {
         if (Reader.getClass() == LocalIndexReader.class) {
-            ((LocalIndexReader) Reader).setIndexPattern(DateTimeFormat.forPattern(indexPattern));
+            ((LocalIndexReader) Reader).setIndexPattern(DateTimeFormatter.ofPattern(indexPattern, Locale.ROOT));
         }
         return Reader;
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,7 +33,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joda.time.DateTime;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -362,10 +362,10 @@ public class TopQueriesService {
         }
         List<SearchQueryRecord> filterQueries = queries;
         if (from != null && to != null) {
-            final DateTime start = DateTime.parse(from);
-            final DateTime end = DateTime.parse(to);
-            Predicate<SearchQueryRecord> timeFilter = element -> start.getMillis() <= element.getTimestamp()
-                && element.getTimestamp() <= end.getMillis();
+            final ZonedDateTime start = ZonedDateTime.parse(from);
+            final ZonedDateTime end = ZonedDateTime.parse(to);
+            Predicate<SearchQueryRecord> timeFilter = element -> start.toInstant().toEpochMilli() <= element.getTimestamp()
+                && element.getTimestamp() <= end.toInstant().toEpochMilli();
             filterQueries = queries.stream().filter(checkIfInternal.and(timeFilter)).collect(Collectors.toList());
         }
         return Stream.of(filterQueries)
@@ -394,11 +394,11 @@ public class TopQueriesService {
         final List<SearchQueryRecord> queries = new ArrayList<>();
         if (reader != null) {
             try {
-                final DateTime start = DateTime.parse(from);
-                final DateTime end = DateTime.parse(to);
+                final ZonedDateTime start = ZonedDateTime.parse(from);
+                final ZonedDateTime end = ZonedDateTime.parse(to);
                 List<SearchQueryRecord> records = reader.read(from, to);
-                Predicate<SearchQueryRecord> timeFilter = element -> start.getMillis() <= element.getTimestamp()
-                    && element.getTimestamp() <= end.getMillis();
+                Predicate<SearchQueryRecord> timeFilter = element -> start.toInstant().toEpochMilli() <= element.getTimestamp()
+                    && element.getTimestamp() <= end.toInstant().toEpochMilli();
                 List<SearchQueryRecord> filteredRecords = records.stream()
                     .filter(checkIfInternal.and(timeFilter))
                     .collect(Collectors.toList());

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
@@ -11,11 +11,11 @@ package org.opensearch.plugin.insights.rules.resthandler.top_queries;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_QUERIES_BASE_URI;
 import static org.opensearch.rest.RestRequest.Method.GET;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.joda.time.DateTime;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.Strings;
@@ -67,7 +67,7 @@ public class RestTopQueriesAction extends BaseRestHandler {
 
     private static boolean isNotISODate(final String dateTime) {
         try {
-            DateTime.parse(dateTime);
+            ZonedDateTime.parse(dateTime);
             return false;
         } catch (Exception e) {
             return true;

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
@@ -14,9 +14,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import java.util.Locale;
 import org.junit.Before;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequestBuilder;
@@ -31,7 +31,7 @@ import org.opensearch.test.OpenSearchTestCase;
  * Granular tests for the {@link LocalIndexExporterTests} class.
  */
 public class LocalIndexExporterTests extends OpenSearchTestCase {
-    private final DateTimeFormatter format = DateTimeFormat.forPattern("YYYY.MM.dd");
+    private final DateTimeFormatter format = DateTimeFormatter.ofPattern("YYYY.MM.dd", Locale.ROOT);
     private final Client client = mock(Client.class);
     private LocalIndexExporter localIndexExporter;
 
@@ -91,7 +91,7 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
     }
 
     public void testGetAndSetIndexPattern() {
-        DateTimeFormatter newFormatter = mock(DateTimeFormatter.class);
+        final DateTimeFormatter newFormatter = DateTimeFormatter.ofPattern("YYYY-MM-dd", Locale.ROOT);
         localIndexExporter.setIndexPattern(newFormatter);
         assert (localIndexExporter.getIndexPattern() == newFormatter);
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactoryTests.java
@@ -13,7 +13,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.EXPORTER_TYPE;
 
-import org.joda.time.format.DateTimeFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import org.junit.Before;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
@@ -76,9 +77,9 @@ public class QueryInsightsExporterFactoryTests extends OpenSearchTestCase {
     }
 
     public void testUpdateExporter() {
-        LocalIndexExporter exporter = new LocalIndexExporter(client, DateTimeFormat.forPattern("yyyy-MM-dd"));
+        LocalIndexExporter exporter = new LocalIndexExporter(client, DateTimeFormatter.ofPattern(format, Locale.ROOT));
         queryInsightsExporterFactory.updateExporter(exporter, "yyyy-MM-dd-HH");
-        assertEquals(DateTimeFormat.forPattern("yyyy-MM-dd-HH"), exporter.getIndexPattern());
+        assertEquals(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH", Locale.ROOT).toString(), exporter.getIndexPattern().toString());
     }
 
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
@@ -13,7 +13,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN;
 
-import org.joda.time.format.DateTimeFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import org.junit.Before;
 import org.opensearch.client.Client;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
@@ -55,9 +56,9 @@ public class QueryInsightsReaderFactoryTests extends OpenSearchTestCase {
     }
 
     public void testUpdateReader() {
-        LocalIndexReader reader = new LocalIndexReader(client, DateTimeFormat.forPattern(format), namedXContentRegistry);
+        LocalIndexReader reader = new LocalIndexReader(client, DateTimeFormatter.ofPattern(format, Locale.ROOT), namedXContentRegistry);
         queryInsightsReaderFactory.updateReader(reader, "yyyy-MM-dd-HH");
-        assertEquals(DateTimeFormat.forPattern("yyyy-MM-dd-HH"), reader.getIndexPattern());
+        assertEquals(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH", Locale.ROOT).toString(), reader.getIndexPattern().toString());
     }
 
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -8,8 +8,10 @@
 
 package org.opensearch.plugin.insights.core.service;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
@@ -21,12 +23,15 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
+import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.plugin.insights.rules.model.healthStats.QueryInsightsHealthStats;
 import org.opensearch.plugin.insights.rules.model.healthStats.TopQueriesHealthStats;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.telemetry.metrics.noop.NoopMetricsRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ScalingExecutorBuilder;
@@ -64,6 +69,12 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         queryInsightsService.enableCollection(MetricType.CPU, true);
         queryInsightsService.enableCollection(MetricType.MEMORY, true);
         queryInsightsServiceSpy = spy(queryInsightsService);
+
+        MetricsRegistry metricsRegistry = mock(MetricsRegistry.class);
+        when(metricsRegistry.createCounter(any(String.class), any(String.class), any(String.class))).thenAnswer(
+            invocation -> mock(Counter.class)
+        );
+        OperationalMetricsCounter.initialize("cluster", metricsRegistry);
     }
 
     @Override

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesActionTests.java
@@ -10,12 +10,13 @@ package org.opensearch.plugin.insights.rules.resthandler.top_queries;
 
 import static org.opensearch.plugin.insights.rules.resthandler.top_queries.RestTopQueriesAction.ALLOWED_METRICS;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesRequest;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
@@ -27,8 +28,8 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
     public void testEmptyNodeIdsValidType() {
         Map<String, String> params = new HashMap<>();
         params.put("type", randomFrom(ALLOWED_METRICS));
-        params.put("from", DateTime.now(DateTimeZone.UTC).toString());
-        params.put("to", DateTime.now(DateTimeZone.UTC).toString());
+        params.put("from", ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
+        params.put("to", ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
         RestRequest restRequest = buildRestRequest(params);
         TopQueriesRequest actual = RestTopQueriesAction.prepareRequest(restRequest);
         assertEquals(0, actual.nodesIds().length);
@@ -60,7 +61,7 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
     public void testInValidFrom() {
         Map<String, String> params = new HashMap<>();
         params.put("from", "not valid timestamp");
-        params.put("to", DateTime.now(DateTimeZone.UTC).toString());
+        params.put("to", ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
         RestRequest restRequest = buildRestRequest(params);
         Exception exception = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest); });
         assertEquals(
@@ -75,7 +76,7 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
 
     public void testInValidTo() {
         Map<String, String> params = new HashMap<>();
-        params.put("from", DateTime.now(DateTimeZone.UTC).toString());
+        params.put("from", ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
         params.put("to", "not valid timestamp");
         RestRequest restRequest = buildRestRequest(params);
         Exception exception = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest); });
@@ -91,7 +92,7 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
 
     public void testMissingOneTimeParam() {
         Map<String, String> params = new HashMap<>();
-        params.put("from", DateTime.now(DateTimeZone.UTC).toString());
+        params.put("from", ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
         RestRequest restRequest = buildRestRequest(params);
         Exception exception = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest); });
         assertEquals(
@@ -99,7 +100,7 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
             exception.getMessage()
         );
         Map<String, String> params2 = new HashMap<>();
-        params2.put("to", DateTime.now(DateTimeZone.UTC).toString());
+        params2.put("to", ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));
         RestRequest restRequest2 = buildRestRequest(params2);
         Exception exception2 = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest2); });
         assertEquals(


### PR DESCRIPTION
### Description
This PR migrates the codebase from Joda-Time to the `java.time` API to align with Java's standard library and ensure future compatibility, as Joda-Time is no longer maintained. It replaces Joda-Time classes like `DateTime` and `DateTimeZone` with `java.time` equivalents (`ZonedDateTime`, `ZoneOffset`) and updates parsing, formatting, and date-time operations. This change improves maintainability and uses the modern, supported `java.time` API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
