### PR TITLE
Always collect available metrics in top queries service

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -220,10 +220,6 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         constructSearchQueryRecord(context, searchRequestContext);
     }
 
-    private boolean shouldCollect(MetricType metricType) {
-        return queryInsightsService.isSearchQueryMetricsFeatureEnabled() || queryInsightsService.isCollectionEnabled(metricType);
-    }
-
     private void constructSearchQueryRecord(final SearchPhaseContext context, final SearchRequestContext searchRequestContext) {
         SearchTask searchTask = context.getTask();
         List<TaskResourceInfo> tasksResourceUsages = searchRequestContext.getPhaseResourceUsage();
@@ -240,28 +236,22 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         final SearchRequest request = context.getRequest();
         try {
             Map<MetricType, Measurement> measurements = new HashMap<>();
-            if (shouldCollect(MetricType.LATENCY)) {
-                measurements.put(
-                    MetricType.LATENCY,
-                    new Measurement(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - searchRequestContext.getAbsoluteStartNanos()))
-                );
-            }
-            if (shouldCollect(MetricType.CPU)) {
-                measurements.put(
-                    MetricType.CPU,
-                    new Measurement(
-                        tasksResourceUsages.stream().map(a -> a.getTaskResourceUsage().getCpuTimeInNanos()).mapToLong(Long::longValue).sum()
-                    )
-                );
-            }
-            if (shouldCollect(MetricType.MEMORY)) {
-                measurements.put(
-                    MetricType.MEMORY,
-                    new Measurement(
-                        tasksResourceUsages.stream().map(a -> a.getTaskResourceUsage().getMemoryInBytes()).mapToLong(Long::longValue).sum()
-                    )
-                );
-            }
+            measurements.put(
+                MetricType.LATENCY,
+                new Measurement(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - searchRequestContext.getAbsoluteStartNanos()))
+            );
+            measurements.put(
+                MetricType.CPU,
+                new Measurement(
+                    tasksResourceUsages.stream().map(a -> a.getTaskResourceUsage().getCpuTimeInNanos()).mapToLong(Long::longValue).sum()
+                )
+            );
+            measurements.put(
+                MetricType.MEMORY,
+                new Measurement(
+                    tasksResourceUsages.stream().map(a -> a.getTaskResourceUsage().getMemoryInBytes()).mapToLong(Long::longValue).sum()
+                )
+            );
 
             Map<Attribute, Object> attributes = new HashMap<>();
             attributes.put(Attribute.SEARCH_TYPE, request.searchType().toString().toLowerCase(Locale.ROOT));

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
@@ -140,9 +140,15 @@ public final class SearchQueryCounters {
     }
 
     private void incrementAllHistograms(Tags tags, Map<MetricType, Measurement> measurements) {
-        queryTypeLatencyHistogram.record(measurements.get(MetricType.LATENCY).getMeasurement().doubleValue(), tags);
-        queryTypeCpuHistogram.record(measurements.get(MetricType.CPU).getMeasurement().doubleValue(), tags);
-        queryTypeMemoryHistogram.record(measurements.get(MetricType.MEMORY).getMeasurement().doubleValue(), tags);
+        if (measurements.containsKey(MetricType.LATENCY)) {
+            queryTypeLatencyHistogram.record(measurements.get(MetricType.LATENCY).getMeasurement().doubleValue(), tags);
+        }
+        if (measurements.containsKey(MetricType.CPU)) {
+            queryTypeCpuHistogram.record(measurements.get(MetricType.CPU).getMeasurement().doubleValue(), tags);
+        }
+        if (measurements.containsKey(MetricType.MEMORY)) {
+            queryTypeMemoryHistogram.record(measurements.get(MetricType.MEMORY).getMeasurement().doubleValue(), tags);
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -322,6 +322,9 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      * @return the measurement object, or null if not found
      */
     public Number getMeasurement(final MetricType name) {
+        if (!measurements.containsKey(name)) {
+            return null;
+        }
         return measurements.get(name).getMeasurement();
     }
 
@@ -337,6 +340,10 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      * @param numberToAdd The measurement number we want to add to the current measurement.
      */
     public void addMeasurement(final MetricType metricType, Number numberToAdd) {
+        if (!measurements.containsKey(metricType)) {
+            measurements.put(metricType, new Measurement(numberToAdd));
+            return;
+        }
         measurements.get(metricType).addMeasurement(numberToAdd);
     }
 
@@ -346,6 +353,9 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      * @param aggregationType Aggregation type to set
      */
     public void setMeasurementAggregation(final MetricType name, AggregationType aggregationType) {
+        if (!measurements.containsKey(name)) {
+            return;
+        }
         measurements.get(name).setAggregationType(aggregationType);
     }
 


### PR DESCRIPTION
### Description
Currently we are not collecting metrics that are not enabled for top n queries, which causes certain measurements fields missing in local index sometimes. This is not a consistent behavior, idealy, when user configure "enabling/disabling top n queries by cpu", we should really just adding/removing the logic to push the records into the cpu metric heap, but whether the the top n queries are configured or not, we should always collect the metric.

### Issues Resolved
https://github.com/opensearch-project/query-insights/issues/204

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
