### PR TITLE
Use ClusterStateRequest with index pattern when searching for expired local indices

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -267,6 +267,11 @@ public class QueryInsightsSettings {
     );
 
     /**
+     * Index pattern glob for matching top query indices
+     */
+    public static final String TOP_QUERIES_INDEX_PATTERN_GLOB = "top_queries-*";
+
+    /**
      * Get the enabled setting based on type
      * @param type MetricType
      * @return enabled setting

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -33,8 +33,8 @@ import static org.opensearch.plugin.insights.core.utils.ExporterReaderUtils.gene
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -358,10 +358,8 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         // Create 9 top_queries-* indices with creation dates older than the retention period
         Map<String, IndexMetadata> indexMetadataMap = new HashMap<>();
         for (int i = 1; i < 10; i++) {
-            String indexName = "top_queries-2023.01.0"
-                + i
-                + "-"
-                + generateLocalIndexDateHash(ZonedDateTime.now(ZoneOffset.UTC).toLocalDate());
+            LocalDate date = LocalDate.of(2023, 1, i);
+            String indexName = "top_queries-" + date.format(format) + "-" + generateLocalIndexDateHash(date);
             long creationTime = Instant.now().minus(i + 100, ChronoUnit.DAYS).toEpochMilli(); // Ensure indices are expired
             IndexMetadata indexMetadata = IndexMetadata.builder(indexName)
                 .settings(


### PR DESCRIPTION
### Description
Currently we scan a list of all indices on a domain when looking for expired Top N local indices. This causes extra computation on domains with many indices & greater possibility of mistake.

This PR reduces risk by limiting the indices fetched to those that match the `top_queries-*` name pattern. It then applies the existing protocol, which includes a stricter check for the index name (`top_queries-<date>-<5 digits>`), as well as validation of creation time and metadata before any deletions are performed.

### Testing
1. Create a few indices including 1 real Query Insights local index
```
% curl -X GET "localhost:9200/_cat/indices?v&s=index"                                                       
health status index                        uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   logs-1                       LUay8iGnTZSSW3rjMUHiKA   1   0          0            0       208b           208b
green  open   logs-2                       I1y6WAWkSF2mTy8QtX1Pcg   1   0          0            0       208b           208b
yellow open   my_index                     h27P91J7TNCdv1rMhFB6fg   1   1          2            0      6.4kb          6.4kb
green  open   top_queries-2020.01.01-12345 _AaDcAN4TEujGrFMjGLidw   1   0          0            0       208b           208b
green  open   top_queries-2025.03.10-21661 cyi2BDaLS42BlO6lmwpO9Q   1   0          1            2       29kb           29kb
```

2. Update `delete_after_days` setting to trigger expired index scan + deletion
```
% curl -XPUT "http://localhost:9200/_cluster/settings?pretty" -H 'Content-Type: application/json' -d'          
{              
  "persistent" : {        
    "search.insights.top_queries.exporter.delete_after_days" : "5"
  }
} 
'
{
  "acknowledged" : true,
  "persistent" : {
    "search" : {
      "insights" : {
        "top_queries" : {
          "exporter" : {
            "delete_after_days" : "5"
          }
        }
      }
    }
  },
  "transient" : { }
}
```

3. Verified with logging, only indices with name matching `top_queries-*` pattern were considered for deletion
```
[2025-03-10T16:24:45,187][INFO ][o.o.c.s.ClusterSettings  ] [integTest-0] updating [search.insights.top_queries.exporter.delete_after_days] from [7] to [5]
[2025-03-10T16:24:45,188][ERROR][o.o.p.i.c.s.QueryInsightsService] [integTest-0] in deleteExpiredTopNIndices
[2025-03-10T16:24:45,188][ERROR][o.o.p.i.c.s.QueryInsightsService] [integTest-0] top_queries-2020.01.01-12345
[2025-03-10T16:24:45,189][ERROR][o.o.p.i.c.s.QueryInsightsService] [integTest-0] top_queries-2025.03.10-21661
```

### Issues Resolved
Resolves https://github.com/opensearch-project/query-insights/issues/261

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
