### PR TITLE
Fix null indexFieldMap bug & add UTs

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCache.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCache.java
@@ -68,9 +68,11 @@ public class IndicesFieldTypeCache {
 
     public void invalidate(Index index) {
         IndexFieldMap indexFieldMap = cache.get(index);
-        evictionCount.inc(indexFieldMap.fieldTypeMap.size());
-        entryCount.dec(indexFieldMap.fieldTypeMap.size());
-        weight.dec(indexFieldMap.weight());
+        if (indexFieldMap != null) {
+            evictionCount.inc(indexFieldMap.fieldTypeMap.size());
+            entryCount.dec(indexFieldMap.fieldTypeMap.size());
+            weight.dec(indexFieldMap.weight());
+        }
         cache.invalidate(index);
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCacheTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/IndicesFieldTypeCacheTests.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.categorizer;
+
+import java.util.UUID;
+import java.util.stream.StreamSupport;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.test.OpenSearchTestCase;
+
+public final class IndicesFieldTypeCacheTests extends OpenSearchTestCase {
+    final Index index1 = new Index("index1", UUID.randomUUID().toString());
+    final Index index2 = new Index("index2", UUID.randomUUID().toString());
+
+    public IndicesFieldTypeCacheTests() {}
+
+    public void testCache() {
+        final IndicesFieldTypeCache indicesFieldTypeCache = new IndicesFieldTypeCache(Settings.EMPTY);
+
+        // Assert cache is empty
+        assertEquals(0, StreamSupport.stream(indicesFieldTypeCache.keySet().spliterator(), false).count());
+        assertEquals(0, (long) indicesFieldTypeCache.getEntryCount());
+        assertEquals(0, (long) indicesFieldTypeCache.getEvictionCount());
+        assertEquals(0, (long) indicesFieldTypeCache.getWeight());
+
+        // Test invalidate on empty cache
+        indicesFieldTypeCache.invalidate(index1);
+        indicesFieldTypeCache.invalidate(index2);
+
+        // Insert some items in the cache
+        if (indicesFieldTypeCache.getOrInitialize(index1).putIfAbsent("field1", "keyword")) {
+            indicesFieldTypeCache.incrementCountAndWeight("field1", "keyword");
+        }
+        if (indicesFieldTypeCache.getOrInitialize(index1).putIfAbsent("field2", "boolean")) {
+            indicesFieldTypeCache.incrementCountAndWeight("field2", "boolean");
+        }
+        if (indicesFieldTypeCache.getOrInitialize(index2).putIfAbsent("field3", "float_range")) {
+            indicesFieldTypeCache.incrementCountAndWeight("field3", "float_range");
+        }
+        if (indicesFieldTypeCache.getOrInitialize(index2).putIfAbsent("field4", "date")) {
+            indicesFieldTypeCache.incrementCountAndWeight("field4", "date");
+        }
+
+        assertEquals(2, StreamSupport.stream(indicesFieldTypeCache.keySet().spliterator(), false).count());
+        assertEquals(4, (long) indicesFieldTypeCache.getEntryCount());
+        assertEquals(0, (long) indicesFieldTypeCache.getEvictionCount());
+        assertTrue(0 < indicesFieldTypeCache.getWeight());
+
+        // Invalidate index1
+        indicesFieldTypeCache.invalidate(index1);
+
+        assertEquals(1, StreamSupport.stream(indicesFieldTypeCache.keySet().spliterator(), false).count());
+        assertEquals(2, (long) indicesFieldTypeCache.getEntryCount());
+        assertEquals(2, (long) indicesFieldTypeCache.getEvictionCount());
+        assertTrue(0 < indicesFieldTypeCache.getWeight());
+    }
+
+}


### PR DESCRIPTION
### Description
Fixes null pointer bug when invalidating an index which has no cache entries.

```
[2025-01-23T22:32:47,810][WARN ][o.o.c.s.ClusterApplierService] [integTest-1] failed to notify ClusterStateListener
java.lang.NullPointerException: Cannot read field "fieldTypeMap" because "indexFieldMap" is null
java.lang.NullPointerException: Cannot read field "fieldTypeMap" because "indexFieldMap" is null
        at org.opensearch.plugin.insights.core.service.categorizer.IndicesFieldTypeCache.invalidate(IndicesFieldTypeCache.java:71) ~[?:?]
        at org.opensearch.plugin.insights.core.service.categorizer.IndicesFieldTypeCache.invalidate(IndicesFieldTypeCache.java:71) ~[?:?]
        at org.opensearch.plugin.insights.core.service.categorizer.QueryShapeGenerator.clusterChanged(QueryShapeGenerator.java:64) ~[?:?]
        at org.opensearch.plugin.insights.core.service.categorizer.QueryShapeGenerator.clusterChanged(QueryShapeGenerator.java:64) ~[?:?]
        at org.opensearch.cluster.service.ClusterApplierService.callClusterStateListener(ClusterApplierService.java:662) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService.callClusterStateListener(ClusterApplierService.java:662) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService.callClusterStateListeners(ClusterApplierService.java:648) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService.callClusterStateListeners(ClusterApplierService.java:648) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:606) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:606) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:510) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:510) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:205) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:205) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:932) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:932) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at 
```
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
