### PR TITLE
Using java-agent gradle plugin to phase off Security Manager in favor of Java-agent.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.rest-test'
 apply plugin: 'opensearch.repositories'
+apply plugin: 'opensearch.java-agent'
 
 def pluginName = 'query-insights'
 def pluginDescription = 'OpenSearch Query Insights plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -57,13 +57,6 @@ def pluginClassName = 'QueryInsightsPlugin'
 
 configurations {
   zipArchive
-  agent
-}
-
-dependencies {
-  agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
-  agent "org.opensearch:opensearch-agent:${opensearch_version}"
-  agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
 }
 
 java {
@@ -369,15 +362,5 @@ task updateVersion {
          // String tokenization to support -SNAPSHOT
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
-}
-
-task prepareAgent(type: Copy) {
-  from(configurations.agent)
-  into "$buildDir/agent"
-}
-
-tasks.withType(Test) {
-    dependsOn prepareAgent
-    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }
 


### PR DESCRIPTION
### Description
Using java-agent gradle plugin to phase off Security Manager in favor of Java-agent.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
