### PR TITLE
Fix github upload artifact error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,14 @@ jobs:
         with:
           name: logs-ubuntu
           path: build/testclusters/integTest-*/logs/*
+          overwrite: true
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: query-insights-plugin-${{ matrix.os }}
           path: query-insights-artifacts
+          overwrite: true
 
   build-windows-macos:
     env:
@@ -120,6 +122,7 @@ jobs:
         with:
           name: logs-mac
           path: build/testclusters/integTest-*/logs/*
+          overwrite: true
 
       - name: Upload failed logs
         uses: actions/upload-artifact@v4
@@ -127,9 +130,11 @@ jobs:
         with:
           name: logs-windows
           path: build\testclusters\integTest-*\logs\*
+          overwrite: true
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: query-insights-plugin-${{ matrix.os }}
           path: query-insights-artifacts
+          overwrite: true


### PR DESCRIPTION
### Description
Fix github upload artifact error on 2.x, 2.19 branches. Verified fix on `2.x` branch in https://github.com/opensearch-project/query-insights/pull/228.

Error:
```
Run actions/upload-artifact@v4
  with:
    name: query-insights-plugin-ubuntu-latest
    path: query-insights-artifacts
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
    include-hidden-files: false
  env:
    ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
    JAVA_HOME_17.0.14_x64: /__t/jdk/17.0.14/x64
    JAVA_HOME: /__t/jdk/17.0.14/x64
    JAVA_HOME_17_0_14_X64: /__t/jdk/17.0.14/x64
/usr/bin/docker exec  c0d55acae0991e6b[2](https://github.com/opensearch-project/query-insights/actions/runs/12941332812/job/36097209054#step:10:2)c1058b7b22b7e16661fdfab119b0ed99f5ad7ca118eee4a sh -c "cat /etc/*release | grep ^ID"
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: ([4](https://github.com/opensearch-project/query-insights/actions/runs/12941332812/job/36097209054#step:10:4)09) Conflict: an artifact with this name already exists on the workflow run
```

Ref: https://github.com/opensearch-project/security-analytics/blob/dca74ce58b638de442f49b06cce78a113c55bc2b/.github/workflows/ci.yml#L67-L72

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
