### PR TITLE
Upgrades to top_queries endpoint

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -306,7 +306,7 @@ public class TopQueriesService {
         @Nullable final String to,
         @Nullable final String id,
         @Nullable final Boolean verbose
-    ) throws IllegalArgumentException {
+    ) {
         OperationalMetricsCounter.getInstance()
             .incrementCounter(
                 OperationalMetric.TOP_N_QUERIES_USAGE_COUNT,
@@ -314,11 +314,6 @@ public class TopQueriesService {
                     .addTag(METRIC_TYPE_TAG, this.metricType.name())
                     .addTag(GROUPBY_TAG, this.queryGrouper.getGroupingType().name())
             );
-        if (!enabled) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "Cannot get top n queries for [%s] when it is not enabled.", metricType.toString())
-            );
-        }
         // read from window snapshots
         final List<SearchQueryRecord> queries = new ArrayList<>(topQueriesCurrentSnapshot.get());
         if (includeLastWindow) {
@@ -363,14 +358,12 @@ public class TopQueriesService {
      * @return List of the records that are in local index (if enabled) with timestamps between from and to
      * @throws IllegalArgumentException if query insights is disabled in the cluster
      */
-    public List<SearchQueryRecord> getTopQueriesRecordsFromIndex(final String from, final String to, final String id, final Boolean verbose)
-        throws IllegalArgumentException {
-        if (!enabled) {
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "Cannot get top n queries for [%s] when it is not enabled.", metricType.toString())
-            );
-        }
-
+    public List<SearchQueryRecord> getTopQueriesRecordsFromIndex(
+        final String from,
+        final String to,
+        final String id,
+        final Boolean verbose
+    ) {
         final List<SearchQueryRecord> queries = new ArrayList<>();
         final QueryInsightsReader reader = queryInsightsReaderFactory.getReader(TOP_QUERIES_READER_ID);
         if (reader != null) {

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponse.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponse.java
@@ -30,7 +30,6 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
 
     private static final String CLUSTER_LEVEL_RESULTS_KEY = "top_queries";
     private final MetricType metricType;
-    private final int top_n_size;
 
     /**
      * Constructor for TopQueriesResponse.
@@ -40,7 +39,6 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
      */
     public TopQueriesResponse(final StreamInput in) throws IOException {
         super(in);
-        top_n_size = in.readInt();
         metricType = in.readEnum(MetricType.class);
     }
 
@@ -50,18 +48,15 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
      * @param clusterName The current cluster name
      * @param nodes A list that contains top queries results from all nodes
      * @param failures A list that contains FailedNodeException
-     * @param top_n_size The top N size to return to the user
      * @param metricType the {@link MetricType} to be returned in this response
      */
     public TopQueriesResponse(
         final ClusterName clusterName,
         final List<TopQueries> nodes,
         final List<FailedNodeException> failures,
-        final int top_n_size,
         final MetricType metricType
     ) {
         super(clusterName, nodes, failures);
-        this.top_n_size = top_n_size;
         this.metricType = metricType;
     }
 
@@ -73,7 +68,6 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
     @Override
     protected void writeNodesTo(final StreamOutput out, final List<TopQueries> nodes) throws IOException {
         out.writeList(nodes);
-        out.writeLong(top_n_size);
         out.writeEnum(metricType);
     }
 
@@ -112,7 +106,6 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
             .map(TopQueries::getTopQueriesRecord)
             .flatMap(Collection::stream)
             .sorted((a, b) -> SearchQueryRecord.compare(a, b, metricType) * -1)
-            .limit(top_n_size)
             .collect(Collectors.toList());
         builder.startArray(CLUSTER_LEVEL_RESULTS_KEY);
         for (SearchQueryRecord record : all_records) {

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -22,7 +22,6 @@ import org.opensearch.plugin.insights.rules.action.top_queries.TopQueries;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesRequest;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesResponse;
-import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportService;
@@ -75,22 +74,12 @@ public class TransportTopQueriesAction extends TransportNodesAction<
         final List<TopQueries> responses,
         final List<FailedNodeException> failures
     ) {
-        int size;
-        switch (topQueriesRequest.getMetricType()) {
-            case CPU:
-                size = clusterService.getClusterSettings().get(QueryInsightsSettings.TOP_N_CPU_QUERIES_SIZE);
-                break;
-            case MEMORY:
-                size = clusterService.getClusterSettings().get(QueryInsightsSettings.TOP_N_MEMORY_QUERIES_SIZE);
-                break;
-            default:
-                size = clusterService.getClusterSettings().get(QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE);
-        }
         final String from = topQueriesRequest.getFrom();
         final String to = topQueriesRequest.getTo();
         final String id = topQueriesRequest.getId();
         final Boolean verbose = topQueriesRequest.getVerbose();
         if (from != null && to != null) {
+            // If date range is provided, fetch historical data from local index
             responses.add(
                 new TopQueries(
                     clusterService.localNode(),
@@ -99,7 +88,7 @@ public class TransportTopQueriesAction extends TransportNodesAction<
                 )
             );
         }
-        return new TopQueriesResponse(clusterService.getClusterName(), responses, failures, size, topQueriesRequest.getMetricType());
+        return new TopQueriesResponse(clusterService.getClusterName(), responses, failures, topQueriesRequest.getMetricType());
     }
 
     @Override

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -129,7 +129,7 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
 
     public void testGetTopQueriesWhenNotEnabled() {
         topQueriesService.setEnabled(false);
-        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.getTopQueriesRecords(false, null, null, null, null); });
+        assertEquals(0, topQueriesService.getTopQueriesRecords(false, null, null, null, null).size());
     }
 
     public void testValidateWindowSize() {

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
@@ -34,7 +34,7 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
     public void testSerialize() throws Exception {
         TopQueries topQueries = QueryInsightsTestUtils.createRandomTopQueries();
         ClusterName clusterName = new ClusterName("test-cluster");
-        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(topQueries), new ArrayList<>(), 10, MetricType.LATENCY);
+        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(topQueries), new ArrayList<>(), MetricType.LATENCY);
         TopQueriesResponse deserializedResponse = roundTripResponse(response);
         assertEquals(response.toString(), deserializedResponse.toString());
     }
