### PR TITLE
Make sure query_group_hashcode is present in top_queries response in all cases

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -288,7 +288,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
                 // Add hashcode attribute when grouping is enabled
                 if (queryInsightsService.isGroupingEnabled()) {
                     String hashcode = queryShapeGenerator.getShapeHashCodeAsString(queryShape);
-                    attributes.put(Attribute.QUERY_HASHCODE, hashcode);
+                    attributes.put(Attribute.QUERY_GROUP_HASHCODE, hashcode);
                 }
             }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -288,7 +288,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
                 // Add hashcode attribute when grouping is enabled
                 if (queryInsightsService.isGroupingEnabled()) {
                     String hashcode = queryShapeGenerator.getShapeHashCodeAsString(queryShape);
-                    attributes.put(Attribute.QUERY_GROUP_HASHCODE, hashcode);
+                    attributes.put(Attribute.ID, hashcode);
                 }
             }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouper.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouper.java
@@ -271,7 +271,7 @@ public class MinMaxHeapQueryGrouper implements QueryGrouper {
     private String getGroupingId(final SearchQueryRecord searchQueryRecord) {
         switch (groupingType) {
             case SIMILARITY:
-                return searchQueryRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE).toString();
+                return searchQueryRecord.getAttributes().get(Attribute.ID).toString();
             case NONE:
                 throw new IllegalArgumentException("Should not try to group queries if grouping type is NONE");
             default:

--- a/src/main/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouper.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouper.java
@@ -271,7 +271,7 @@ public class MinMaxHeapQueryGrouper implements QueryGrouper {
     private String getGroupingId(final SearchQueryRecord searchQueryRecord) {
         switch (groupingType) {
             case SIMILARITY:
-                return searchQueryRecord.getAttributes().get(Attribute.QUERY_HASHCODE).toString();
+                return searchQueryRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE).toString();
             case NONE:
                 throw new IllegalArgumentException("Should not try to group queries if grouping type is NONE");
             default:

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -58,9 +58,9 @@ public enum Attribute {
      */
     LABELS,
     /**
-     * Unique hashcode used to group similar queries
+     * Query Group hashcode or query hashcode representing a unique identifier for the query/group
      */
-    QUERY_GROUP_HASHCODE,
+    ID,
     /**
      * Grouping type of the query record (none, similarity)
      */

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -60,7 +60,7 @@ public enum Attribute {
     /**
      * Unique hashcode used to group similar queries
      */
-    QUERY_HASHCODE,
+    QUERY_GROUP_HASHCODE,
     /**
      * Grouping type of the query record (none, similarity)
      */

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -96,6 +96,11 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      */
     public static final String GROUP_BY = "group_by";
 
+    /**
+     * Query Group hashcode
+     */
+    public static final String QUERY_GROUP_HASHCODE = "query_group_hashcode";
+
     public static final String MEASUREMENTS = "measurements";
     private String groupingId;
 
@@ -175,6 +180,9 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
                         break;
                     case GROUP_BY:
                         attributes.put(Attribute.GROUP_BY, parser.text());
+                        break;
+                    case QUERY_GROUP_HASHCODE:
+                        attributes.put(Attribute.QUERY_GROUP_HASHCODE, parser.text());
                         break;
                     case SOURCE:
                         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.plugin.insights.rules.model;
 
-import static org.opensearch.plugin.insights.rules.model.Attribute.GROUP_BY;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -97,9 +95,9 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
     public static final String GROUP_BY = "group_by";
 
     /**
-     * Query Group hashcode
+     * Query Group hashcode or query hashcode representing a unique identifier for the query/group
      */
-    public static final String QUERY_GROUP_HASHCODE = "query_group_hashcode";
+    public static final String ID = "id";
 
     public static final String MEASUREMENTS = "measurements";
     private String groupingId;
@@ -181,8 +179,8 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
                     case GROUP_BY:
                         attributes.put(Attribute.GROUP_BY, parser.text());
                         break;
-                    case QUERY_GROUP_HASHCODE:
-                        attributes.put(Attribute.QUERY_GROUP_HASHCODE, parser.text());
+                    case ID:
+                        attributes.put(Attribute.ID, parser.text());
                         break;
                     case SOURCE:
                         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -139,7 +139,7 @@ final public class QueryInsightsTestUtils {
             attributes.put(Attribute.TOTAL_SHARDS, randomIntBetween(1, 100));
             attributes.put(Attribute.INDICES, randomArray(1, 3, Object[]::new, () -> randomAlphaOfLengthBetween(5, 10)));
             attributes.put(Attribute.PHASE_LATENCY_MAP, phaseLatencyMap);
-            attributes.put(Attribute.QUERY_GROUP_HASHCODE, Objects.hashCode(i));
+            attributes.put(Attribute.ID, Objects.hashCode(i));
             attributes.put(Attribute.GROUP_BY, GroupingType.NONE);
             attributes.put(
                 Attribute.TASK_RESOURCE_USAGES,
@@ -200,13 +200,13 @@ final public class QueryInsightsTestUtils {
 
     public static void populateSameQueryHashcodes(List<SearchQueryRecord> searchQueryRecords) {
         for (SearchQueryRecord record : searchQueryRecords) {
-            record.getAttributes().put(Attribute.QUERY_GROUP_HASHCODE, 1);
+            record.getAttributes().put(Attribute.ID, 1);
         }
     }
 
     public static void populateHashcode(List<SearchQueryRecord> searchQueryRecords, int hash) {
         for (SearchQueryRecord record : searchQueryRecords) {
-            record.getAttributes().put(Attribute.QUERY_GROUP_HASHCODE, hash);
+            record.getAttributes().put(Attribute.ID, hash);
         }
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -139,7 +139,7 @@ final public class QueryInsightsTestUtils {
             attributes.put(Attribute.TOTAL_SHARDS, randomIntBetween(1, 100));
             attributes.put(Attribute.INDICES, randomArray(1, 3, Object[]::new, () -> randomAlphaOfLengthBetween(5, 10)));
             attributes.put(Attribute.PHASE_LATENCY_MAP, phaseLatencyMap);
-            attributes.put(Attribute.QUERY_HASHCODE, Objects.hashCode(i));
+            attributes.put(Attribute.QUERY_GROUP_HASHCODE, Objects.hashCode(i));
             attributes.put(Attribute.GROUP_BY, GroupingType.NONE);
             attributes.put(
                 Attribute.TASK_RESOURCE_USAGES,
@@ -200,13 +200,13 @@ final public class QueryInsightsTestUtils {
 
     public static void populateSameQueryHashcodes(List<SearchQueryRecord> searchQueryRecords) {
         for (SearchQueryRecord record : searchQueryRecords) {
-            record.getAttributes().put(Attribute.QUERY_HASHCODE, 1);
+            record.getAttributes().put(Attribute.QUERY_GROUP_HASHCODE, 1);
         }
     }
 
     public static void populateHashcode(List<SearchQueryRecord> searchQueryRecords, int hash) {
         for (SearchQueryRecord record : searchQueryRecords) {
-            record.getAttributes().put(Attribute.QUERY_HASHCODE, hash);
+            record.getAttributes().put(Attribute.QUERY_GROUP_HASHCODE, hash);
         }
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
@@ -44,7 +44,7 @@ public class MinMaxHeapQueryGrouperTests extends OpenSearchTestCase {
         Set<Integer> hashcodeSet = new HashSet<>();
         for (SearchQueryRecord record : records) {
             groupedRecord = minMaxHeapQueryGrouper.add(record);
-            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE);
+            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.ID);
             hashcodeSet.add(hashcode);
         }
         assertEquals(numOfRecords, hashcodeSet.size());
@@ -58,7 +58,7 @@ public class MinMaxHeapQueryGrouperTests extends OpenSearchTestCase {
         Set<Integer> hashcodeSet = new HashSet<>();
         for (SearchQueryRecord record : records) {
             groupedRecord = minMaxHeapQueryGrouper.add(record);
-            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE);
+            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.ID);
             hashcodeSet.add(hashcode);
         }
         assertEquals(1, hashcodeSet.size());

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
@@ -44,7 +44,7 @@ public class MinMaxHeapQueryGrouperTests extends OpenSearchTestCase {
         Set<Integer> hashcodeSet = new HashSet<>();
         for (SearchQueryRecord record : records) {
             groupedRecord = minMaxHeapQueryGrouper.add(record);
-            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.QUERY_HASHCODE);
+            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE);
             hashcodeSet.add(hashcode);
         }
         assertEquals(numOfRecords, hashcodeSet.size());
@@ -58,7 +58,7 @@ public class MinMaxHeapQueryGrouperTests extends OpenSearchTestCase {
         Set<Integer> hashcodeSet = new HashSet<>();
         for (SearchQueryRecord record : records) {
             groupedRecord = minMaxHeapQueryGrouper.add(record);
-            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.QUERY_HASHCODE);
+            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE);
             hashcodeSet.add(hashcode);
         }
         assertEquals(1, hashcodeSet.size());


### PR DESCRIPTION
### Description
_Describe what this change achieves._
Fixes the bug where `query_group_hashcode` is not present in the top_queries response in some cases when the from request param is specified. This caused duplicate entries on the dashboard and caused all historical rows to be displayed without query_group_hashcode.

Refactoring: Rename `query_hashcode` to `id` as a prereq for https://github.com/opensearch-project/query-insights/issues/159

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 
closes https://github.com/opensearch-project/query-insights/issues/186

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
