### PR TITLE
Reduce LocalIndexReader size to 50

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -33,13 +33,15 @@ import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.transport.client.Client;
 
 /**
  * Local index reader for reading query insights data from local OpenSearch indices.
  */
 public final class LocalIndexReader implements QueryInsightsReader {
-    private final static int MAX_TOP_N_INDEX_READ_SIZE = 1000;
+    private final static int MAX_TOP_N_INDEX_READ_SIZE = 50;
     /**
      * Logger of the local index reader
      */
@@ -128,6 +130,7 @@ public final class LocalIndexReader implements QueryInsightsReader {
                 query.must(QueryBuilders.matchQuery("id", id));
             }
             searchSourceBuilder.query(query);
+            searchSourceBuilder.sort(SortBuilders.fieldSort("measurements.latency.number").order(SortOrder.DESC));
             searchRequest.source(searchSourceBuilder);
             try {
                 SearchResponse searchResponse = client.search(searchRequest).actionGet();


### PR DESCRIPTION
### Description
Limit the number of Top N queries that can be fetched from the local index.

### Issues Resolved
Related to https://github.com/opensearch-project/query-insights-dashboards/issues/105

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