@@ -86,7 +86,7 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
 
         TopQueries topQueries = QueryInsightsTestUtils.createFixedTopQueries(id);
         ClusterName clusterName = new ClusterName("test-cluster");
-        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(topQueries), new ArrayList<>(), 10, MetricType.LATENCY);
+        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(topQueries), new ArrayList<>(), MetricType.LATENCY);
 
         XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
         char[] xContent = BytesReference.bytes(response.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString().toCharArray();


### PR DESCRIPTION
### Description
This PR includes bug fixes for the Query Insights `top_queries` API.

1. Do not throw illegal argument exception from `top_queries` api when a metric type is disabled. The user may be trying to fetch historical data or data for other metric types.
2. We are currently limiting the number of records returned by the top_queries api to `top_n_size`. Note, this is different than the LocalIndexReader limit of 50. Removed this limit

### Testing
1. Disable top_n latency
```
% curl -X PUT "localhost:9200/_cluster/settings?pretty&flat_settings" -H 'Content-Type: application/json' -d '
{
  "transient" : {
    "search.insights.top_queries.latency.enabled" : false
  }
}'
{
  "acknowledged" : true,
  "persistent" : { },
  "transient" : {
    "search.insights.top_queries.latency.enabled" : "false"
  }
}
```
2. Call top queries API. Verify no error thrown
```
% curl -XGET "http://localhost:9200/_insights/top_queries?pretty"              
{
  "top_queries" : [ ]
}
```

### Issues Resolved
Resolves https://github.com/opensearch-project/query-insights/issues/292

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
