### PR TITLE
Update default .enabled and exporter.type settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ For information about installing plugins, see [Installing plugins](https://opens
 
 ### Enabling top N query monitoring
 
-When you install the `query-insights` plugin, top N query monitoring is disabled by default. To enable top N query monitoring, update the dynamic settings for the desired monitoring types. These settings enable the corresponding collectors and aggregators in the running cluster. For example, to enable monitoring top N queries by latency, update the `search.insights.top_queries.latency.enabled` setting:
+When you install the `query-insights` plugin, top N query monitoring is enabled by default. To disable top N query monitoring, update the dynamic cluster settings for the desired metric types. For example, to disable monitoring top N queries by latency, update the `search.insights.top_queries.latency.enabled` setting:
 
 ```
 PUT _cluster/settings
 {
   "persistent" : {
-    "search.insights.top_queries.latency.enabled" : true
+    "search.insights.top_queries.latency.enabled" : false
   }
 }
 ```

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -95,7 +95,7 @@ public class QueryInsightsSettings {
      */
     public static final Setting<Boolean> TOP_N_LATENCY_QUERIES_ENABLED = Setting.boolSetting(
         TOP_N_LATENCY_QUERIES_PREFIX + ".enabled",
-        false,
+        true,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -159,7 +159,7 @@ public class QueryInsightsSettings {
      */
     public static final Setting<Boolean> TOP_N_CPU_QUERIES_ENABLED = Setting.boolSetting(
         TOP_N_CPU_QUERIES_PREFIX + ".enabled",
-        false,
+        true,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -189,7 +189,7 @@ public class QueryInsightsSettings {
      */
     public static final Setting<Boolean> TOP_N_MEMORY_QUERIES_ENABLED = Setting.boolSetting(
         TOP_N_MEMORY_QUERIES_PREFIX + ".enabled",
-        false,
+        true,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -229,7 +229,7 @@ public class QueryInsightsSettings {
     /**
      * Default exporter type of top queries
      */
-    public static final String DEFAULT_TOP_QUERIES_EXPORTER_TYPE = SinkType.NONE.toString();
+    public static final String DEFAULT_TOP_QUERIES_EXPORTER_TYPE = SinkType.LOCAL_INDEX.toString();
     /**
      * Default Top N local indices retention period in days
      */


### PR DESCRIPTION
### Description
- Change default .enabled setting to `true` for all metric types
- Change default exporter.type setting to `local_index`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
