### PR TITLE
fix parsing error in SearchQueryRecord

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -175,6 +175,7 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
                         break;
                     case GROUP_BY:
                         attributes.put(Attribute.GROUP_BY, parser.text());
+                        break;
                     case SOURCE:
                         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
                         attributes.put(Attribute.SOURCE, SearchSourceBuilder.fromXContent(parser, false));


### PR DESCRIPTION
### Description
fix parsing error in SearchQueryRecord as we are missing a break in https://github.com/opensearch-project/query-insights/pull/157.


### Issues Resolved
https://github.com/opensearch-project/query-insights/issues/178

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
