### PR TITLE
Skip profile queries

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -221,6 +221,11 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     }
 
     private void constructSearchQueryRecord(final SearchPhaseContext context, final SearchRequestContext searchRequestContext) {
+        // Skip profile queries
+        if (searchRequestContext.getRequest().source().profile()) {
+            return;
+        }
+
         SearchTask searchTask = context.getTask();
         List<TaskResourceInfo> tasksResourceUsages = searchRequestContext.getPhaseResourceUsage();
         tasksResourceUsages.add(

--- a/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
@@ -79,7 +79,7 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
         ClusterServiceUtils.setState(clusterService, state);
         when(queryInsightsService.isCollectionEnabled(MetricType.LATENCY)).thenReturn(true);
         when(queryInsightsService.getTopQueriesService(MetricType.LATENCY)).thenReturn(topQueriesService);
-
+        when(searchRequestContext.getRequest()).thenReturn(searchRequest);
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         threadPool.getThreadContext().setHeaders(new Tuple<>(Collections.singletonMap(Task.X_OPAQUE_ID, "userLabel"), new HashMap<>()));
     }
@@ -347,11 +347,10 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
     }
 
     public void testSkipProfileQuery() {
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        searchSourceBuilder.profile(true);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().profile(true);
         when(searchRequest.source()).thenReturn(searchSourceBuilder);
-        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
-
+        QueryInsightsListener queryInsightsListener = new QueryInsightsListener(clusterService, queryInsightsService);
+        queryInsightsListener.onRequestEnd(searchPhaseContext, searchRequestContext);
         verify(queryInsightsService, times(0)).addRecord(any());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
@@ -345,4 +345,13 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
 
         return queryInsightsListener;
     }
+
+    public void testSkipProfileQuery() {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.profile(true);
+        when(searchRequest.source()).thenReturn(searchSourceBuilder);
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+
+        verify(queryInsightsService, times(0)).addRecord(any());
+    }
 }


### PR DESCRIPTION
### Description
Profile search requests will be skipped during the search query construction in both request end and fail

### Issues Resolved
[[FEATURE] Filter out profile queries from the Top N queries ](https://github.com/opensearch-project/query-insights/issues/180)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
