### PR TITLE
Revert "[Backport 2.19] [Backport 2.x] fix unit test SearchQueryCategorizerTests.testFunctionScoreQuery"

### DIFF
--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizerTests.java
@@ -142,7 +142,7 @@ public final class SearchQueryCategorizerTests extends OpenSearchTestCase {
         SearchQueryRecord record = generateQueryInsightRecords(1, sourceBuilder).get(0);
         searchQueryCategorizer.categorize(record);
 
-        verifyMeasurementHistogramsIncremented(record, 2);
+        verifyMeasurementHistogramsIncremented(record, 1);
 
         verify(searchQueryCategorizer.getSearchQueryCounters().getCounterByQueryBuilderName("function_score")).add(
             eq(1.0d),


### PR DESCRIPTION
Reverts opensearch-project/query-insights#273
Seems the upstream change is only on 2.x and 3.x