### PR TITLE
Add default index template for query insights local index

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -148,6 +148,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
             QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER,
             QueryInsightsSettings.TOP_N_EXPORTER_TYPE,
+            QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY,
             QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
         );
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -64,8 +64,8 @@ public class LocalIndexExporter implements QueryInsightsExporter {
     private DateTimeFormatter indexPattern;
     private int deleteAfter;
     private final String id;
-    private static final int DEFAULT_NUMBER_OF_REPLICA = 0;
     private static final int DEFAULT_NUMBER_OF_SHARDS = 1;
+    private static final String DEFAULT_AUTO_EXPAND_REPLICAS = "0-2";
     private static final String TEMPLATE_NAME = "query_insights_top_queries_template";
     private long templatePriority;
 
@@ -179,7 +179,7 @@ public class LocalIndexExporter implements QueryInsightsExporter {
         createIndexRequest.settings(
             Settings.builder()
                 .put("index.number_of_shards", DEFAULT_NUMBER_OF_SHARDS)
-                .put("index.number_of_replicas", DEFAULT_NUMBER_OF_REPLICA)
+                .put("index.auto_expand_replicas", DEFAULT_AUTO_EXPAND_REPLICAS)
         );
         createIndexRequest.mapping(readIndexMappings());
 
@@ -378,7 +378,7 @@ public class LocalIndexExporter implements QueryInsightsExporter {
             org.opensearch.cluster.metadata.Template template = new org.opensearch.cluster.metadata.Template(
                 Settings.builder()
                     .put("index.number_of_shards", DEFAULT_NUMBER_OF_SHARDS)
-                    .put("index.number_of_replicas", DEFAULT_NUMBER_OF_REPLICA)
+                    .put("index.auto_expand_replicas", DEFAULT_AUTO_EXPAND_REPLICAS)
                     .build(),
                 compressedMapping,
                 null

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -10,14 +10,18 @@ package org.opensearch.plugin.insights.core.exporter;
 
 import static org.opensearch.plugin.insights.core.utils.ExporterReaderUtils.generateLocalIndexDateHash;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_DELETE_AFTER_VALUE;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TEMPLATE_PRIORITY;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_QUERIES_INDEX_PATTERN_GLOB;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
@@ -25,11 +29,16 @@ import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.template.get.GetComposableIndexTemplateAction;
+import org.opensearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.clustermanager.AcknowledgedResponse;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.ComposableIndexTemplate;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.compress.CompressedXContent;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -57,21 +66,17 @@ public class LocalIndexExporter implements QueryInsightsExporter {
     private final String id;
     private static final int DEFAULT_NUMBER_OF_REPLICA = 0;
     private static final int DEFAULT_NUMBER_OF_SHARDS = 1;
-    private static final List<String> DEFAULT_SORTED_FIELDS = List.of(
-        "measurements.latency.number",
-        "measurements.cpu.number",
-        "measurements.memory.number"
-    );
-    private static final List<String> DEFAULT_SORTED_ORDERS = List.of("desc", "desc", "desc");
+    private static final String TEMPLATE_NAME = "query_insights_top_queries_template";
+    private long templatePriority;
 
     /**
-     * Constructor of LocalIndexExporter
+     * Constructor
      *
-     * @param client OS client
+     * @param client         client instance
      * @param clusterService cluster service
-     * @param indexPattern the pattern of index to export to
-     * @param indexMapping the index mapping file
-     * @param id id of the exporter
+     * @param indexPattern   index pattern
+     * @param indexMapping   index mapping
+     * @param id             exporter id
      */
     public LocalIndexExporter(
         final Client client,
@@ -80,17 +85,18 @@ public class LocalIndexExporter implements QueryInsightsExporter {
         final String indexMapping,
         final String id
     ) {
-        this.indexPattern = indexPattern;
         this.client = client;
         this.clusterService = clusterService;
+        this.indexPattern = indexPattern;
         this.indexMapping = indexMapping;
-        this.deleteAfter = DEFAULT_DELETE_AFTER_VALUE;
         this.id = id;
+        this.deleteAfter = DEFAULT_DELETE_AFTER_VALUE;
+        this.templatePriority = DEFAULT_TEMPLATE_PRIORITY;
     }
 
     /**
      * Retrieves the identifier for the local index exporter.
-     *
+     * <p>
      * Each service can either have its own dedicated local index exporter or share
      * an existing one. This identifier is used by the QueryInsightsExporterFactory
      * to locate and manage the appropriate exporter instance.
@@ -134,56 +140,81 @@ public class LocalIndexExporter implements QueryInsightsExporter {
         try {
             final String indexName = buildLocalIndexName();
             if (!checkIndexExists(indexName)) {
-                CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
-
-                createIndexRequest.settings(
-                    Settings.builder()
-                        .putList("index.sort.field", DEFAULT_SORTED_FIELDS)
-                        .putList("index.sort.order", DEFAULT_SORTED_ORDERS)
-                        .put("index.number_of_shards", DEFAULT_NUMBER_OF_SHARDS)
-                        .put("index.number_of_replicas", DEFAULT_NUMBER_OF_REPLICA)
-                );
-                createIndexRequest.mapping(readIndexMappings());
-
-                client.admin().indices().create(createIndexRequest, new ActionListener<>() {
-                    @Override
-                    public void onResponse(CreateIndexResponse createIndexResponse) {
-                        if (createIndexResponse.isAcknowledged()) {
-                            try {
-                                bulk(indexName, records);
-                            } catch (IOException e) {
-                                OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
-                                logger.error("Unable to index query insights data: ", e);
-                            }
-                        }
+                // First ensure the template exists, then create the index
+                ensureTemplateExists().whenComplete((templateCreated, templateException) -> {
+                    if (templateException != null) {
+                        logger.error("Error ensuring template exists:", templateException);
+                        OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
                     }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        Throwable cause = ExceptionsHelper.unwrapCause(e);
-                        if (cause instanceof ResourceAlreadyExistsException) {
-                            try {
-                                bulk(indexName, records);
-                            } catch (IOException ex) {
-                                OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
-                                logger.error("Unable to index query insights data: ", e);
-                            }
-                        } else {
-                            OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
-                            logger.error("Unable to create query insights index: ", e);
-                        }
+                    // Proceed with index creation even if there was a template error
+                    // The template might already exist or might be created by another node
+                    try {
+                        createIndexAndBulk(indexName, records);
+                    } catch (IOException ioe) {
+                        logger.error("Error creating index:", ioe);
+                        OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
                     }
                 });
             } else {
+                // Index already exists, proceed with bulk export
                 bulk(indexName, records);
             }
-        } catch (final Exception e) {
+        } catch (IOException e) {
+            logger.error("Unable to export query insights data:", e);
             OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
-            logger.error("Unable to index query insights data: ", e);
         }
     }
 
-    private void bulk(final String indexName, final List<SearchQueryRecord> records) throws IOException {
+    /**
+     * Creates an index with the specified name and exports records to it
+     *
+     * @param indexName Name of the index to create
+     * @param records Records to export
+     * @throws IOException If there's an error reading mappings
+     */
+    void createIndexAndBulk(String indexName, List<SearchQueryRecord> records) throws IOException {
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
+
+        createIndexRequest.settings(
+            Settings.builder()
+                .put("index.number_of_shards", DEFAULT_NUMBER_OF_SHARDS)
+                .put("index.number_of_replicas", DEFAULT_NUMBER_OF_REPLICA)
+        );
+        createIndexRequest.mapping(readIndexMappings());
+
+        client.admin().indices().create(createIndexRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(CreateIndexResponse createIndexResponse) {
+                if (createIndexResponse.isAcknowledged()) {
+                    try {
+                        bulk(indexName, records);
+                    } catch (IOException e) {
+                        OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
+                        logger.error("Unable to index query insights data: ", e);
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Throwable cause = ExceptionsHelper.unwrapCause(e);
+                if (cause instanceof ResourceAlreadyExistsException) {
+                    try {
+                        bulk(indexName, records);
+                    } catch (IOException ioe) {
+                        OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
+                        logger.error("Unable to index query insights data: ", ioe);
+                    }
+                } else {
+                    OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
+                    logger.error("Unable to create query insights index: ", cause);
+                }
+            }
+        });
+    }
+
+    void bulk(final String indexName, final List<SearchQueryRecord> records) throws IOException {
         final BulkRequestBuilder bulkRequestBuilder = client.prepareBulk().setTimeout(TimeValue.timeValueMinutes(1));
         for (SearchQueryRecord record : records) {
             bulkRequestBuilder.add(
@@ -243,13 +274,13 @@ public class LocalIndexExporter implements QueryInsightsExporter {
      * Deletes the specified index and logs any failure that occurs during the operation.
      *
      * @param indexName The name of the index to delete.
-     * @param client The OpenSearch client used to perform the deletion.
+     * @param client    The OpenSearch client used to perform the deletion.
      */
     public void deleteSingleIndex(String indexName, Client client) {
         Logger logger = LogManager.getLogger();
         client.admin().indices().delete(new DeleteIndexRequest(indexName), new ActionListener<>() {
             @Override
-            public void onResponse(org.opensearch.action.support.clustermanager.AcknowledgedResponse acknowledgedResponse) {}
+            public void onResponse(AcknowledgedResponse acknowledgedResponse) {}
 
             @Override
             public void onFailure(Exception e) {
@@ -264,24 +295,152 @@ public class LocalIndexExporter implements QueryInsightsExporter {
     }
 
     /**
-     * check if index exists
-     * @return boolean
+     * Check if an index exists
+     *
+     * @param indexName Name of the index to check
+     * @return true if the index exists, false otherwise
      */
-    private boolean checkIndexExists(String indexName) {
+    boolean checkIndexExists(String indexName) {
         ClusterState clusterState = clusterService.state();
         return clusterState.getRoutingTable().hasIndex(indexName);
     }
 
     /**
-     * get correlation rule index mappings
-     * @return mappings of correlation rule index
-     * @throws IOException IOException
+     * Read index mappings from the provided mapping string or from the default resource file
+     *
+     * @return String containing the index mappings
+     * @throws IOException If there's an error reading the mappings
      */
-    private String readIndexMappings() throws IOException {
-        return new String(
-            Objects.requireNonNull(LocalIndexExporter.class.getClassLoader().getResourceAsStream(indexMapping)).readAllBytes(),
-            Charset.defaultCharset()
-        );
+    String readIndexMappings() throws IOException {
+        if (indexMapping == null || indexMapping.isEmpty()) {
+            return "{}";
+        }
+
+        // Check if this is a resource path or direct content
+        if (indexMapping.endsWith(".json")) {
+            return new String(
+                Objects.requireNonNull(LocalIndexExporter.class.getClassLoader().getResourceAsStream(indexMapping)).readAllBytes(),
+                Charset.defaultCharset()
+            );
+        }
+
+        return indexMapping;
+    }
+
+    /**
+     * Ensures that the template exists. This method first checks if the template exists and
+     * only creates it if it doesn't.
+     *
+     * @return CompletableFuture that completes when the template check/creation is done
+     */
+    CompletableFuture<Boolean> ensureTemplateExists() {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        // First check if the template already exists
+        GetComposableIndexTemplateAction.Request getRequest = new GetComposableIndexTemplateAction.Request();
+
+        client.execute(GetComposableIndexTemplateAction.INSTANCE, getRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetComposableIndexTemplateAction.Response response) {
+                // If the template exists and priority has not been changed, we don't need to create/update it
+                if (response.indexTemplates().containsKey(TEMPLATE_NAME)
+                    && response.indexTemplates().get(TEMPLATE_NAME).priority() == templatePriority) {
+                    logger.debug("Template [{}] already exists, skipping creation", TEMPLATE_NAME);
+                    future.complete(true);
+                    return;
+                }
+
+                // Template doesn't exist, create it
+                createTemplate(future);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                // If we can't retrieve the template info, try creating it anyway
+                logger.warn("Failed to check if template [{}] exists: {}", TEMPLATE_NAME, e.getMessage());
+                createTemplate(future);
+            }
+        });
+
+        return future;
+    }
+
+    /**
+     * Helper method to create the template
+     *
+     * @param future The CompletableFuture to complete when done
+     */
+    void createTemplate(CompletableFuture<Boolean> future) {
+        try {
+            // Create a V2 template (ComposableIndexTemplate)
+            CompressedXContent compressedMapping = new CompressedXContent(readIndexMappings());
+
+            // Create template component
+            org.opensearch.cluster.metadata.Template template = new org.opensearch.cluster.metadata.Template(
+                Settings.builder()
+                    .put("index.number_of_shards", DEFAULT_NUMBER_OF_SHARDS)
+                    .put("index.number_of_replicas", DEFAULT_NUMBER_OF_REPLICA)
+                    .build(),
+                compressedMapping,
+                null
+            );
+
+            // Create the composable template
+            ComposableIndexTemplate composableTemplate = new ComposableIndexTemplate(
+                Collections.singletonList(TOP_QUERIES_INDEX_PATTERN_GLOB),
+                template,
+                null,
+                templatePriority, // Priority using configured value
+                null,
+                null
+            );
+
+            // Use the V2 API to put the template
+            PutComposableIndexTemplateAction.Request request = new PutComposableIndexTemplateAction.Request(TEMPLATE_NAME).indexTemplate(
+                composableTemplate
+            );
+
+            client.execute(PutComposableIndexTemplateAction.INSTANCE, request, new ActionListener<>() {
+                @Override
+                public void onResponse(AcknowledgedResponse response) {
+                    if (response.isAcknowledged()) {
+                        logger.info("Successfully created or updated template [{}] with priority {}", TEMPLATE_NAME, templatePriority);
+                        future.complete(true);
+                    } else {
+                        logger.warn("Failed to create or update template [{}]", TEMPLATE_NAME);
+                        future.complete(false);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    logger.error("Error creating or updating template [{}]", TEMPLATE_NAME, e);
+                    OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
+                    future.completeExceptionally(e);
+                }
+            });
+        } catch (Exception e) {
+            logger.error("Failed to manage template", e);
+            OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_EXPORTER_EXCEPTIONS);
+            future.completeExceptionally(e);
+        }
+    }
+
+    /**
+     * Set the template priority for the exporter
+     *
+     * @param templatePriority New template priority value
+     */
+    public void setTemplatePriority(final long templatePriority) {
+        this.templatePriority = templatePriority;
+    }
+
+    /**
+     * Get the current template priority
+     *
+     * @return Current template priority value
+     */
+    public long getTemplatePriority() {
+        return templatePriority;
     }
 
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.plugin.insights.core.exporter;
 
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TEMPLATE_PRIORITY;
+
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -74,9 +76,10 @@ public class QueryInsightsExporterFactory {
      * @param id id of the exporter so that exporters can be retrieved and reused across services
      * @param indexPattern the index pattern if creating an index exporter
      * @param indexMapping index mapping file
+     * @param templatePriority the priority value for the template
      * @return LocalIndexExporter the created exporter sink
      */
-    public LocalIndexExporter createLocalIndexExporter(String id, String indexPattern, String indexMapping) {
+    public LocalIndexExporter createLocalIndexExporter(String id, String indexPattern, String indexMapping, long templatePriority) {
         LocalIndexExporter exporter = new LocalIndexExporter(
             client,
             clusterService,
@@ -84,8 +87,21 @@ public class QueryInsightsExporterFactory {
             indexMapping,
             id
         );
+        exporter.setTemplatePriority(templatePriority);
         this.exporters.put(id, exporter);
         return exporter;
+    }
+
+    /**
+     * Create a local index exporter based on provided parameters, using default template priority
+     *
+     * @param id id of the exporter so that exporters can be retrieved and reused across services
+     * @param indexPattern the index pattern if creating an index exporter
+     * @param indexMapping index mapping file
+     * @return LocalIndexExporter the created exporter sink
+     */
+    public LocalIndexExporter createLocalIndexExporter(String id, String indexPattern, String indexMapping) {
+        return createLocalIndexExporter(id, indexPattern, indexMapping, DEFAULT_TEMPLATE_PRIORITY);
     }
 
     /**
@@ -105,11 +121,14 @@ public class QueryInsightsExporterFactory {
      *
      * @param exporter The exporter to update
      * @param indexPattern the index pattern if creating a index exporter
+     * @param templatePriority the priority value for the template (for LocalIndexExporter)
      * @return QueryInsightsExporter the updated exporter sink
      */
-    public QueryInsightsExporter updateExporter(QueryInsightsExporter exporter, String indexPattern) {
+    public QueryInsightsExporter updateExporter(QueryInsightsExporter exporter, String indexPattern, long templatePriority) {
         if (exporter.getClass() == LocalIndexExporter.class) {
-            ((LocalIndexExporter) exporter).setIndexPattern(DateTimeFormatter.ofPattern(indexPattern, Locale.ROOT));
+            LocalIndexExporter localExporter = (LocalIndexExporter) exporter;
+            localExporter.setIndexPattern(DateTimeFormatter.ofPattern(indexPattern, Locale.ROOT));
+            localExporter.setTemplatePriority(templatePriority);
         }
         return exporter;
     }

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -231,6 +231,10 @@ public class QueryInsightsSettings {
      */
     public static final String DEFAULT_TOP_QUERIES_EXPORTER_TYPE = SinkType.LOCAL_INDEX.toString();
     /**
+     * Default template priority for top queries indices
+     */
+    public static final long DEFAULT_TEMPLATE_PRIORITY = 1847L;
+    /**
      * Default Top N local indices retention period in days
      */
     public static final int DEFAULT_DELETE_AFTER_VALUE = 7;
@@ -270,6 +274,17 @@ public class QueryInsightsSettings {
      * Index pattern glob for matching top query indices
      */
     public static final String TOP_QUERIES_INDEX_PATTERN_GLOB = "top_queries-*";
+
+    /**
+     * Setting for Top N local indices template priority
+     */
+    public static final Setting<Long> TOP_N_EXPORTER_TEMPLATE_PRIORITY = Setting.longSetting(
+        TOP_N_QUERIES_EXPORTER_PREFIX + ".template_priority",
+        DEFAULT_TEMPLATE_PRIORITY,
+        0L, // min value is 0
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
 
     /**
      * Get the enabled setting based on type

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -81,6 +81,7 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
                 QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
                 QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER,
                 QueryInsightsSettings.TOP_N_EXPORTER_TYPE,
+                QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY,
                 QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
             ),
             queryInsightsPlugin.getSettings()

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -354,6 +354,7 @@ final public class QueryInsightsTestUtils {
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY);
         clusterSettings.registerSetting(QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING);
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
@@ -9,41 +9,54 @@
 package org.opensearch.plugin.insights.core.exporter;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.plugin.insights.core.utils.ExporterReaderUtils.generateLocalIndexDateHash;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TEMPLATE_PRIORITY;
 import static org.opensearch.plugin.insights.core.service.QueryInsightsService.QUERY_INSIGHTS_INDEX_TAG_NAME;
 import static org.opensearch.plugin.insights.core.service.TopQueriesService.TOP_QUERIES_INDEX_TAG_VALUE;
 
+import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
-import org.opensearch.Version;
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
+import org.opensearch.action.admin.indices.template.get.GetComposableIndexTemplateAction;
+import org.opensearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.replication.ClusterStateCreationUtils;
 import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.metadata.IndexMetadata;
-import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.ComposableIndexTemplate;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
+import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.core.utils.ExporterReaderUtils;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.telemetry.metrics.Counter;
+import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.TestThreadPool;
@@ -67,35 +80,36 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
 
     @Before
     public void setup() {
+        // Setup metrics registry and counter
+        MetricsRegistry metricsRegistry = mock(MetricsRegistry.class);
+        when(metricsRegistry.createCounter(any(String.class), any(String.class), any(String.class))).thenAnswer(
+            invocation -> mock(Counter.class)
+        );
+        OperationalMetricsCounter.initialize("test", metricsRegistry);
+
+        // Setup mocks
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+
+        // Setup exists response
+        doAnswer(invocation -> {
+            org.opensearch.core.action.ActionListener<Boolean> listener = invocation.getArgument(1);
+            listener.onResponse(true);
+            return null;
+        }).when(indicesAdminClient).exists(any(IndicesExistsRequest.class), any());
+
+        // Setup cluster service with default values
         indexName = format.format(ZonedDateTime.now(ZoneOffset.UTC))
             + "-"
             + ExporterReaderUtils.generateLocalIndexDateHash(ZonedDateTime.now(ZoneOffset.UTC).toLocalDate());
         Settings.Builder settingsBuilder = Settings.builder();
         Settings settings = settingsBuilder.build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
-        ClusterState state = ClusterStateCreationUtils.stateWithActivePrimary(indexName, true, 1 + randomInt(3), randomInt(2));
+        ClusterState state = ClusterStateCreationUtils.stateWithActivePrimary(indexName, true, 1, 0);
         clusterService = ClusterServiceUtils.createClusterService(threadPool, state.getNodes().getLocalNode(), clusterSettings);
 
-        RoutingTable.Builder routingTable = RoutingTable.builder(state.routingTable());
-        routingTable.addAsRecovery(
-            IndexMetadata.builder(indexName)
-                .settings(
-                    Settings.builder()
-                        .put("index.version.created", Version.CURRENT.id)
-                        .put("index.number_of_shards", 1)
-                        .put("index.number_of_replicas", 1)
-                )
-                .putMapping(
-                    new MappingMetadata("_doc", Map.of("_meta", Map.of(QUERY_INSIGHTS_INDEX_TAG_NAME, TOP_QUERIES_INDEX_TAG_VALUE)))
-                )
-                .build()
-        );
-        ClusterState updatedState = ClusterState.builder(state).routingTable(routingTable.build()).build();
-        ClusterServiceUtils.setState(clusterService, updatedState);
+        // Create local index exporter
         localIndexExporter = new LocalIndexExporter(client, clusterService, format, "", "id");
-
-        when(client.admin()).thenReturn(adminClient);
-        when(adminClient.indices()).thenReturn(indicesAdminClient);
     }
 
     @Override
@@ -114,48 +128,100 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    public void testExportRecordsWhenIndexExists() {
-        BulkRequestBuilder bulkRequestBuilder = spy(new BulkRequestBuilder(client, BulkAction.INSTANCE));
-        final PlainActionFuture<BulkResponse> future = mock(PlainActionFuture.class);
-        when(future.actionGet()).thenReturn(null);
-        doAnswer(invocation -> future).when(bulkRequestBuilder).execute();
-        when(client.prepareBulk()).thenReturn(bulkRequestBuilder);
+    public void testExportRecordsWhenIndexExists() throws IOException {
+        Client mockClient = mock(Client.class);
+        ClusterService mockClusterService = mock(ClusterService.class);
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
+        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "{}", "id");
+        LocalIndexExporter exporterSpy = spy(exporter);
 
-        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(2);
-        try {
-            localIndexExporter.export(records);
-        } catch (Exception e) {
-            fail("No exception should be thrown when exporting query insights data");
-        }
-        assertEquals(2, bulkRequestBuilder.numberOfActions());
+        doReturn(true).when(exporterSpy).checkIndexExists(anyString());
+        // Mock the bulk method to track calls
+        doAnswer(invocation -> null).when(exporterSpy).bulk(anyString(), any());
+
+        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(3);
+
+        exporterSpy.export(records);
+
+        // bulk was called (to add records to existing index)
+        verify(exporterSpy).bulk(anyString(), eq(records));
+
+        // ensureTemplateExists was NOT called
+        verify(exporterSpy, never()).ensureTemplateExists();
+
+        // createIndexAndBulk was NOT called
+        verify(exporterSpy, never()).createIndexAndBulk(anyString(), any());
     }
 
-    public void testExportRecordsWhenIndexNotExist() {
-        RoutingTable.Builder routingTable = RoutingTable.builder();
-        routingTable.addAsRecovery(
-            IndexMetadata.builder("another_index")
-                .settings(
-                    Settings.builder()
-                        .put("index.version.created", Version.CURRENT.id)
-                        .put("index.number_of_shards", 1)
-                        .put("index.number_of_replicas", 1)
-                )
-                .putMapping(
-                    new MappingMetadata("_doc", Map.of("_meta", Map.of(QUERY_INSIGHTS_INDEX_TAG_NAME, TOP_QUERIES_INDEX_TAG_VALUE)))
-                )
-                .build()
-        );
-        ClusterState updatedState = ClusterState.builder(clusterService.state()).routingTable(routingTable.build()).build();
-        ClusterServiceUtils.setState(clusterService, updatedState);
+    public void testExportRecordsWhenIndexNotExist() throws IOException {
+        Client mockClient = mock(Client.class);
+        ClusterService mockClusterService = mock(ClusterService.class);
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
+        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "{}", "id");
+        LocalIndexExporter exporterSpy = spy(exporter);
 
-        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(2);
-        try {
-            localIndexExporter.export(records);
-        } catch (Exception e) {
-            fail("No exception should be thrown when exporting query insights data");
-        }
-        verify(indicesAdminClient, times(1)).create(any(), any());
+        // to simulate index doesn't exist
+        doReturn(false).when(exporterSpy).checkIndexExists(anyString());
+        CompletableFuture<Boolean> completedFuture = CompletableFuture.completedFuture(true);
+        doReturn(completedFuture).when(exporterSpy).ensureTemplateExists();
+        doAnswer(invocation -> null).when(exporterSpy).createIndexAndBulk(anyString(), any());
+        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(3);
+
+        exporterSpy.export(records);
+
+        // ensureTemplateExists was called (since index doesn't exist)
+        verify(exporterSpy).ensureTemplateExists();
+        // createIndexAndBulk was called
+        verify(exporterSpy).createIndexAndBulk(anyString(), eq(records));
+        // bulk was NOT called directly (it's called inside createIndexAndBulk)
+        verify(exporterSpy, never()).bulk(anyString(), any());
+    }
+
+    public void testExportWaitsForTemplateCreation() throws Exception {
+        Client mockClient = mock(Client.class);
+        ClusterService mockClusterService = mock(ClusterService.class);
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
+        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "{}", "id");
+        LocalIndexExporter exporterSpy = spy(exporter);
+
+        // simulate index doesn't exist
+        doReturn(false).when(exporterSpy).checkIndexExists(anyString());
+        CompletableFuture<Boolean> templateFuture = new CompletableFuture<>();
+        doReturn(templateFuture).when(exporterSpy).ensureTemplateExists();
+
+        // Use a CountDownLatch to track if createIndexAndBulk is called
+        CountDownLatch createIndexCalled = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            createIndexCalled.countDown();
+            return null;
+        }).when(exporterSpy).createIndexAndBulk(anyString(), any());
+
+        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(3);
+
+        // call export in a separate thread so it doesn't block our test..
+        Thread exportThread = new Thread(() -> {
+            try {
+                exporterSpy.export(records);
+            } catch (Exception e) {
+                fail("Export should not throw an exception: " + e.getMessage());
+            }
+        });
+        exportThread.start();
+        Thread.sleep(100);
+        // createIndexAndBulk has NOT been called yet - it should be waiting for template..
+        assertEquals("createIndexAndBulk should not be called until template is created", 1, createIndexCalled.getCount());
+
+        // Complete the template future
+        templateFuture.complete(true);
+
+        // Wait for createIndexAndBulk to be called
+        boolean createIndexWasCalled = createIndexCalled.await(1, TimeUnit.SECONDS);
+
+        // Verify createIndexAndBulk was eventually called after template was created
+        assertTrue("createIndexAndBulk should be called after template is created", createIndexWasCalled);
+
+        // Clean up the thread
+        exportThread.join(1000);
     }
 
     @SuppressWarnings("unchecked")
@@ -186,5 +252,126 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
         final DateTimeFormatter newFormatter = DateTimeFormatter.ofPattern("YYYY-MM-dd", Locale.ROOT);
         localIndexExporter.setIndexPattern(newFormatter);
         assert (localIndexExporter.getIndexPattern() == newFormatter);
+    }
+
+    public void testGetAndSetTemplatePriority() {
+        final long newTemplatePriority = 2000L;
+        localIndexExporter.setTemplatePriority(newTemplatePriority);
+        assertEquals(newTemplatePriority, localIndexExporter.getTemplatePriority());
+    }
+
+    /**
+     * Test that ensureTemplateExists creates a V2 template correctly when it doesn't exist
+     */
+    public void testEnsureTemplateExistsCreatesV2Template() throws Exception {
+        Client mockClient = mock(Client.class);
+        ClusterService mockClusterService = mock(ClusterService.class);
+
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
+        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "{}", "id");
+        LocalIndexExporter exporterSpy = spy(exporter);
+
+        // Set a custom priority to verify it's used in the template
+        exporterSpy.setTemplatePriority(5000L);
+
+        // make ensureTemplateExists to complete successfully
+        CompletableFuture<Boolean> completedFuture = CompletableFuture.completedFuture(true);
+        doReturn(completedFuture).when(exporterSpy).ensureTemplateExists();
+
+        CompletableFuture<Boolean> future = exporterSpy.ensureTemplateExists();
+        assertTrue(future.get(5, TimeUnit.SECONDS));
+
+        assertEquals("Template priority should be set correctly", 5000L, exporterSpy.getTemplatePriority());
+    }
+
+    /**
+     * Test that ensureTemplateExists skips creating a template when it already exists
+     */
+    public void testEnsureTemplateExistsSkipsWhenTemplateExists() throws Exception {
+        Client mockClient = mock(Client.class);
+
+        ClusterService mockClusterService = mock(ClusterService.class);
+        ClusterState mockState = mock(ClusterState.class);
+        org.opensearch.cluster.metadata.Metadata metadata = mock(org.opensearch.cluster.metadata.Metadata.class);
+        when(metadata.templates()).thenReturn(Map.of());
+        when(metadata.templatesV2()).thenReturn(Map.of());
+        when(mockState.getMetadata()).thenReturn(metadata);
+        when(mockClusterService.state()).thenReturn(mockState);
+
+        // Mock the GetComposableIndexTemplateAction call to return that the template exists
+        doAnswer(invocation -> {
+            GetComposableIndexTemplateAction.Response mockResponse = mock(GetComposableIndexTemplateAction.Response.class);
+            ComposableIndexTemplate mockTemplate = mock(ComposableIndexTemplate.class);
+            when(mockTemplate.priority()).thenReturn(DEFAULT_TEMPLATE_PRIORITY);
+            when(mockResponse.indexTemplates()).thenReturn(Map.of("query_insights_top_queries_template", mockTemplate));
+
+            ActionListener listener = invocation.getArgument(2);
+            listener.onResponse(mockResponse);
+
+            return null;
+        }).when(mockClient)
+            .execute(
+                eq(GetComposableIndexTemplateAction.INSTANCE),
+                any(GetComposableIndexTemplateAction.Request.class),
+                any(ActionListener.class)
+            );
+
+        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "{}", "id");
+
+        CompletableFuture<Boolean> future = exporter.ensureTemplateExists();
+        Boolean result = future.get(5, TimeUnit.SECONDS);
+
+        assertTrue("Template check should be successful", result);
+
+        verify(mockClient).execute(
+            eq(GetComposableIndexTemplateAction.INSTANCE),
+            any(GetComposableIndexTemplateAction.Request.class),
+            any(org.opensearch.core.action.ActionListener.class)
+        );
+        verify(mockClient, never()).execute(
+            eq(PutComposableIndexTemplateAction.INSTANCE),
+            any(PutComposableIndexTemplateAction.Request.class),
+            any(org.opensearch.core.action.ActionListener.class)
+        );
+    }
+
+    /**
+     * Test that checkIndexExists returns true when the index exists
+     */
+    public void testCheckIndexExists() {
+        RoutingTable mockRoutingTable = mock(RoutingTable.class);
+        when(mockRoutingTable.hasIndex("test-index")).thenReturn(true);
+
+        ClusterState mockState = mock(ClusterState.class);
+        when(mockState.getRoutingTable()).thenReturn(mockRoutingTable);
+        ClusterService mockClusterService = mock(ClusterService.class);
+        when(mockClusterService.state()).thenReturn(mockState);
+
+        // Create a LocalIndexExporter with our mock components
+        LocalIndexExporter exporter = new LocalIndexExporter(client, mockClusterService, format, "{}", "id");
+
+        // checkIndexExists returns true for the test index
+        assertTrue(exporter.checkIndexExists("test-index"));
+
+        // checkIndexExists returns false for a non-existent index
+        when(mockRoutingTable.hasIndex("non-existent-index")).thenReturn(false);
+        assertFalse(exporter.checkIndexExists("non-existent-index"));
+    }
+
+    /**
+     * Test that readIndexMappings returns the provided mapping string when it's not empty
+     */
+    public void testReadIndexMappingsWithProvidedMapping() throws IOException {
+        String customMapping = "{\"properties\":{\"test\":{\"type\":\"keyword\"}}}";
+        LocalIndexExporter exporter = new LocalIndexExporter(client, clusterService, format, customMapping, "id");
+        assertEquals(customMapping, exporter.readIndexMappings());
+    }
+
+    /**
+     * Test that readIndexMappings returns empty JSON object when mapping string is empty
+     */
+    public void testReadIndexMappingsWithEmptyMapping() throws IOException {
+        LocalIndexExporter exporter = new LocalIndexExporter(client, clusterService, format, "", "id");
+        assertEquals("{}", exporter.readIndexMappings());
     }
 }


### PR DESCRIPTION
### Description
- Add default index template for query insights local index
- Add configuration endpoint to modify the priority - Ideally we should be increasing the priority automatically. We need to do this as a follow up.

### Issues Resolved
 Closes https://github.com/opensearch-project/query-insights/issues/248, https://github.com/opensearch-project/query-insights/issues/256

### Test basic correctness
1. Create document
```
curl -X POST "localhost:9200/my-index-0/_doc/?pretty" -H 'Content-Type: application/json' -d'
{
  "@timestamp": "2099-11-15T13:12:00",
  "message": "this is document 0",
  "user": {
    "id": "cyji",
    "age": 1
  }
}'
```
2. Create an index template on `*` with priority 100
```
curl -X PUT "localhost:9200/_index_template/user_age_sorting_template" -H 'Content-Type: application/json' -d'
{
  "index_patterns": ["*"],
  "priority": 100,
  "template": {
    "settings": {
      "index.sort.field": "user.age",
      "index.sort.order": "asc"
    },
    "mappings": {
      "properties": {
        "@timestamp": {
          "type": "date"
        },
        "message": {
          "type": "text"
        },
        "user": {
          "properties": {
            "id": {
              "type": "keyword"
            },
            "age": {
              "type": "integer",
              "doc_values": true
            }
          }
        }
      }
    }
  }
}'
```
3. Do search
```
curl -X GET "localhost:9200/my-index-0/_search?size=20&pretty" -H 'Content-Type: application/json' -d'
{
  "query": {
    "term": {
      "user.id": "cyji"
    }
  }
}'
```

4. Check top queries indices are created correctly and is green
```
curl -X GET "localhost:9200/_cat/indices"
green open my-index-0                   XJQRJ31DQVeZFnwPQB5TEA 1 0 1 0 5.2kb 5.2kb
green open top_queries-2025.03.10-21661 e-2IfzPCQYSChb_Q-Cjt-w 1 0 2 4  208b  208b
```
5. Check data is valid
```
curl -X GET "localhost:9200/top_queries-2025.03.10-21661/_search?size=200&pretty"
{
  "took" : 5,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 2,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "top_queries-2025.03.10-21661",
        "_id" : "e6332aae-f890-457b-9c61-1941fda6a8d5",
        "_score" : 1.0,
        "_source" : {
          "timestamp" : 1741641093569,
          "id" : "e6332aae-f890-457b-9c61-1941fda6a8d5",
          "indices" : [
            "my-index-0"
          ],
          "labels" : { },
          "group_by" : "NONE",
          "source" : {
            "size" : 20,
            "query" : {
              "term" : {
                "user.id" : {
                  "value" : "cyji",
                  "boost" : 1.0
                }
              }
            }
          },
          "node_id" : "PldZjWcvQ3a3h7StDlHlGA",
          "phase_latency_map" : {
            "expand" : 0,
            "query" : 2,
            "fetch" : 0
          },
          "search_type" : "query_then_fetch",
          "total_shards" : 1,
          "task_resource_usages" : [
            {
              "action" : "indices:data/read/search[phase/query]",
              "taskId" : 40,
              "parentTaskId" : 39,
              "nodeId" : "PldZjWcvQ3a3h7StDlHlGA",
              "taskResourceUsage" : {
                "cpu_time_in_nanos" : 952000,
                "memory_in_bytes" : 32296
              }
            },
...
```

### Test overriding index template priority 
1. Create document
```
curl -X POST "localhost:9200/my-index-0/_doc/?pretty" -H 'Content-Type: application/json' -d'
{
  "@timestamp": "2099-11-15T13:12:00",
  "message": "this is document 0",
  "user": {
    "id": "cyji",
    "age": 1
  }
}'
```
2. Create an index template on `*` with high priority (2000)
```
curl -X PUT "http://localhost:9200/_index_template/my_template?pretty" -H 'Content-Type: application/json' -d'
{
  "index_patterns": ["*"],
  "template": {
    "settings": {
      "number_of_shards": 1,
      "number_of_replicas": 1,
      "index.blocks.write": true
    },
    "mappings": {
      "properties": {
        "group_by": {
          "type": "keyword"
        }
      }
    },
    "aliases": {
      "my_alias": {}
    }
  },
  "priority" : 2000
}'
```
3. Increase the template priority for our indicees.
```
curl -X PUT 'localhost:9200/_cluster/settings' -H 'Content-Type: application/json' -d'
{
    "persistent" : {
        "search.insights.top_queries.exporter.template_priority" : "3000"
    }
}'
```
4. Do search
```
curl -X GET "localhost:9200/my-index-0/_search?size=20&pretty" -H 'Content-Type: application/json' -d'
{
  "query": {
    "term": {
      "user.id": "cyji"
    }
  }
}'
```

5. Check top queries indices are created correctly and are all green
```
curl -X GET "localhost:9200/_cat/indices"
green open my-index-0                   fnYdjtYJTNuZ9cOoId04Eg 1 0 1 0  5.2kb  5.2kb
green open top_queries-2025.03.10-21661 EryS1-YlSGyJR8krjFcV_w 1 0 2 4 48.4kb 48.4kb
```
6. Check data is valid
```
 curl -X GET "localhost:9200/top_queries-2025.03.10-21661/_search?size=200&pretty"
{
  "took" : 46,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 2,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "top_queries-2025.03.10-21661",
        "_id" : "fe5f9c96-0954-4f8a-b965-067282d32b51",
        "_score" : 1.0,
        "_source" : {
          "timestamp" : 1741641197212,
          "id" : "fe5f9c96-0954-4f8a-b965-067282d32b51",
          "group_by" : "NONE",
          "search_type" : "query_then_fetch",
          "labels" : { },
          "phase_latency_map" : {
            "expand" : 0,
            "query" : 2,
            "fetch" : 0
          },
          "source" : {
            "size" : 20,
            "query" : {
              "term" : {
                "user.id" : {
                  "value" : "cyji",
                  "boost" : 1.0
                }
              }
            }
          },
          "total_shards" : 1,
          "task_resource_usages" : [
            {
              "action" : "indices:data/read/search[phase/query]",
              "taskId" : 31,
              "parentTaskId" : 30,
              "nodeId" : "8APMOZ-0TuOCpBgz4mIppg",
              "taskResourceUsage" : {
                "cpu_time_in_nanos" : 829000,
                "memory_in_bytes" : 32296
              }
            },
...
```
7. Check index template is correct with required fields and settings
```
curl -X GET "localhost:9200/_index_template?pretty"
...
"index_templates" : [
    {
      "name" : "query_insights_top_queries_template",
      "index_template" : {
        "index_patterns" : [
          "top_queries-*"
        ],
        "template" : {
          "settings" : {
            "index" : {
              "number_of_shards" : "1",
              "auto_expand_replicas" : "0-2"
            }
          },
          "mappings" : {
            "_meta" : {
              "schema_version" : 1,
              "query_insights_feature_space" : "top_n_queries"
            },
            "dynamic" : true,
            "properties" : {
              "total_shards" : {
                "type" : "long"
              },
              "phase_latency_map" : {
...
},
        "composed_of" : [ ],
        "priority" : 3000
...
```

### Test auto expand index
- Run the cluster with 2 nodes
- Repeat the above test steps to create document, do search
- Check indices, noticing the replica count is 1
```
curl -X GET "localhost:9200/_cat/indices"
green open my-index-0                   Ej0gAr2GSp-FB73WOfWRxA 1 0 1 0  5.2kb  5.2kb
green open top_queries-2025.03.10-21661 xFzOnQ2NTwKUOXwnLrLxPg 1 1 1 2 65.3kb 46.6kb
```
- Rerun the cluster with 3 nodes and repeat the above test steps to create document, do search.
- Check indices, noticing the replica count is 2
```
curl -X GET "localhost:9200/_cat/indices"
green open my-index-0                   2tygdbLdTUKBiTvBP1qFPw 1 1 1 0  10.6kb  5.2kb
green open top_queries-2025.03.10-21661 6-DSqdwKSNqk63bidGVB4A 1 2 2 4 148.8kb 49.8kb
```
- Rerun the cluster with 4 or more nodes and repeat the above test steps to create document, do search.
- Check indices, noticing the replica count is also 2
```
curl -X GET "localhost:9200/_cat/indices"
green open my-index-0                   6iHP0K1WSW2SAnHPR2WF1Q 1 1 1 0 10.6kb  5.2kb
green open top_queries-2025.03.10-21661 H7EdJoemQ8C5qaQxzDxPOg 1 2 1 2 67.6kb 24.4kb
```
- Check index template is expected with required fields and settings
```
curl -X GET "localhost:9200/_index_template?pretty"
...
{
      "name" : "query_insights_top_queries_template",
      "index_template" : {
        "index_patterns" : [
          "top_queries-*"
        ],
        "template" : {
          "settings" : {
            "index" : {
              "number_of_shards" : "1",
              "auto_expand_replicas" : "0-2"
            }
          },
          "mappings" : {
            "_meta" : {
              "schema_version" : 1,
              "query_insights_feature_space" : "top_n_queries"
            },
            "dynamic" : true,
            "properties" : {
              "total_shards" : {
                "type" : "long"
              },
              "phase_latency_map" : {
                "properties" : {
                  "expand" : {
...
},
        "composed_of" : [ ],
        "priority" : 1847
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
