### PR TITLE
Add field type cache data to health stats API

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -87,6 +87,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         this.clusterService = clusterService;
         this.queryInsightsService = queryInsightsService;
         this.queryShapeGenerator = new QueryShapeGenerator(clusterService);
+        queryInsightsService.setQueryShapeGenerator(queryShapeGenerator);
 
         // Setting endpoints set up for top n queries, including enabling top n queries, window size, and top n size
         // Expected metricTypes are Latency, CPU, and Memory.

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/health_stats/HealthStatsNodeResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/health_stats/HealthStatsNodeResponseTests.java
@@ -53,6 +53,7 @@ public class HealthStatsNodeResponseTests extends OpenSearchTestCase {
         this.healthStats = new QueryInsightsHealthStats(
             threadPool.info(QueryInsightsSettings.QUERY_INSIGHTS_EXECUTOR),
             10,
+            new HashMap<>(),
             new HashMap<>()
         );
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/health_stats/HealthStatsResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/health_stats/HealthStatsResponseTests.java
@@ -58,6 +58,7 @@ public class HealthStatsResponseTests extends OpenSearchTestCase {
         this.healthStats = new QueryInsightsHealthStats(
             threadPool.info(QueryInsightsSettings.QUERY_INSIGHTS_EXECUTOR),
             10,
+            new HashMap<>(),
             new HashMap<>()
         );
     }
@@ -113,7 +114,7 @@ public class HealthStatsResponseTests extends OpenSearchTestCase {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         response.toXContent(builder, ToXContent.EMPTY_PARAMS);
         String expectedJson =
-            "{\"node_for_health_stats_test\":{\"ThreadPoolInfo\":{\"query_insights_executor\":{\"type\":\"scaling\",\"core\":1,\"max\":5,\"keep_alive\":\"5m\",\"queue_size\":-1}},\"QueryRecordsQueueSize\":10,\"TopQueriesHealthStats\":{}}}";
+            "{\"node_for_health_stats_test\":{\"ThreadPoolInfo\":{\"query_insights_executor\":{\"type\":\"scaling\",\"core\":1,\"max\":5,\"keep_alive\":\"5m\",\"queue_size\":-1}},\"QueryRecordsQueueSize\":10,\"TopQueriesHealthStats\":{},\"FieldTypeCacheStats\":{\"size_in_bytes\":0,\"entry_count\":0,\"evictions\":0,\"hit_count\":0,\"miss_count\":0}}}";
         assertEquals(expectedJson, builder.toString());
     }
 }


### PR DESCRIPTION
### Description
Add field type cache stats to the Query Insights `health_stats` API.

This enables users to track total hit count, miss count, entry count, and cache memory size.

```
% curl -XGET "http://localhost:9200/_insights/health_stats?pretty"                     
{
  "WcXrhPnVRdmjADJAFf98aw" : {
    "ThreadPoolInfo" : {
      "query_insights_executor" : {
        "type" : "scaling",
        "core" : 1,
        "max" : 5,
        "keep_alive" : "5m",
        "queue_size" : -1
      }
    },
    "QueryRecordsQueueSize" : 0,
    "TopQueriesHealthStats" : {
      "cpu" : {
        "TopQueriesHeapSize" : 0,
        "QueryGroupCount_Total" : 0,
        "QueryGroupCount_MaxHeap" : 0
      },
      "memory" : {
        "TopQueriesHeapSize" : 0,
        "QueryGroupCount_Total" : 0,
        "QueryGroupCount_MaxHeap" : 0
      },
      "latency" : {
        "TopQueriesHeapSize" : 2,
        "QueryGroupCount_Total" : 2,
        "QueryGroupCount_MaxHeap" : 0
      }
    },
    "FieldTypeCacheStats" : {
      "size_in_bytes" : 336,
      "entry_count" : 3,
      "evictions" : 1,
      "hit_count" : 5,
      "miss_count" : 4
    }
  }
}
```
### Issues Resolved
Resolves https://github.com/opensearch-project/query-insights/issues/146

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
