### PR TITLE
Add top_queries API verbose param

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -9,11 +9,13 @@
 package org.opensearch.plugin.insights.core.reader;
 
 import static org.opensearch.plugin.insights.core.utils.ExporterReaderUtils.generateLocalIndexDateHash;
+import static org.opensearch.plugin.insights.rules.model.SearchQueryRecord.VERBOSE_ONLY_FIELDS;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,6 +23,7 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.IndexNotFoundException;
@@ -30,6 +33,7 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
+import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -101,10 +105,11 @@ public final class LocalIndexReader implements QueryInsightsReader {
      * @param from start timestamp
      * @param to   end timestamp
      * @param id query/group id
+     * @param verbose whether to return full output
      * @return list of SearchQueryRecords whose timestamps fall between from and to
      */
     @Override
-    public List<SearchQueryRecord> read(final String from, final String to, String id) {
+    public List<SearchQueryRecord> read(final String from, final String to, final String id, final Boolean verbose) {
         List<SearchQueryRecord> records = new ArrayList<>();
         if (from == null || to == null) {
             return records;
@@ -116,6 +121,7 @@ public final class LocalIndexReader implements QueryInsightsReader {
             end = now;
         }
         ZonedDateTime curr = start;
+        // TODO: send single search request instead of one per index
         while (curr.isBefore(end.plusDays(1).toLocalDate().atStartOfDay(end.getZone()))) {
             String indexName = buildLocalIndexName(curr);
             SearchRequest searchRequest = new SearchRequest(indexName);
@@ -130,6 +136,13 @@ public final class LocalIndexReader implements QueryInsightsReader {
                 query.must(QueryBuilders.matchQuery("id", id));
             }
             searchSourceBuilder.query(query);
+            if (Boolean.FALSE.equals(verbose)) {
+                // Exclude these fields
+                searchSourceBuilder.fetchSource(
+                    Strings.EMPTY_ARRAY,
+                    Arrays.stream(VERBOSE_ONLY_FIELDS).map(Attribute::toString).toArray(String[]::new)
+                );
+            }
             searchSourceBuilder.sort(SortBuilders.fieldSort("measurements.latency.number").order(SortOrder.DESC));
             searchRequest.source(searchSourceBuilder);
             try {

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
@@ -22,9 +22,10 @@ public interface QueryInsightsReader extends Closeable {
      * @param from string
      * @param to   string
      * @param id query/group id
+     * @param verbose whether to return full output
      * @return List of SearchQueryRecord
      */
-    List<SearchQueryRecord> read(final String from, final String to, final String id);
+    List<SearchQueryRecord> read(final String from, final String to, final String id, final Boolean verbose);
 
     String getId();
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporter;
 import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporterFactory;
@@ -56,6 +57,7 @@ import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.telemetry.metrics.tags.Tags;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
+import reactor.util.annotation.NonNull;
 
 /**
  * Service responsible for gathering and storing top N queries
@@ -294,14 +296,16 @@ public class TopQueriesService {
      * @param from start timestamp
      * @param to end timestamp
      * @param id unique identifier for query/query group
+     * @param verbose whether to return full output
      * @return List of the records that are in the query insight store
      * @throws IllegalArgumentException if query insights is disabled in the cluster
      */
     public List<SearchQueryRecord> getTopQueriesRecords(
-        final boolean includeLastWindow,
-        final String from,
-        final String to,
-        final String id
+        @NonNull final boolean includeLastWindow,
+        @Nullable final String from,
+        @Nullable final String to,
+        @Nullable final String id,
+        @Nullable final Boolean verbose
     ) throws IllegalArgumentException {
         OperationalMetricsCounter.getInstance()
             .incrementCounter(
@@ -336,6 +340,11 @@ public class TopQueriesService {
             filterQueries = filterQueries.stream().filter(record -> record.getId().equals(id)).collect(Collectors.toList());
         }
 
+        // If verbose is false (not null), trim records
+        if (Boolean.FALSE.equals(verbose)) {
+            filterQueries = filterQueries.stream().map(SearchQueryRecord::copyAndSimplifyRecord).collect(Collectors.toList());
+        }
+
         return Stream.of(filterQueries)
             .flatMap(Collection::stream)
             .sorted((a, b) -> SearchQueryRecord.compare(a, b, metricType) * -1)
@@ -350,10 +359,11 @@ public class TopQueriesService {
      * @param from start timestamp
      * @param to   end timestamp
      * @param id search query record id
+     * @param verbose whether to return full output
      * @return List of the records that are in local index (if enabled) with timestamps between from and to
      * @throws IllegalArgumentException if query insights is disabled in the cluster
      */
-    public List<SearchQueryRecord> getTopQueriesRecordsFromIndex(final String from, final String to, final String id)
+    public List<SearchQueryRecord> getTopQueriesRecordsFromIndex(final String from, final String to, final String id, final Boolean verbose)
         throws IllegalArgumentException {
         if (!enabled) {
             throw new IllegalArgumentException(
@@ -367,7 +377,7 @@ public class TopQueriesService {
             try {
                 final ZonedDateTime start = ZonedDateTime.parse(from);
                 final ZonedDateTime end = ZonedDateTime.parse(to);
-                List<SearchQueryRecord> records = reader.read(from, to, id);
+                List<SearchQueryRecord> records = reader.read(from, to, id, verbose);
                 Predicate<SearchQueryRecord> timeFilter = element -> start.toInstant().toEpochMilli() <= element.getTimestamp()
                     && element.getTimestamp() <= end.toInstant().toEpochMilli();
                 List<SearchQueryRecord> filteredRecords = records.stream()

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -23,6 +23,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     final String from;
     final String to;
     final String id;
+    final Boolean verbose;
 
     /**
      * Constructor for TopQueriesRequest
@@ -35,6 +36,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
         this.metricType = MetricType.readFromStream(in);
         this.from = null;
         this.to = null;
+        this.verbose = null;
         this.id = null;
     }
 
@@ -45,13 +47,23 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
      * @param metricType {@link MetricType}
      * @param from start timestamp
      * @param to end timestamp
+     * @param id query/group id
+     * @param verbose whether to return full output
      * @param nodesIds the nodeIds specified in the request
      */
-    public TopQueriesRequest(final MetricType metricType, final String from, final String to, final String id, final String... nodesIds) {
+    public TopQueriesRequest(
+        final MetricType metricType,
+        final String from,
+        final String to,
+        final String id,
+        final Boolean verbose,
+        final String... nodesIds
+    ) {
         super(nodesIds);
         this.metricType = metricType;
         this.from = from;
         this.to = to;
+        this.verbose = verbose;
         this.id = id;
     }
 
@@ -65,7 +77,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
 
     /**
      * Get from for timestamp request
-     * @return String of fromtimestamp
+     * @return String of from timestamp
      */
     public String getFrom() {
         return from;
@@ -81,10 +93,18 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
 
     /**
      * Get id which is the query_id and query_group_id
-     * @return String of to timestamp
+     * @return String of id
      */
     public String getId() {
         return id;
+    }
+
+    /**
+     * Get verbose value for request
+     * @return Boolean verbose value
+     */
+    public Boolean getVerbose() {
+        return verbose;
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -110,6 +110,11 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
     private String groupingId;
 
     /**
+     * Array of search query record {@link Attribute} to ignore when verbose is false
+     */
+    public static final Attribute[] VERBOSE_ONLY_FIELDS = { Attribute.TASK_RESOURCE_USAGES, Attribute.SOURCE, Attribute.PHASE_LATENCY_MAP };
+
+    /**
      * Constructor of SearchQueryRecord
      *
      * @param in the StreamInput to read the SearchQueryRecord from
@@ -169,6 +174,25 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
         this.attributes = attributes;
         this.timestamp = timestamp;
         this.id = id;
+    }
+
+    /**
+     * Copy Constructor of {@link SearchQueryRecord}.
+     * <p>
+     * Creates a new {@link SearchQueryRecord} by copying the values from another
+     * {@link SearchQueryRecord}. This constructor performs a shallow copy of the
+     * given record, meaning that the references to mutable objects (such as the
+     * {@link #measurements} and {@link #attributes} maps) are copied, but the
+     * objects inside the maps are shared between the original and the copied record.
+     *
+     * @param other the {@link SearchQueryRecord} to copy.
+     */
+    public SearchQueryRecord(SearchQueryRecord other) {
+        this.measurements = new HashMap<>(other.measurements);
+        this.attributes = new HashMap<>(other.attributes);
+        this.timestamp = other.timestamp;
+        this.id = other.id;
+        this.groupingId = other.groupingId;
     }
 
     /**
@@ -477,4 +501,22 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
     public String getGroupingId() {
         return this.groupingId;
     }
+
+    /**
+     * Creates a new {@link SearchQueryRecord} by removing specific attributes
+     * from the attributes map. The original record remains unchanged.
+     *
+     * @return a new {@link SearchQueryRecord} without some attributes.
+     */
+    public SearchQueryRecord copyAndSimplifyRecord() {
+        // Create a new instance by copying the current record
+        SearchQueryRecord simplifiedRecord = new SearchQueryRecord(this);
+
+        // Remove verbose-only attributes
+        for (Attribute attribute : VERBOSE_ONLY_FIELDS) {
+            simplifiedRecord.getAttributes().remove(attribute);
+        }
+        return simplifiedRecord;
+    }
+
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
@@ -80,6 +80,7 @@ public class RestTopQueriesAction extends BaseRestHandler {
         final String from = request.param("from", null);
         final String to = request.param("to", null);
         final String id = request.param("id", null);
+        final boolean verbose = request.paramAsBoolean("verbose", true);
         if (!ALLOWED_METRICS.contains(metricType)) {
             throw new IllegalArgumentException(
                 String.format(Locale.ROOT, "request [%s] contains invalid metric type [%s]", request.path(), metricType)
@@ -90,7 +91,7 @@ public class RestTopQueriesAction extends BaseRestHandler {
             validateTimeRange(request, from, to);
         }
 
-        return new TopQueriesRequest(MetricType.fromString(metricType), from, to, id, nodesIds);
+        return new TopQueriesRequest(MetricType.fromString(metricType), from, to, id, verbose, nodesIds);
     }
 
     private static void validateTimeRange(RestRequest request, String from, String to) {

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -89,11 +89,13 @@ public class TransportTopQueriesAction extends TransportNodesAction<
         final String from = topQueriesRequest.getFrom();
         final String to = topQueriesRequest.getTo();
         final String id = topQueriesRequest.getId();
+        final Boolean verbose = topQueriesRequest.getVerbose();
         if (from != null && to != null) {
             responses.add(
                 new TopQueries(
                     clusterService.localNode(),
-                    queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType()).getTopQueriesRecordsFromIndex(from, to, id)
+                    queryInsightsService.getTopQueriesService(topQueriesRequest.getMetricType())
+                        .getTopQueriesRecordsFromIndex(from, to, id, verbose)
                 )
             );
         }
@@ -116,9 +118,10 @@ public class TransportTopQueriesAction extends TransportNodesAction<
         final String from = request.getFrom();
         final String to = request.getTo();
         final String id = request.getId();
+        final Boolean verbose = request.getVerbose();
         return new TopQueries(
             clusterService.localNode(),
-            queryInsightsService.getTopQueriesService(request.getMetricType()).getTopQueriesRecords(true, from, to, id)
+            queryInsightsService.getTopQueriesService(request.getMetricType()).getTopQueriesRecords(true, from, to, id, verbose)
         );
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
@@ -87,7 +87,15 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
         String id = "example-hashcode";
         List<SearchQueryRecord> records = List.of();
         try {
-            records = localIndexReader.read(time, time, id);
+            records = localIndexReader.read(time, time, id, true);
+        } catch (Exception e) {
+            fail("No exception should be thrown when reading query insights data");
+        }
+        assertNotNull(records);
+        assertEquals(1, records.size());
+
+        try {
+            records = localIndexReader.read(time, time, id, false);
         } catch (Exception e) {
             fail("No exception should be thrown when reading query insights data");
         }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -177,7 +177,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         queryInsightsService.drainRecords();
         assertEquals(
             QueryInsightsSettings.DEFAULT_TOP_N_SIZE,
-            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null).size()
+            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null, null).size()
         );
     }
 
@@ -250,7 +250,7 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
 
         assertEquals(
             QueryInsightsSettings.DEFAULT_TOP_N_SIZE,
-            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null).size()
+            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null, null).size()
         );
     }
 
@@ -273,7 +273,10 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         assertTrue(queryInsightsService.addRecord(records.get(numberOfRecordsRequired - 1)));
 
         queryInsightsService.drainRecords();
-        assertEquals(1, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null).size());
+        assertEquals(
+            1,
+            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null, null).size()
+        );
     }
 
     public void testAddRecordGroupBySimilarityWithTwoGroups() {
@@ -292,7 +295,10 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         }
 
         queryInsightsService.drainRecords();
-        assertEquals(2, queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null).size());
+        assertEquals(
+            2,
+            queryInsightsService.getTopQueriesService(MetricType.LATENCY).getTopQueriesRecords(false, null, null, null, null).size()
+        );
     }
 
     public void testGetHealthStats() {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -36,6 +36,7 @@ import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporterFactory
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.core.reader.QueryInsightsReaderFactory;
 import org.opensearch.plugin.insights.core.utils.ExporterReaderUtils;
+import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
@@ -89,7 +90,7 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         topQueriesService.consumeRecords(records);
         assertTrue(
             QueryInsightsTestUtils.checkRecordsEqualsWithoutOrder(
-                topQueriesService.getTopQueriesRecords(false, null, null, null),
+                topQueriesService.getTopQueriesRecords(false, null, null, null, null),
                 records,
                 MetricType.LATENCY
             )
@@ -102,20 +103,20 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         records = QueryInsightsTestUtils.generateQueryInsightRecords(5, 5, System.currentTimeMillis() - 1000 * 60 * 10, 0);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null, null).size());
+        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null, null, null).size());
 
         // Create 10 records at now + 1 minute, to make sure they belong to the current window
         records = QueryInsightsTestUtils.generateQueryInsightRecords(10, 10, System.currentTimeMillis() + 1000 * 60, 0);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(10, topQueriesService.getTopQueriesRecords(true, null, null, null).size());
+        assertEquals(10, topQueriesService.getTopQueriesRecords(true, null, null, null, null).size());
     }
 
     public void testSmallNSize() {
         final List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(10);
         topQueriesService.setTopNSize(1);
         topQueriesService.consumeRecords(records);
-        assertEquals(1, topQueriesService.getTopQueriesRecords(false, null, null, null).size());
+        assertEquals(1, topQueriesService.getTopQueriesRecords(false, null, null, null, null).size());
     }
 
     public void testValidateTopNSize() {
@@ -128,7 +129,7 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
 
     public void testGetTopQueriesWhenNotEnabled() {
         topQueriesService.setEnabled(false);
-        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.getTopQueriesRecords(false, null, null, null); });
+        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.getTopQueriesRecords(false, null, null, null, null); });
     }
 
     public void testValidateWindowSize() {
@@ -161,13 +162,13 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         records = QueryInsightsTestUtils.generateQueryInsightRecords(5, 5, System.currentTimeMillis() - 1000 * 60 * 10, 0);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null, null).size());
+        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null, null, null).size());
 
         // Create 10 records at now + 1 minute, to make sure they belong to the current window
         records = QueryInsightsTestUtils.generateQueryInsightRecords(10, 10, System.currentTimeMillis() + 1000 * 60, 0);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(10, topQueriesService.getTopQueriesRecords(true, null, null, null).size());
