### PR TITLE
Fix github CI by adding eclipse dependency in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ spotless {
     }
     removeUnusedImports()
     importOrder()
-    eclipse().configFile rootProject.file('config/formatterConfig.xml')
+    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('config/formatterConfig.xml')
     trimTrailingWhitespace()
     endWithNewline()
   }


### PR DESCRIPTION
### Description
Fix for github check failures:
```
* What went wrong:
A problem occurred configuring root project 'query-insights'.
> java.io.IOException: Failed to load eclipse jdt formatter: java.lang.RuntimeException: java.net.SocketTimeoutException: timeout
```

Reference PR: https://github.com/opensearch-project/neural-search/pull/1079

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
