### PR TITLE
Model changes for query_group_hashcode and id

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -288,7 +288,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
                 // Add hashcode attribute when grouping is enabled
                 if (queryInsightsService.isGroupingEnabled()) {
                     String hashcode = queryShapeGenerator.getShapeHashCodeAsString(queryShape);
-                    attributes.put(Attribute.ID, hashcode);
+                    attributes.put(Attribute.QUERY_GROUP_HASHCODE, hashcode);
                 }
             }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouper.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouper.java
@@ -271,7 +271,7 @@ public class MinMaxHeapQueryGrouper implements QueryGrouper {
     private String getGroupingId(final SearchQueryRecord searchQueryRecord) {
         switch (groupingType) {
             case SIMILARITY:
-                return searchQueryRecord.getAttributes().get(Attribute.ID).toString();
+                return searchQueryRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE).toString();
             case NONE:
                 throw new IllegalArgumentException("Should not try to group queries if grouping type is NONE");
             default:

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -58,9 +58,9 @@ public enum Attribute {
      */
     LABELS,
     /**
-     * Query Group hashcode or query hashcode representing a unique identifier for the query/group
+     * Query Group hashcode
      */
-    ID,
+    QUERY_GROUP_HASHCODE,
     /**
      * Grouping type of the query record (none, similarity)
      */

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -139,7 +139,7 @@ final public class QueryInsightsTestUtils {
             attributes.put(Attribute.TOTAL_SHARDS, randomIntBetween(1, 100));
             attributes.put(Attribute.INDICES, randomArray(1, 3, Object[]::new, () -> randomAlphaOfLengthBetween(5, 10)));
             attributes.put(Attribute.PHASE_LATENCY_MAP, phaseLatencyMap);
-            attributes.put(Attribute.ID, Objects.hashCode(i));
+            attributes.put(Attribute.QUERY_GROUP_HASHCODE, Objects.hashCode(i));
             attributes.put(Attribute.GROUP_BY, GroupingType.NONE);
             attributes.put(
                 Attribute.TASK_RESOURCE_USAGES,
@@ -200,13 +200,13 @@ final public class QueryInsightsTestUtils {
 
     public static void populateSameQueryHashcodes(List<SearchQueryRecord> searchQueryRecords) {
         for (SearchQueryRecord record : searchQueryRecords) {
-            record.getAttributes().put(Attribute.ID, 1);
+            record.getAttributes().put(Attribute.QUERY_GROUP_HASHCODE, 1);
         }
     }
 
     public static void populateHashcode(List<SearchQueryRecord> searchQueryRecords, int hash) {
         for (SearchQueryRecord record : searchQueryRecords) {
-            record.getAttributes().put(Attribute.ID, hash);
+            record.getAttributes().put(Attribute.QUERY_GROUP_HASHCODE, hash);
         }
     }
 
@@ -223,7 +223,7 @@ final public class QueryInsightsTestUtils {
         return new TopQueries(node, records);
     }
 
-    public static TopQueries createFixedTopQueries() {
+    public static TopQueries createFixedTopQueries(String id) {
         DiscoveryNode node = new DiscoveryNode(
             "node_for_top_queries_test",
             buildNewFakeTransportAddress(),
@@ -232,12 +232,12 @@ final public class QueryInsightsTestUtils {
             VersionUtils.randomVersion(random())
         );
         List<SearchQueryRecord> records = new ArrayList<>();
-        records.add(createFixedSearchQueryRecord());
+        records.add(createFixedSearchQueryRecord(id));
 
         return new TopQueries(node, records);
     }
 
-    public static SearchQueryRecord createFixedSearchQueryRecord() {
+    public static SearchQueryRecord createFixedSearchQueryRecord(String id) {
         long timestamp = 1706574180000L;
         Map<MetricType, Measurement> measurements = Map.of(MetricType.LATENCY, new Measurement(1L));
 
@@ -256,7 +256,7 @@ final public class QueryInsightsTestUtils {
             )
         );
 
-        return new SearchQueryRecord(timestamp, measurements, attributes);
+        return new SearchQueryRecord(timestamp, measurements, attributes, id);
     }
 
     public static void compareJson(ToXContent param1, ToXContent param2) throws IOException {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxHeapQueryGrouperTests.java
@@ -44,7 +44,7 @@ public class MinMaxHeapQueryGrouperTests extends OpenSearchTestCase {
         Set<Integer> hashcodeSet = new HashSet<>();
         for (SearchQueryRecord record : records) {
             groupedRecord = minMaxHeapQueryGrouper.add(record);
-            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.ID);
+            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE);
             hashcodeSet.add(hashcode);
         }
         assertEquals(numOfRecords, hashcodeSet.size());
@@ -58,7 +58,7 @@ public class MinMaxHeapQueryGrouperTests extends OpenSearchTestCase {
         Set<Integer> hashcodeSet = new HashSet<>();
         for (SearchQueryRecord record : records) {
             groupedRecord = minMaxHeapQueryGrouper.add(record);
-            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.ID);
+            int hashcode = (int) groupedRecord.getAttributes().get(Attribute.QUERY_GROUP_HASHCODE);
             hashcodeSet.add(hashcode);
         }
         assertEquals(1, hashcodeSet.size());

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
@@ -40,18 +40,61 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
     }
 
     public void testToXContent() throws IOException {
-        char[] expectedXcontent =
-            "{\"top_queries\":[{\"timestamp\":1706574180000,\"node_id\":\"node_for_top_queries_test\",\"phase_latency_map\":{\"expand\":1,\"query\":10,\"fetch\":1},\"task_resource_usages\":[{\"action\":\"action\",\"taskId\":2,\"parentTaskId\":1,\"nodeId\":\"id\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":1000,\"memory_in_bytes\":2000}},{\"action\":\"action2\",\"taskId\":3,\"parentTaskId\":1,\"nodeId\":\"id2\",\"taskResourceUsage\":{\"cpu_time_in_nanos\":2000,\"memory_in_bytes\":1000}}],\"search_type\":\"query_then_fetch\",\"measurements\":{\"latency\":{\"number\":1,\"count\":1,\"aggregationType\":\"NONE\"}}}]}"
-                .toCharArray();
-        TopQueries topQueries = QueryInsightsTestUtils.createFixedTopQueries();
+        String id = "sample_id";
+
+        char[] expectedXContent = ("{"
+            + "\"top_queries\":[{"
+            + "\"timestamp\":1706574180000,"
+            + "\"node_id\":\"node_for_top_queries_test\","
+            + "\"phase_latency_map\":{"
+            + "\"expand\":1,"
+            + "\"query\":10,"
+            + "\"fetch\":1"
+            + "},"
+            + "\"task_resource_usages\":[{"
+            + "\"action\":\"action\","
+            + "\"taskId\":2,"
+            + "\"parentTaskId\":1,"
+            + "\"nodeId\":\"id\","
+            + "\"taskResourceUsage\":{"
+            + "\"cpu_time_in_nanos\":1000,"
+            + "\"memory_in_bytes\":2000"
+            + "}"
+            + "},{"
+            + "\"action\":\"action2\","
+            + "\"taskId\":3,"
+            + "\"parentTaskId\":1,"
+            + "\"nodeId\":\"id2\","
+            + "\"taskResourceUsage\":{"
+            + "\"cpu_time_in_nanos\":2000,"
+            + "\"memory_in_bytes\":1000"
+            + "}"
+            + "}],"
+            + "\"search_type\":\"query_then_fetch\","
+            + "\"measurements\":{"
+            + "\"latency\":{"
+            + "\"number\":1,"
+            + "\"count\":1,"
+            + "\"aggregationType\":\"NONE\""
+            + "}"
+            + "},"
+            + "\"id\":\""
+            + id
+            + "\""
+            + "}]"
+            + "}").toCharArray();
+
+        TopQueries topQueries = QueryInsightsTestUtils.createFixedTopQueries(id);
         ClusterName clusterName = new ClusterName("test-cluster");
         TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(topQueries), new ArrayList<>(), 10, MetricType.LATENCY);
+
         XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
         char[] xContent = BytesReference.bytes(response.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString().toCharArray();
-        Arrays.sort(expectedXcontent);
+
+        Arrays.sort(expectedXContent);
         Arrays.sort(xContent);
 
-        assertEquals(Arrays.hashCode(expectedXcontent), Arrays.hashCode(xContent));
+        assertEquals(Arrays.hashCode(expectedXContent), Arrays.hashCode(xContent));
     }
 
     /**

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
@@ -45,19 +45,19 @@ public class SearchQueryRecordTests extends OpenSearchTestCase {
     }
 
     public void testCompare() {
-        SearchQueryRecord record1 = QueryInsightsTestUtils.createFixedSearchQueryRecord();
-        SearchQueryRecord record2 = QueryInsightsTestUtils.createFixedSearchQueryRecord();
+        SearchQueryRecord record1 = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
+        SearchQueryRecord record2 = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
         assertEquals(0, SearchQueryRecord.compare(record1, record2, MetricType.LATENCY));
     }
 
     public void testEqual() {
-        SearchQueryRecord record1 = QueryInsightsTestUtils.createFixedSearchQueryRecord();
-        SearchQueryRecord record2 = QueryInsightsTestUtils.createFixedSearchQueryRecord();
+        SearchQueryRecord record1 = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
+        SearchQueryRecord record2 = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
         assertEquals(record1, record2);
     }
 
     public void testFromXContent() {
-        SearchQueryRecord record = QueryInsightsTestUtils.createFixedSearchQueryRecord();
+        SearchQueryRecord record = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
         try (XContentParser recordParser = createParser(JsonXContent.jsonXContent, record.toString())) {
             SearchQueryRecord parsedRecord = SearchQueryRecord.fromXContent(recordParser);
             QueryInsightsTestUtils.checkRecordsEquals(List.of(record), List.of(parsedRecord));


### PR DESCRIPTION
### Description
Model changes for `query_group_hashcode` and `id`.

**query_group_hashcode**: Will be used to store the hashcode of the query shape and used by the group_by feature (only applicable for query groups)
**id**: UUID used to uniquely identify a query/group. This will be displayed in the id column on the dashboard

Updated the unit tests.

Changes are part of the larger set of changes required to solve the issue where the query/group details page on the dashboard is broken when refreshed.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

Addresses: https://github.com/opensearch-project/query-insights/issues/159
Addresses: https://github.com/opensearch-project/query-insights-dashboards/issues/12 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


Sample Dashboard Screenshots with UUID:
![image](https://github.com/user-attachments/assets/90560d94-b6dc-45b9-b620-74ba3937c464)
![image](https://github.com/user-attachments/assets/14a7aa29-4aa2-4a54-93e6-6b5fddf9eaa8)


