### PR TITLE
Add setting to exclude certain indices from insight query

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -153,6 +153,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER,
             QueryInsightsSettings.TOP_N_EXPORTER_TYPE,
             QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY,
+            QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES,
             QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
         );
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -19,7 +19,6 @@ import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.QUER
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_TYPE;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_QUERIES_INDEX_PATTERN_GLOB;
 
 import java.io.IOException;
@@ -35,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
@@ -142,8 +140,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      */
     private QueryShapeGenerator queryShapeGenerator;
 
-    private List<String> excludedIndices = new ArrayList<>();
-
     private final Client client;
     SinkType sinkType;
 
@@ -201,8 +197,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         this.setExporterDeleteAfterAndDelete(clusterService.getClusterSettings().get(TOP_N_EXPORTER_DELETE_AFTER));
         this.setExporterAndReaderType(SinkType.parse(clusterService.getClusterSettings().get(TOP_N_EXPORTER_TYPE)));
         this.setTemplatePriority(clusterService.getClusterSettings().get(TOP_N_EXPORTER_TEMPLATE_PRIORITY));
-        this.setExcludedIndices(clusterService.getClusterSettings().get(TOP_N_QUERIES_EXCLUDED_INDICES));
-
         this.searchQueryCategorizer = SearchQueryCategorizer.getInstance(metricsRegistry);
         this.enableSearchQueryMetricsFeature(false);
         this.groupingType = DEFAULT_GROUPING_TYPE;
@@ -532,32 +526,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
                     MAX_DELETE_AFTER_VALUE
                 )
             );
-        }
-    }
-
-    /**
-     * Setter for excluded indices
-     * @param excludedIndices
-     */
-    public void setExcludedIndices(List<String> excludedIndices) {
-        this.excludedIndices = excludedIndices;
-    }
-
-    /**
-     * Validate the index name for excluded indices
-     * @param excludedIndices
-     */
-    public void validateExcludedIndices(List<String> excludedIndices) {
-        for (String index : excludedIndices) {
-            if (Objects.isNull(index)) {
-                throw new IllegalArgumentException("Excluded index name cannot be null.");
-            }
-            if (!index.isEmpty() && index.isBlank()) {
-                throw new IllegalArgumentException("Excluded index name should not be blank.");
-            }
-        }
-        if (excludedIndices.size() > 1 && excludedIndices.stream().anyMatch(String::isBlank)) {
-            throw new IllegalArgumentException("Excluded index name should not be blank.");
         }
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -19,6 +19,7 @@ import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.QUER
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_TYPE;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_QUERIES_INDEX_PATTERN_GLOB;
 
 import java.io.IOException;
@@ -34,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
@@ -140,6 +142,8 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      */
     private QueryShapeGenerator queryShapeGenerator;
 
+    private List<String> excludedIndices = new ArrayList<>();
+
     private final Client client;
     SinkType sinkType;
 
@@ -197,6 +201,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         this.setExporterDeleteAfterAndDelete(clusterService.getClusterSettings().get(TOP_N_EXPORTER_DELETE_AFTER));
         this.setExporterAndReaderType(SinkType.parse(clusterService.getClusterSettings().get(TOP_N_EXPORTER_TYPE)));
         this.setTemplatePriority(clusterService.getClusterSettings().get(TOP_N_EXPORTER_TEMPLATE_PRIORITY));
+        this.setExcludedIndices(clusterService.getClusterSettings().get(TOP_N_QUERIES_EXCLUDED_INDICES));
 
         this.searchQueryCategorizer = SearchQueryCategorizer.getInstance(metricsRegistry);
         this.enableSearchQueryMetricsFeature(false);
@@ -527,6 +532,32 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
                     MAX_DELETE_AFTER_VALUE
                 )
             );