+        assertEquals(10, topQueriesService.getTopQueriesRecords(true, null, null, null, null).size());
     }
 
     public void testRollingWindowsWithDifferentGroup() {
@@ -179,14 +180,14 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
 
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null, null).size());
+        assertEquals(0, topQueriesService.getTopQueriesRecords(true, null, null, null, null).size());
 
         // Create 10 records at now + 1 minute, to make sure they belong to the current window
         records = QueryInsightsTestUtils.generateQueryInsightRecords(10, 10, System.currentTimeMillis() + 1000 * 60, 0);
         QueryInsightsTestUtils.populateSameQueryHashcodes(records);
         topQueriesService.setWindowSize(TimeValue.timeValueMinutes(10));
         topQueriesService.consumeRecords(records);
-        assertEquals(1, topQueriesService.getTopQueriesRecords(true, null, null, null).size());
+        assertEquals(1, topQueriesService.getTopQueriesRecords(true, null, null, null, null).size());
     }
 
     public void testGetHealthStats_EmptyService() {
@@ -421,7 +422,7 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         // Validate that the records for "id-1" are correctly retrieved
         assertTrue(
             QueryInsightsTestUtils.checkRecordsEqualsWithoutOrder(
-                topQueriesService.getTopQueriesRecords(false, null, null, "id-1"),
+                topQueriesService.getTopQueriesRecords(false, null, null, "id-1", null),
                 records1.stream().filter(record -> "id-1".equals(record.getId())).collect(Collectors.toList()),
                 MetricType.LATENCY
             )
@@ -430,10 +431,39 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         // Validate that the records for "id-2" are correctly retrieved
         assertTrue(
             QueryInsightsTestUtils.checkRecordsEqualsWithoutOrder(
-                topQueriesService.getTopQueriesRecords(false, null, null, "id-2"),
+                topQueriesService.getTopQueriesRecords(false, null, null, "id-2", null),
                 records1.stream().filter(record -> "id-2".equals(record.getId())).collect(Collectors.toList()),
                 MetricType.LATENCY
             )
         );
+    }
+
+    public void testTopQueriesVerbose() {
+        final List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(2);
+        topQueriesService.consumeRecords(records);
+
+        // verbose = null
+        List<SearchQueryRecord> results = topQueriesService.getTopQueriesRecords(false, null, null, null, null);
+        for (SearchQueryRecord record : results) {
+            assertNotNull(record.getAttributes().get(Attribute.TASK_RESOURCE_USAGES));
+            assertNotNull(record.getAttributes().get(Attribute.SOURCE));
+            assertNotNull(record.getAttributes().get(Attribute.PHASE_LATENCY_MAP));
+        }
+
+        // verbose = true
+        results = topQueriesService.getTopQueriesRecords(false, null, null, null, true);
+        for (SearchQueryRecord record : results) {
+            assertNotNull(record.getAttributes().get(Attribute.TASK_RESOURCE_USAGES));
+            assertNotNull(record.getAttributes().get(Attribute.SOURCE));
+            assertNotNull(record.getAttributes().get(Attribute.PHASE_LATENCY_MAP));
+        }
+
+        // verbose = false
+        results = topQueriesService.getTopQueriesRecords(false, null, null, null, false);
+        for (SearchQueryRecord record : results) {
+            assertNull(record.getAttributes().get(Attribute.TASK_RESOURCE_USAGES));
+            assertNull(record.getAttributes().get(Attribute.SOURCE));
+            assertNull(record.getAttributes().get(Attribute.PHASE_LATENCY_MAP));
+        }
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequestTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequestTests.java
@@ -22,7 +22,7 @@ public class TopQueriesRequestTests extends OpenSearchTestCase {
      * Check that we can set the metric type
      */
     public void testSetMetricType() throws Exception {
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, randomAlphaOfLength(5));
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, randomAlphaOfLength(5), null);
         TopQueriesRequest deserializedRequest = roundTripRequest(request);
         assertEquals(request.getMetricType(), deserializedRequest.getMetricType());
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/health_stats/TransportHealthStatsActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/health_stats/TransportHealthStatsActionTests.java
@@ -69,7 +69,7 @@ public class TransportHealthStatsActionTests extends OpenSearchTestCase {
         }
 
         public TopQueriesResponse createNewResponse() {
-            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null);
+            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
             return newResponse(request, List.of(), List.of());
         }
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
@@ -64,7 +64,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
         }
 
         public TopQueriesResponse createNewResponse() {
-            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null);
+            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
             return newResponse(request, List.of(), List.of());
         }
     }


