### PR TITLE
Change local index replica count to 0

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -55,7 +55,7 @@ public class LocalIndexExporter implements QueryInsightsExporter {
     private DateTimeFormatter indexPattern;
     private int deleteAfter;
     private final String id;
-    private static final int DEFAULT_NUMBER_OF_REPLICA = 1;
+    private static final int DEFAULT_NUMBER_OF_REPLICA = 0;
     private static final int DEFAULT_NUMBER_OF_SHARDS = 1;
     private static final List<String> DEFAULT_SORTED_FIELDS = List.of(
         "measurements.latency.number",


### PR DESCRIPTION
### Description
Change local index replica count to 0 so that `top-queries-*` indices are not yellow on single-node domains.

### Testing
```
% curl -X GET "localhost:9200/_cat/indices?v&s=index"                                                   
health status index                        uuid                   pri rep docs.count docs.deleted store.size pri.store.size
yellow open   my_index                     uqyrGgMtR7mWxe7sjXTSwg   1   1          2            0      6.3kb          6.3kb
green  open   top_queries-2025.03.07-21637 MnAUaYYIRZSySeXbpZHWmw   1   0          3            6     88.7kb         88.7kb
```

### Issues Resolved
Resolves https://github.com/opensearch-project/query-insights/issues/256

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
