### PR TITLE
Add strict hash check on top queries indices

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -45,6 +45,7 @@ import org.opensearch.plugin.insights.core.reader.QueryInsightsReader;
 import org.opensearch.plugin.insights.core.reader.QueryInsightsReaderFactory;
 import org.opensearch.plugin.insights.core.service.grouper.MinMaxHeapQueryGrouper;
 import org.opensearch.plugin.insights.core.service.grouper.QueryGrouper;
+import org.opensearch.plugin.insights.core.utils.ExporterReaderUtils;
 import org.opensearch.plugin.insights.rules.model.AggregationType;
 import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
@@ -545,14 +546,16 @@ public class TopQueriesService {
 
             // Validate the second part is a valid date in "YYYY.MM.dd" format
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT);
+            LocalDate date;
             try {
-                LocalDate.parse(parts[1], formatter);
+                date = LocalDate.parse(parts[1], formatter);
             } catch (DateTimeParseException e) {
                 return false;
             }
 
-            // Validate the third part is exactly 5 digits
-            return parts[2].matches("\\d{5}");
+            // Generate the expected hash for the date and compare with the third part
+            String expectedHash = ExporterReaderUtils.generateLocalIndexDateHash(date);
+            return parts[2].equals(expectedHash);
         } catch (Exception e) {
             return false;
         }

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.opensearch.plugin.insights.core.service.QueryInsightsService.QUERY_INSIGHTS_INDEX_TAG_NAME;
 import static org.opensearch.plugin.insights.core.service.TopQueriesService.TOP_QUERIES_INDEX_TAG_VALUE;
-import static org.opensearch.plugin.insights.core.utils.ExporterReaderUtils.generateLocalIndexDateHash;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -43,6 +42,7 @@ import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
+import org.opensearch.plugin.insights.core.utils.ExporterReaderUtils;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.test.ClusterServiceUtils;
 import org.opensearch.test.OpenSearchTestCase;