### PR DESCRIPTION
### Description
This PR adds the option to get a lightweight response from the Query Insights top_queries API.

```
curl -XGET "http://localhost:9200/_insights/top_queries?pretty&verbose"
curl -XGET "http://localhost:9200/_insights/top_queries?pretty&verbose=true"
curl -XGET "http://localhost:9200/_insights/top_queries?pretty&verbose=false"
```

When `verbose=false`, the following fields are omitted:
1.  task_resource_usages
2. source
3. phase_latency_map

If `verbose` is not defined, the full output is returned (no change).

### Testing

Current window, verbose=false
```
% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&verbose=false"        
{
  "top_queries" : [
    {
      "timestamp" : 1744666964815,
      "id" : "bc493b5e-e935-4f1b-a6ea-1dc7f31d8690",
      "node_id" : "A87s3OPBT5e2U-jExa0uOw",
      "labels" : { },
      "indices" : [
        "my_index"
      ],
      "group_by" : "NONE",
      "search_type" : "query_then_fetch",
      "total_shards" : 1,
      "measurements" : {
        "cpu" : {
          "number" : 183664000,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "memory" : {
          "number" : 11080000,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 325,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    }
  ]
}
```

Current window, verbose=true
```
% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&verbose=true" 
{
  "top_queries" : [
    {
      "timestamp" : 1744666964815,
      "id" : "bc493b5e-e935-4f1b-a6ea-1dc7f31d8690",
      "node_id" : "A87s3OPBT5e2U-jExa0uOw",
      "source" : {
        "query" : {
          "match" : {
            "author" : {
              "query" : "Jane Smith",
              "operator" : "OR",
              "prefix_length" : 0,
              "max_expansions" : 50,
              "fuzzy_transpositions" : true,
              "lenient" : false,
              "zero_terms_query" : "NONE",
              "auto_generate_synonyms_phrase_query" : true,
              "boost" : 1.0
            }
          }
        }
      },
      "labels" : { },
      "indices" : [
        "my_index"
      ],
      "task_resource_usages" : [
        {
          "action" : "indices:data/read/search[phase/query]",
          "taskId" : 58,
          "parentTaskId" : 57,
          "nodeId" : "A87s3OPBT5e2U-jExa0uOw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 178807000,
            "memory_in_bytes" : 10964472
          }
        },
        {
          "action" : "indices:data/read/search",
          "taskId" : 57,
          "parentTaskId" : -1,
          "nodeId" : "A87s3OPBT5e2U-jExa0uOw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 4857000,
            "memory_in_bytes" : 115528
          }
        }
      ],
      "phase_latency_map" : {
        "expand" : 0,
        "query" : 266,
        "fetch" : 5
      },
      "group_by" : "NONE",
      "search_type" : "query_then_fetch",
      "total_shards" : 1,
      "measurements" : {
        "cpu" : {
          "number" : 183664000,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "memory" : {
          "number" : 11080000,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 325,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    }
  ]
}
```