+        }
+    }
+
+    /**
+     * Setter for excluded indices
+     * @param excludedIndices
+     */
+    public void setExcludedIndices(List<String> excludedIndices) {
+        this.excludedIndices = excludedIndices;
+    }
+
+    /**
+     * Validate the index name for excluded indices
+     * @param excludedIndices
+     */
+    public void validateExcludedIndices(List<String> excludedIndices) {
+        for (String index : excludedIndices) {
+            if (Objects.isNull(index)) {
+                throw new IllegalArgumentException("Excluded index name cannot be null.");
+            }
+            if (!index.isEmpty() && index.isBlank()) {
+                throw new IllegalArgumentException("Excluded index name should not be blank.");
+            }
+        }
+        if (excludedIndices.size() > 1 && excludedIndices.stream().anyMatch(String::isBlank)) {
+            throw new IllegalArgumentException("Excluded index name should not be blank.");
         }
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -9,9 +9,12 @@
 package org.opensearch.plugin.insights.settings;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugin.insights.core.exporter.SinkType;
@@ -277,6 +280,17 @@ public class QueryInsightsSettings {
     public static final Setting<String> TOP_N_EXPORTER_TYPE = Setting.simpleString(
         TOP_N_QUERIES_EXPORTER_PREFIX + ".type",
         DEFAULT_TOP_QUERIES_EXPORTER_TYPE,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    /**
+     * Settings for the list of indices that excluded from top queries.
+     */
+    public static final Setting<List<String>> TOP_N_QUERIES_EXCLUDED_INDICES = Setting.listSetting(
+        TOP_N_QUERIES_SETTING_PREFIX + ".excluded_indices",
+        Collections.emptyList(),
+        Function.identity(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -85,6 +85,7 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
                 QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER,
                 QueryInsightsSettings.TOP_N_EXPORTER_TYPE,
                 QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY,
+                QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES,
                 QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
             ),
             queryInsightsPlugin.getSettings()

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -358,6 +358,7 @@ final public class QueryInsightsTestUtils {
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY);
+        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES);
         clusterSettings.registerSetting(QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING);
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
@@ -430,24 +430,24 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
 
         List<String> containEmptyList = List.of("index1", "");
         assertThrows(
-            "Excluded index name should not be blank.",
+            "Excluded index name cannot be blank.",
             IllegalArgumentException.class,
             () -> queryInsightsListener.validateExcludedIndices(containEmptyList)
         );
 
         List<String> containBlankList = List.of("index1", "  ");
         assertThrows(
-            "Excluded index name should not be blank when there are multiple indices.",
+            "Excluded index name cannot be blank.",
             IllegalArgumentException.class,
             () -> queryInsightsListener.validateExcludedIndices(containBlankList)
         );
 
-        List<String> validResetValue = List.of("");
-        try {
-            queryInsightsListener.validateExcludedIndices(validResetValue);
-        } catch (Exception e) {
-            fail("Expect no exception when excluded indices is reset.");
-        }
+        List<String> blankResetValue = List.of("");
+        assertThrows(
+            "Excluded index name cannot be blank.",
+            IllegalArgumentException.class,
+            () -> queryInsightsListener.validateExcludedIndices(blankResetValue)
+        );
 
         List<String> validIndicesList = List.of("first-index", "wildcard-index*");
         try {

--- a/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
@@ -449,6 +449,13 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
             () -> queryInsightsListener.validateExcludedIndices(blankResetValue)
         );
 
+        List<String> indexNameWithUpperCaseChar = List.of("acceptedIndex", "rejectedIndex");
+        assertThrows(
+            "Index name must be lowercase.",
+            IllegalArgumentException.class,
+            () -> queryInsightsListener.validateExcludedIndices(indexNameWithUpperCaseChar)
+        );
+
         List<String> validIndicesList = List.of("first-index", "wildcard-index*");
         try {
             queryInsightsListener.validateExcludedIndices(validIndicesList);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -40,6 +40,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -649,5 +650,44 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         // Create a local index exporter with a retention period of 7 days
         updatedQueryInsightsService.queryInsightsExporterFactory.createLocalIndexExporter(TOP_QUERIES_EXPORTER_ID, "YYYY.MM.dd", "");
         return List.of(updatedQueryInsightsService, updatedClusterService);
+    }
+
+    public void testExcludedIndicesValidation() {
+        List<String> containNullList = new ArrayList<>();
+        containNullList.add("index1");
+        containNullList.add(null);
+        assertThrows(
+            "Excluded index name cannot be null.",
+            IllegalArgumentException.class,
+            () -> queryInsightsService.validateExcludedIndices(containNullList)
+        );
+
+        List<String> containEmptyList = List.of("index1", "");
+        assertThrows(
+            "Excluded index name should not be blank.",
+            IllegalArgumentException.class,
+            () -> queryInsightsService.validateExcludedIndices(containEmptyList)
+        );
+
+        List<String> containBlankList = List.of("index1", "  ");
+        assertThrows(
+            "Excluded index name should not be blank.",
+            IllegalArgumentException.class,
+            () -> queryInsightsService.validateExcludedIndices(containBlankList)
+        );
+
+        List<String> containOnlyBlankList = List.of("  ");
+        assertThrows(
+            "Excluded index name should not be blank.",
+            IllegalArgumentException.class,
+            () -> queryInsightsService.validateExcludedIndices(containOnlyBlankList)
+        );
+
+        List<String> validResetValue = List.of("");
+        try {
+            queryInsightsService.validateExcludedIndices(validResetValue);
+        } catch (Exception e) {
+            fail("Expect no exception when excluded indices is reset");
+        }
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -40,7 +40,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -650,44 +649,5 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         // Create a local index exporter with a retention period of 7 days
         updatedQueryInsightsService.queryInsightsExporterFactory.createLocalIndexExporter(TOP_QUERIES_EXPORTER_ID, "YYYY.MM.dd", "");
         return List.of(updatedQueryInsightsService, updatedClusterService);
-    }
-
-    public void testExcludedIndicesValidation() {
-        List<String> containNullList = new ArrayList<>();
-        containNullList.add("index1");
-        containNullList.add(null);
-        assertThrows(
-            "Excluded index name cannot be null.",
-            IllegalArgumentException.class,
-            () -> queryInsightsService.validateExcludedIndices(containNullList)
-        );
-
-        List<String> containEmptyList = List.of("index1", "");
-        assertThrows(
-            "Excluded index name should not be blank.",
-            IllegalArgumentException.class,
-            () -> queryInsightsService.validateExcludedIndices(containEmptyList)
-        );
-
-        List<String> containBlankList = List.of("index1", "  ");
-        assertThrows(
-            "Excluded index name should not be blank.",
-            IllegalArgumentException.class,
-            () -> queryInsightsService.validateExcludedIndices(containBlankList)
-        );
-
-        List<String> containOnlyBlankList = List.of("  ");
-        assertThrows(
-            "Excluded index name should not be blank.",
-            IllegalArgumentException.class,
-            () -> queryInsightsService.validateExcludedIndices(containOnlyBlankList)
-        );
-
-        List<String> validResetValue = List.of("");
-        try {
-            queryInsightsService.validateExcludedIndices(validResetValue);
-        } catch (Exception e) {
-            fail("Expect no exception when excluded indices is reset");
-        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Du Tran <quangdutran809@gmail.com>

### Description
Add setting `excluded_indices` to let user exclude certain indices from insight query

### Issues Resolved
https://github.com/opensearch-project/query-insights/issues/260

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