@@ -69,7 +69,7 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
     public void setup() {
         indexName = format.format(ZonedDateTime.now(ZoneOffset.UTC))
             + "-"
-            + generateLocalIndexDateHash(ZonedDateTime.now(ZoneOffset.UTC).toLocalDate());
+            + ExporterReaderUtils.generateLocalIndexDateHash(ZonedDateTime.now(ZoneOffset.UTC).toLocalDate());
         Settings.Builder settingsBuilder = Settings.builder();
         Settings settings = settingsBuilder.build();
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -94,7 +94,7 @@ import org.opensearch.transport.client.IndicesAdminClient;
  * Unit Tests for {@link QueryInsightsService}.
  */
 public class QueryInsightsServiceTests extends OpenSearchTestCase {
-    private final DateTimeFormatter format = DateTimeFormatter.ofPattern("YYYY.MM.dd", Locale.ROOT);
+    private final DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT);
     private ThreadPool threadPool;
     private final Client client = mock(Client.class);
     private final NamedXContentRegistry namedXContentRegistry = mock(NamedXContentRegistry.class);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -17,7 +17,10 @@ import static org.opensearch.plugin.insights.core.service.TopQueriesService.TOP_
 import static org.opensearch.plugin.insights.core.service.TopQueriesService.isTopQueriesIndex;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -32,6 +35,7 @@ import org.opensearch.plugin.insights.QueryInsightsTestUtils;
 import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporterFactory;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.core.reader.QueryInsightsReaderFactory;
+import org.opensearch.plugin.insights.core.utils.ExporterReaderUtils;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
@@ -222,18 +226,31 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     }
 
     public void testIsTopQueriesIndexWithValidMetaData() {
-        assertTrue(isTopQueriesIndex("top_queries-2024.01.01-01234", createValidIndexMetadata("top_queries-2024.01.01-01234")));
-        assertTrue(isTopQueriesIndex("top_queries-2025.12.12-99999", createValidIndexMetadata("top_queries-2025.12.12-99999")));
+        // Generate correct hash values for test dates
+        LocalDate date1 = LocalDate.parse("2024.01.01", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        LocalDate date2 = LocalDate.parse("2025.12.12", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        String hash1 = ExporterReaderUtils.generateLocalIndexDateHash(date1);
+        String hash2 = ExporterReaderUtils.generateLocalIndexDateHash(date2);
+        
+        // Test with valid index names and correct hash values
+        assertTrue(isTopQueriesIndex("top_queries-2024.01.01-" + hash1, createValidIndexMetadata("top_queries-2024.01.01-" + hash1)));
+        assertTrue(isTopQueriesIndex("top_queries-2025.12.12-" + hash2, createValidIndexMetadata("top_queries-2025.12.12-" + hash2)));
+        
+        // Test with invalid index names (wrong hash, format issues, etc.)
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01-012345", createValidIndexMetadata("top_queries-2024.01.01-012345")));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01-0123w", createValidIndexMetadata("top_queries-2024.01.01-0123w")));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01", createValidIndexMetadata("top_queries-2024.01.01")));
-        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-01234", createValidIndexMetadata("top_queries-2024.01.32-01234")));
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-" + hash1, createValidIndexMetadata("top_queries-2024.01.32-" + hash1)));
         assertFalse(isTopQueriesIndex("top_queries-01234", createValidIndexMetadata("top_queries-01234")));
-        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-01234", createValidIndexMetadata("top_querie-2024.01.01-01234")));
-        assertFalse(isTopQueriesIndex("2024.01.01-01234", createValidIndexMetadata("2024.01.01-01234")));
+        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-" + hash1, createValidIndexMetadata("top_querie-2024.01.01-" + hash1)));
+        assertFalse(isTopQueriesIndex("2024.01.01-" + hash1, createValidIndexMetadata("2024.01.01-" + hash1)));
         assertFalse(isTopQueriesIndex("any_index", createValidIndexMetadata("any_index")));
         assertFalse(isTopQueriesIndex("", createValidIndexMetadata("")));
         assertFalse(isTopQueriesIndex("_customer_index", createValidIndexMetadata("_customer_index")));
+        
+        // Test with a valid date but incorrect hash
+        String wrongHash = hash1.equals("00000") ? "11111" : "00000";
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-" + wrongHash, createValidIndexMetadata("top_queries-2024.01.01-" + wrongHash)));
     }
 
     private IndexMetadata createIndexMetadataWithEmptyMapping(String indexName) {
@@ -250,17 +267,23 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     }
 
     public void testIsTopQueriesIndexWithEmptyMetaData() {
-        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-01234", createIndexMetadataWithEmptyMapping("top_queries-2024.01.01-01234")));
-        assertFalse(isTopQueriesIndex("top_queries-2025.12.12-99999", createIndexMetadataWithEmptyMapping("top_queries-2025.12.12-99999")));
+        // Generate correct hash values for test dates
+        LocalDate date1 = LocalDate.parse("2024.01.01", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        LocalDate date2 = LocalDate.parse("2025.12.12", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        String hash1 = ExporterReaderUtils.generateLocalIndexDateHash(date1);
+        String hash2 = ExporterReaderUtils.generateLocalIndexDateHash(date2);
+        
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-" + hash1, createIndexMetadataWithEmptyMapping("top_queries-2024.01.01-" + hash1)));
+        assertFalse(isTopQueriesIndex("top_queries-2025.12.12-" + hash2, createIndexMetadataWithEmptyMapping("top_queries-2025.12.12-" + hash2)));
         assertFalse(
             isTopQueriesIndex("top_queries-2024.01.01-012345", createIndexMetadataWithEmptyMapping("top_queries-2024.01.01-012345"))
         );
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01-0123w", createIndexMetadataWithEmptyMapping("top_queries-2024.01.01-0123w")));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01", createIndexMetadataWithEmptyMapping("top_queries-2024.01.01")));
-        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-01234", createIndexMetadataWithEmptyMapping("top_queries-2024.01.32-01234")));
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-" + hash1, createIndexMetadataWithEmptyMapping("top_queries-2024.01.32-" + hash1)));
         assertFalse(isTopQueriesIndex("top_queries-01234", createIndexMetadataWithEmptyMapping("top_queries-01234")));
-        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-01234", createIndexMetadataWithEmptyMapping("top_querie-2024.01.01-01234")));
-        assertFalse(isTopQueriesIndex("2024.01.01-01234", createIndexMetadataWithEmptyMapping("2024.01.01-01234")));
+        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-" + hash1, createIndexMetadataWithEmptyMapping("top_querie-2024.01.01-" + hash1)));
+        assertFalse(isTopQueriesIndex("2024.01.01-" + hash1, createIndexMetadataWithEmptyMapping("2024.01.01-" + hash1)));
         assertFalse(isTopQueriesIndex("any_index", createIndexMetadataWithEmptyMapping("any_index")));
         assertFalse(isTopQueriesIndex("", createIndexMetadataWithEmptyMapping("")));
         assertFalse(isTopQueriesIndex("_customer_index", createIndexMetadataWithEmptyMapping("_customer_index")));
@@ -281,11 +304,17 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     }
 
     public void testIsTopQueriesIndexWithDifferentMetaData() {
+        // Generate correct hash values for test dates
+        LocalDate date1 = LocalDate.parse("2024.01.01", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        LocalDate date2 = LocalDate.parse("2025.12.12", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        String hash1 = ExporterReaderUtils.generateLocalIndexDateHash(date1);
+        String hash2 = ExporterReaderUtils.generateLocalIndexDateHash(date2);
+        
         assertFalse(
-            isTopQueriesIndex("top_queries-2024.01.01-01234", createIndexMetadataWithDifferentValue("top_queries-2024.01.01-01234"))
+            isTopQueriesIndex("top_queries-2024.01.01-" + hash1, createIndexMetadataWithDifferentValue("top_queries-2024.01.01-" + hash1))
         );
         assertFalse(
-            isTopQueriesIndex("top_queries-2025.12.12-99999", createIndexMetadataWithDifferentValue("top_queries-2025.12.12-99999"))
+            isTopQueriesIndex("top_queries-2025.12.12-" + hash2, createIndexMetadataWithDifferentValue("top_queries-2025.12.12-" + hash2))
         );
         assertFalse(
             isTopQueriesIndex("top_queries-2024.01.01-012345", createIndexMetadataWithDifferentValue("top_queries-2024.01.01-012345"))
@@ -295,11 +324,11 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         );
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01", createIndexMetadataWithDifferentValue("top_queries-2024.01.01")));
         assertFalse(
-            isTopQueriesIndex("top_queries-2024.01.32-01234", createIndexMetadataWithDifferentValue("top_queries-2024.01.32-01234"))
+            isTopQueriesIndex("top_queries-2024.01.32-" + hash1, createIndexMetadataWithDifferentValue("top_queries-2024.01.32-" + hash1))
         );
         assertFalse(isTopQueriesIndex("top_queries-01234", createIndexMetadataWithDifferentValue("top_queries-01234")));
-        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-01234", createIndexMetadataWithDifferentValue("top_querie-2024.01.01-01234")));
-        assertFalse(isTopQueriesIndex("2024.01.01-01234", createIndexMetadataWithDifferentValue("2024.01.01-01234")));
+        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-" + hash1, createIndexMetadataWithDifferentValue("top_querie-2024.01.01-" + hash1)));
+        assertFalse(isTopQueriesIndex("2024.01.01-" + hash1, createIndexMetadataWithDifferentValue("2024.01.01-" + hash1)));
         assertFalse(isTopQueriesIndex("any_index", createIndexMetadataWithDifferentValue("any_index")));
         assertFalse(isTopQueriesIndex("", createIndexMetadataWithDifferentValue("")));
         assertFalse(isTopQueriesIndex("_customer_index", createIndexMetadataWithDifferentValue("_customer_index")));
@@ -320,30 +349,42 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     }
 
     public void testIsTopQueriesIndexWithExtraMetaData() {
-        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-01234", createIndexMetadataWithExtraValue("top_queries-2024.01.01-01234")));
-        assertFalse(isTopQueriesIndex("top_queries-2025.12.12-99999", createIndexMetadataWithExtraValue("top_queries-2025.12.12-99999")));
+        // Generate correct hash values for test dates
+        LocalDate date1 = LocalDate.parse("2024.01.01", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        LocalDate date2 = LocalDate.parse("2025.12.12", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        String hash1 = ExporterReaderUtils.generateLocalIndexDateHash(date1);
+        String hash2 = ExporterReaderUtils.generateLocalIndexDateHash(date2);
+        
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-" + hash1, createIndexMetadataWithExtraValue("top_queries-2024.01.01-" + hash1)));
+        assertFalse(isTopQueriesIndex("top_queries-2025.12.12-" + hash2, createIndexMetadataWithExtraValue("top_queries-2025.12.12-" + hash2)));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01-012345", createIndexMetadataWithExtraValue("top_queries-2024.01.01-012345")));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01-0123w", createIndexMetadataWithExtraValue("top_queries-2024.01.01-0123w")));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01", createIndexMetadataWithExtraValue("top_queries-2024.01.01")));
-        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-01234", createIndexMetadataWithExtraValue("top_queries-2024.01.32-01234")));
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-" + hash1, createIndexMetadataWithExtraValue("top_queries-2024.01.32-" + hash1)));
         assertFalse(isTopQueriesIndex("top_queries-01234", createIndexMetadataWithExtraValue("top_queries-01234")));
-        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-01234", createIndexMetadataWithExtraValue("top_querie-2024.01.01-01234")));
-        assertFalse(isTopQueriesIndex("2024.01.01-01234", createIndexMetadataWithExtraValue("2024.01.01-01234")));
+        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-" + hash1, createIndexMetadataWithExtraValue("top_querie-2024.01.01-" + hash1)));
+        assertFalse(isTopQueriesIndex("2024.01.01-" + hash1, createIndexMetadataWithExtraValue("2024.01.01-" + hash1)));
         assertFalse(isTopQueriesIndex("any_index", createIndexMetadataWithExtraValue("any_index")));
         assertFalse(isTopQueriesIndex("", createIndexMetadataWithExtraValue("")));
         assertFalse(isTopQueriesIndex("_customer_index", createIndexMetadataWithExtraValue("_customer_index")));
     }
 
     public void testIsTopQueriesIndexWithNullMetaData() {
-        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-01234", null));
-        assertFalse(isTopQueriesIndex("top_queries-2025.12.12-99999", null));
+        // Generate correct hash values for test dates
+        LocalDate date1 = LocalDate.parse("2024.01.01", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        LocalDate date2 = LocalDate.parse("2025.12.12", DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT));
+        String hash1 = ExporterReaderUtils.generateLocalIndexDateHash(date1);
+        String hash2 = ExporterReaderUtils.generateLocalIndexDateHash(date2);
+        
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.01-" + hash1, null));
+        assertFalse(isTopQueriesIndex("top_queries-2025.12.12-" + hash2, null));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01-012345", null));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01-0123w", null));
         assertFalse(isTopQueriesIndex("top_queries-2024.01.01", null));
-        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-01234", null));
+        assertFalse(isTopQueriesIndex("top_queries-2024.01.32-" + hash1, null));
         assertFalse(isTopQueriesIndex("top_queries-01234", null));
-        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-01234", null));
-        assertFalse(isTopQueriesIndex("2024.01.01-01234", null));
+        assertFalse(isTopQueriesIndex("top_querie-2024.01.01-" + hash1, null));
+        assertFalse(isTopQueriesIndex("2024.01.01-" + hash1, null));
         assertFalse(isTopQueriesIndex("any_index", null));
         assertFalse(isTopQueriesIndex("", null));
         assertFalse(isTopQueriesIndex("_customer_index", null));


### PR DESCRIPTION
### Description
Add strict hash check on top queries indices

### Issues Resolved
Related to https://github.com/opensearch-project/query-insights/issues/261

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