Local index, verbose=false
```
% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z&verbose=false"
{
  "top_queries" : [
    {
      "timestamp" : 1744667318746,
      "id" : "4cc08ba6-7187-493a-bceb-c1eb49da195e",
      "node_id" : "A87s3OPBT5e2U-jExa0uOw",
      "labels" : { },
      "indices" : [
        "my_index"
      ],
      "group_by" : "NONE",
      "search_type" : "query_then_fetch",
      "total_shards" : 1,
      "measurements" : {
        "cpu" : {
          "number" : 13634000,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "memory" : {
          "number" : 86856,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 52,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    }
  ]
}
```

Local index, verbose=true
```
% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z&verbose=true" 
{
  "top_queries" : [
    {
      "timestamp" : 1744667318746,
      "id" : "4cc08ba6-7187-493a-bceb-c1eb49da195e",
      "node_id" : "A87s3OPBT5e2U-jExa0uOw",
      "source" : {
        "query" : {
          "match" : {
            "author" : {
              "query" : "Jane Smith",
              "operator" : "OR",
              "prefix_length" : 0,
              "max_expansions" : 50,
              "fuzzy_transpositions" : true,
              "lenient" : false,
              "zero_terms_query" : "NONE",
              "auto_generate_synonyms_phrase_query" : true,
              "boost" : 1.0
            }
          }
        }
      },
      "labels" : { },
      "indices" : [
        "my_index"
      ],
      "task_resource_usages" : [
        {
          "action" : "indices:data/read/search[phase/query]",
          "taskId" : 171,
          "parentTaskId" : 170,
          "nodeId" : "A87s3OPBT5e2U-jExa0uOw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 13021000,
            "memory_in_bytes" : 82984
          }
        },
        {
          "action" : "indices:data/read/search",
          "taskId" : 170,
          "parentTaskId" : -1,
          "nodeId" : "A87s3OPBT5e2U-jExa0uOw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 613000,
            "memory_in_bytes" : 3872
          }
        }
      ],
      "phase_latency_map" : {
        "expand" : 0,
        "query" : 42,
        "fetch" : 1
      },
      "group_by" : "NONE",
      "search_type" : "query_then_fetch",
      "total_shards" : 1,
      "measurements" : {
        "cpu" : {
          "number" : 13634000,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "memory" : {
          "number" : 86856,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 52,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    }
  ]
}
```

```
% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&verbose=none"
{
  "error" : {
    "root_cause" : [
      {
        "type" : "illegal_argument_exception",
        "reason" : "Failed to parse value [none] as only [true] or [false] are allowed."
      }
    ],
    "type" : "illegal_argument_exception",
    "reason" : "Failed to parse value [none] as only [true] or [false] are allowed."
  },
  "status" : 400
}
```

### Issues Resolved
Resolves https://github.com/opensearch-project/query-insights/issues/291

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
