### PR TITLE
Add fetch top queries by id API

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
@@ -20,8 +20,9 @@ public interface QueryInsightsReader extends Closeable {
      * Reader a list of SearchQueryRecord
      *
      * @param from string
-     * @param to string
+     * @param to   string
+     * @param id query/group id
      * @return List of SearchQueryRecord
      */
-    List<SearchQueryRecord> read(final String from, final String to);
+    List<SearchQueryRecord> read(final String from, final String to, final String id);
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -22,6 +22,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     final MetricType metricType;
     final String from;
     final String to;
+    final String id;
 
     /**
      * Constructor for TopQueriesRequest
@@ -34,6 +35,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
         this.metricType = MetricType.readFromStream(in);
         this.from = null;
         this.to = null;
+        this.id = null;
     }
 
     /**
@@ -45,11 +47,12 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
      * @param to end timestamp
      * @param nodesIds the nodeIds specified in the request
      */
-    public TopQueriesRequest(final MetricType metricType, final String from, final String to, final String... nodesIds) {
+    public TopQueriesRequest(final MetricType metricType, final String from, final String to, final String id, final String... nodesIds) {
         super(nodesIds);
         this.metricType = metricType;
         this.from = from;
         this.to = to;
+        this.id = id;
     }
 
     /**
@@ -74,6 +77,14 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
      */
     public String getTo() {
         return to;
+    }
+
+    /**
+     * Get id which is the query_id and query_group_id
+     * @return String of to timestamp
+     */
+    public String getId() {
+        return id;
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -307,6 +307,15 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
     }
 
     /**
+     * Returns the id.
+     *
+     * @return the id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
      * Returns the measurement associated with the specified name.
      *
      * @param name the name of the measurement

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
@@ -79,40 +79,46 @@ public class RestTopQueriesAction extends BaseRestHandler {
         final String metricType = request.param("type", MetricType.LATENCY.toString());
         final String from = request.param("from", null);
         final String to = request.param("to", null);
+        final String id = request.param("id", null);
         if (!ALLOWED_METRICS.contains(metricType)) {
             throw new IllegalArgumentException(
                 String.format(Locale.ROOT, "request [%s] contains invalid metric type [%s]", request.path(), metricType)
             );
         }
-        if (from != null || to != null) {
-            if (from != null ^ to != null) {
-                throw new IllegalArgumentException(
-                    String.format(Locale.ROOT, "request [%s] is missing one of the time parameters. Both must be provided", request.path())
-                );
-            }
-            if (isNotISODate(from)) {
-                throw new IllegalArgumentException(
-                    String.format(
-                        Locale.ROOT,
-                        "request [%s] contains invalid 'from' date format. Expected ISO8601 format string (YYYY-MM-DD'T'HH:mm:ss.SSSZ): [%s]",
-                        request.path(),
-                        from
-                    )
-                );
-            }
-            if (isNotISODate(to)) {
-                throw new IllegalArgumentException(
-                    String.format(
-                        Locale.ROOT,
-                        "request [%s] contains invalid 'to' date format. Expected ISO8601 format string (YYYY-MM-DD'T'HH:mm:ss.SSSZ): [%s]",
-                        request.path(),
-                        to
-                    )
-                );
-            }
+        boolean isTimeRangeProvided = from != null || to != null;
+        if (isTimeRangeProvided) {
+            validateTimeRange(request, from, to);
         }
 
-        return new TopQueriesRequest(MetricType.fromString(metricType), from, to, nodesIds);
+        return new TopQueriesRequest(MetricType.fromString(metricType), from, to, id, nodesIds);
+    }
+
+    private static void validateTimeRange(RestRequest request, String from, String to) {
+        if (from != null ^ to != null) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "request [%s] is missing one of the time parameters. Both must be provided", request.path())
+            );
+        }
+        if (isNotISODate(from)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "request [%s] contains invalid 'from' date format. Expected ISO8601 format string (YYYY-MM-DD'T'HH:mm:ss.SSSZ): [%s]",
+                    request.path(),
+                    from
+                )
+            );
+        }
+        if (isNotISODate(to)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "request [%s] contains invalid 'to' date format. Expected ISO8601 format string (YYYY-MM-DD'T'HH:mm:ss.SSSZ): [%s]",
+                    request.path(),
+                    to
+                )
+            );
+        }
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -88,11 +88,12 @@ public class TransportTopQueriesAction extends TransportNodesAction<
         }
         final String from = topQueriesRequest.getFrom();
         final String to = topQueriesRequest.getTo();
+        final String id = topQueriesRequest.getId();
         if (from != null && to != null) {
             responses.add(
                 new TopQueries(
                     clusterService.localNode(),
-                    queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType()).getTopQueriesRecordsFromIndex(from, to)
+                    queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType()).getTopQueriesRecordsFromIndex(from, to, id)
                 )
             );
         }
@@ -114,9 +115,10 @@ public class TransportTopQueriesAction extends TransportNodesAction<
         final TopQueriesRequest request = nodeRequest.request;
         final String from = request.getFrom();
         final String to = request.getTo();
+        final String id = request.getId();
         return new TopQueries(
             clusterService.localNode(),
-            queryInsightsService.getTopQueriesService(request.getMetricType()).getTopQueriesRecords(true, from, to)
+            queryInsightsService.getTopQueriesService(request.getMetricType()).getTopQueriesRecords(true, from, to, id)
         );
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 import org.opensearch.action.search.SearchType;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.ClusterSettings;
@@ -54,7 +55,18 @@ import org.opensearch.test.VersionUtils;
 
 final public class QueryInsightsTestUtils {
 
+    static String randomId = UUID.randomUUID().toString();
+
     public QueryInsightsTestUtils() {}
+
+    /**
+     * Returns list of randomly generated search query records with a specific id
+     * @param count number of records
+     * @return List of records
+     */
+    public static List<SearchQueryRecord> generateQueryInsightRecords(int count, String id) {
+        return generateQueryInsightRecords(count, count, System.currentTimeMillis(), 0, AggregationType.DEFAULT_AGGREGATION_TYPE, id);
+    }
 
     /**
      * Returns list of randomly generated search query records.
@@ -62,7 +74,7 @@ final public class QueryInsightsTestUtils {
      * @return List of records
      */
     public static List<SearchQueryRecord> generateQueryInsightRecords(int count) {
-        return generateQueryInsightRecords(count, count, System.currentTimeMillis(), 0, AggregationType.DEFAULT_AGGREGATION_TYPE);
+        return generateQueryInsightRecords(count, count, System.currentTimeMillis(), 0, AggregationType.DEFAULT_AGGREGATION_TYPE, randomId);
     }
 
     /**
@@ -77,7 +89,8 @@ final public class QueryInsightsTestUtils {
             count,
             System.currentTimeMillis(),
             0,
-            AggregationType.DEFAULT_AGGREGATION_TYPE
+            AggregationType.DEFAULT_AGGREGATION_TYPE,
+            randomId
         );
         for (SearchQueryRecord record : records) {
             record.getAttributes().put(Attribute.SOURCE, searchSourceBuilder);
@@ -92,14 +105,14 @@ final public class QueryInsightsTestUtils {
      * @return List of records
      */
     public static List<SearchQueryRecord> generateQueryInsightRecords(int count, AggregationType aggregationType) {
-        return generateQueryInsightRecords(count, count, System.currentTimeMillis(), 0, aggregationType);
+        return generateQueryInsightRecords(count, count, System.currentTimeMillis(), 0, aggregationType, randomId);
     }
 
     /**
      * Creates a List of random Query Insight Records for testing purpose
      */
     public static List<SearchQueryRecord> generateQueryInsightRecords(int lower, int upper, long startTimeStamp, long interval) {
-        return generateQueryInsightRecords(lower, upper, startTimeStamp, interval, AggregationType.NONE);
+        return generateQueryInsightRecords(lower, upper, startTimeStamp, interval, AggregationType.NONE, randomId);
     }
 
     /**
@@ -110,7 +123,8 @@ final public class QueryInsightsTestUtils {
         int upper,
         long startTimeStamp,
         long interval,
-        AggregationType aggregationType
+        AggregationType aggregationType,
+        String id
     ) {
         List<SearchQueryRecord> records = new ArrayList<>();
         int countOfRecords = randomIntBetween(lower, upper);
@@ -161,7 +175,7 @@ final public class QueryInsightsTestUtils {
                 )
             );
 
-            records.add(new SearchQueryRecord(timestamp, measurements, attributes));
+            records.add(new SearchQueryRecord(timestamp, measurements, attributes, id));
             timestamp += interval;
         }
         return records;

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
@@ -84,9 +84,10 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
         when(responseActionFuture.actionGet()).thenReturn(searchResponse);
         when(client.search(any(SearchRequest.class))).thenReturn(responseActionFuture);
         String time = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME);
+        String id = "example-hashcode";
         List<SearchQueryRecord> records = List.of();
         try {
-            records = localIndexReader.read(time, time);
+            records = localIndexReader.read(time, time, id);
         } catch (Exception e) {
             fail("No exception should be thrown when reading query insights data");
         }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -94,7 +94,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         queryInsightsService.drainRecords();
         assertEquals(
             QueryInsightsSettings.DEFAULT_TOP_N_SIZE,
-            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null).size()
+            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null).size()
         );
     }
 
@@ -149,7 +149,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
 
         assertEquals(
             QueryInsightsSettings.DEFAULT_TOP_N_SIZE,
-            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null).size()
+            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null).size()
         );
     }
 
@@ -172,7 +172,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         assertTrue(queryInsightsService.addRecord(records.get(numberOfRecordsRequired - 1)));
 
         queryInsightsService.drainRecords();
-        assertEquals(1, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null).size());
+        assertEquals(1, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null).size());
     }
 
     public void testAddRecordGroupBySimilarityWithTwoGroups() {
@@ -191,7 +191,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         }
 
         queryInsightsService.drainRecords();
-        assertEquals(2, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null).size());
+        assertEquals(2, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null).size());
     }
 
     public void testGetHealthStats() {

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/health_stats/TransportHealthStatsActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/health_stats/TransportHealthStatsActionTests.java
@@ -69,7 +69,7 @@ public class TransportHealthStatsActionTests extends OpenSearchTestCase {
         }
 
         public TopQueriesResponse createNewResponse() {
-            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null);
+            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null);
             return newResponse(request, List.of(), List.of());
         }
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
@@ -64,7 +64,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
         }
 
         public TopQueriesResponse createNewResponse() {
-            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null);
+            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null);
             return newResponse(request, List.of(), List.of());
         }
     }


### PR DESCRIPTION
### Description
This PR contains all the backend changes required to add the fetch top queries by id API.

This change is a prerequisite to the change on the UI to make sure we include the `to`, `from` and `id` in the url for the query/group details page and make an API call to fetch the query/group details rather than propagating the information from the Top N queries page.

Change comprises of the following:
1. Update the local index reader to fetch queries from local index by id
2. Update the TopQueriesService to filter based on id if id is provided
3. Refactoring to make parts of the code more readable
4. Update the unit tests based on the changes and add additional unit tests
5. Model changes to add id to the search query record
6. API layer changes to add `id` as an optional param to the top queries API

Testing:
Tested on localhost.

Get query/group by id:
![image](https://github.com/user-attachments/assets/8add460e-f52e-4c94-adfb-6e0d3bfc4256)
Get query/group by id:
![image](https://github.com/user-attachments/assets/e0d386a9-222f-4eb6-9fc1-edf07dc1b337)
Get queries/groups without id with time range:
![image](https://github.com/user-attachments/assets/9e56928b-bdbd-45be-8c97-ba687e617a2e)
Get queries/groups without id and without time range:
![image](https://github.com/user-attachments/assets/01dbbcf1-9aa8-422b-9f40-c0ae9ab00000)





### Issues Resolved
closes: https://github.com/opensearch-project/query-insights/issues/159

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
