### PR TITLE
Add metric labels to historical data

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporter.java
@@ -219,7 +219,7 @@ public class LocalIndexExporter implements QueryInsightsExporter {
         for (SearchQueryRecord record : records) {
             bulkRequestBuilder.add(
                 new IndexRequest(indexName).id(record.getId())
-                    .source(record.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
+                    .source(record.toXContentForExport(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
             );
         }
         bulkRequestBuilder.execute(new ActionListener<BulkResponse>() {

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.plugin.insights.core.listener;
 
+import static org.opensearch.plugin.insights.rules.model.SearchQueryRecord.DEFAULT_TOP_N_QUERY_MAP;
 import static org.opensearch.plugin.insights.settings.QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE;
@@ -267,6 +268,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
             attributes.put(Attribute.TASK_RESOURCE_USAGES, tasksResourceUsages);
             attributes.put(Attribute.GROUP_BY, QueryInsightsSettings.DEFAULT_GROUPING_TYPE);
             attributes.put(Attribute.NODE_ID, clusterService.localNode().getId());
+            attributes.put(Attribute.TOP_N_QUERY, new HashMap<>(DEFAULT_TOP_N_QUERY_MAP));
 
             if (queryInsightsService.isGroupingEnabled() || log.isTraceEnabled()) {
                 // Generate the query shape only if grouping is enabled or trace logging is enabled

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugin.insights.core.reader;
 
 import static org.opensearch.plugin.insights.core.utils.ExporterReaderUtils.generateLocalIndexDateHash;
+import static org.opensearch.plugin.insights.rules.model.SearchQueryRecord.TOP_N_QUERY;
 import static org.opensearch.plugin.insights.rules.model.SearchQueryRecord.VERBOSE_ONLY_FIELDS;
 
 import java.time.ZoneOffset;
@@ -34,12 +35,14 @@ import org.opensearch.index.query.RangeQueryBuilder;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.rules.model.Attribute;
+import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.transport.client.Client;
+import reactor.util.annotation.NonNull;
 
 /**
  * Local index reader for reading query insights data from local OpenSearch indices.
@@ -102,14 +105,21 @@ public final class LocalIndexReader implements QueryInsightsReader {
     /**
      * Export a list of SearchQueryRecord from local index
      *
-     * @param from start timestamp
-     * @param to   end timestamp
-     * @param id query/group id
-     * @param verbose whether to return full output
+     * @param from       start timestamp
+     * @param to         end timestamp
+     * @param id         query/group id
+     * @param verbose    whether to return full output
+     * @param metricType metric type to read
      * @return list of SearchQueryRecords whose timestamps fall between from and to
      */
     @Override
-    public List<SearchQueryRecord> read(final String from, final String to, final String id, final Boolean verbose) {
+    public List<SearchQueryRecord> read(
+        final String from,
+        final String to,
+        final String id,
+        final Boolean verbose,
+        @NonNull final MetricType metricType
+    ) {
         List<SearchQueryRecord> records = new ArrayList<>();
         if (from == null || to == null) {
             return records;
@@ -134,6 +144,9 @@ public final class LocalIndexReader implements QueryInsightsReader {
 
             if (id != null) {
                 query.must(QueryBuilders.matchQuery("id", id));
+            } else {
+                // Add metric type filter only when (id == null)
+                query.must(QueryBuilders.termQuery(TOP_N_QUERY + "." + metricType, true));
             }
             searchSourceBuilder.query(query);
             if (Boolean.FALSE.equals(verbose)) {

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReader.java
@@ -10,6 +10,7 @@ package org.opensearch.plugin.insights.core.reader;
 
 import java.io.Closeable;
 import java.util.List;
+import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 
 /**
@@ -19,13 +20,14 @@ public interface QueryInsightsReader extends Closeable {
     /**
      * Reader a list of SearchQueryRecord
      *
-     * @param from string
-     * @param to   string
-     * @param id query/group id
-     * @param verbose whether to return full output
+     * @param from       string
+     * @param to         string
+     * @param id         query/group id
+     * @param verbose    whether to return full output
+     * @param metricType metric type to read
      * @return List of SearchQueryRecord
      */
-    List<SearchQueryRecord> read(final String from, final String to, final String id, final Boolean verbose);
+    List<SearchQueryRecord> read(final String from, final String to, final String id, final Boolean verbose, final MetricType metricType);
 
     String getId();
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -370,7 +370,7 @@ public class TopQueriesService {
             try {
                 final ZonedDateTime start = ZonedDateTime.parse(from);
                 final ZonedDateTime end = ZonedDateTime.parse(to);
-                List<SearchQueryRecord> records = reader.read(from, to, id, verbose);
+                List<SearchQueryRecord> records = reader.read(from, to, id, verbose, metricType);
                 Predicate<SearchQueryRecord> timeFilter = element -> start.toInstant().toEpochMilli() <= element.getTimestamp()
                     && element.getTimestamp() <= end.toInstant().toEpochMilli();
                 List<SearchQueryRecord> filteredRecords = records.stream()
@@ -454,6 +454,12 @@ public class TopQueriesService {
             }
             topQueriesCurrentSnapshot.set(new ArrayList<>());
             windowStart = newWindowStart;
+
+            // update top_n_query map for all top queries in the window
+            for (SearchQueryRecord record : history) {
+                record.setTopNTrue(metricType);
+            }
+
             // export to the configured sink
             QueryInsightsExporter exporter = queryInsightsExporterFactory.getExporter(TOP_QUERIES_EXPORTER_ID);
             if (exporter != null) {

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -68,7 +68,11 @@ public enum Attribute {
     /**
      * The description of the search query, often used in live queries.
      */
-    DESCRIPTION;
+    DESCRIPTION,
+    /**
+     * A map indicating for which metric type(s) this record was in the Top N
+     */
+    TOP_N_QUERY;
 
     /**
      * Read an Attribute from a StreamInput

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Measurement.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Measurement.java
@@ -264,7 +264,7 @@ public class Measurement implements ToXContentObject, Writeable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Measurement that = (Measurement) o;
-        return count == that.count && Objects.equals(number, that.number) && aggregationType == that.aggregationType;
+        return count == that.count && number.doubleValue() == that.number.doubleValue() && aggregationType == that.aggregationType;
     }
 
     @Override

--- a/src/main/resources/mappings/top-queries-record.json
+++ b/src/main/resources/mappings/top-queries-record.json
@@ -122,6 +122,19 @@
           }
         }
       }
+    },
+    "top_n_query" : {
+      "properties" : {
+        "cpu" : {
+          "type" : "boolean"
+        },
+        "latency" : {
+          "type" : "boolean"
+        },
+        "memory" : {
+          "type" : "boolean"
+        }
+      }
     }
   }
 }

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -13,6 +13,7 @@ import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.opensearch.plugin.insights.rules.model.SearchQueryRecord.DEFAULT_TOP_N_QUERY_MAP;
 import static org.opensearch.test.OpenSearchTestCase.buildNewFakeTransportAddress;
 import static org.opensearch.test.OpenSearchTestCase.random;
 import static org.opensearch.test.OpenSearchTestCase.randomAlphaOfLengthBetween;
@@ -156,6 +157,7 @@ final public class QueryInsightsTestUtils {
             attributes.put(Attribute.QUERY_GROUP_HASHCODE, Objects.hashCode(i));
             attributes.put(Attribute.GROUP_BY, GroupingType.NONE);
             attributes.put(Attribute.NODE_ID, "node_for_top_queries_test");
+            attributes.put(Attribute.TOP_N_QUERY, DEFAULT_TOP_N_QUERY_MAP);
             attributes.put(
                 Attribute.TASK_RESOURCE_USAGES,
                 List.of(
@@ -271,6 +273,7 @@ final public class QueryInsightsTestUtils {
                 new TaskResourceInfo("action2", 3L, 1L, "id2", new TaskResourceUsage(2000L, 1000L))
             )
         );
+        attributes.put(Attribute.TOP_N_QUERY, DEFAULT_TOP_N_QUERY_MAP);
 
         return new SearchQueryRecord(timestamp, measurements, attributes, id);
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
@@ -31,6 +31,7 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
@@ -87,7 +88,7 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
         String id = "example-hashcode";
         List<SearchQueryRecord> records = List.of();
         try {
-            records = localIndexReader.read(time, time, id, true);
+            records = localIndexReader.read(time, time, id, true, MetricType.LATENCY);
         } catch (Exception e) {
             fail("No exception should be thrown when reading query insights data");
         }
@@ -95,7 +96,7 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
         assertEquals(1, records.size());
 
         try {
-            records = localIndexReader.read(time, time, id, false);
+            records = localIndexReader.read(time, time, id, false, MetricType.LATENCY);
         } catch (Exception e) {
             fail("No exception should be thrown when reading query insights data");
         }

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
@@ -8,14 +8,17 @@
 
 package org.opensearch.plugin.insights.rules.model;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
 import org.opensearch.test.OpenSearchTestCase;
@@ -54,6 +57,39 @@ public class SearchQueryRecordTests extends OpenSearchTestCase {
         SearchQueryRecord record1 = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
         SearchQueryRecord record2 = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
         assertEquals(record1, record2);
+    }
+
+    public void testToXContent() throws IOException {
+        SearchQueryRecord originalRecord = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
+
+        // Serialize with toXContent
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        originalRecord.toXContent(builder, null);
+        builder.flush();
+
+        // Deserialize with fromXContent
+        String json = builder.toString();
+        XContentParser parser = JsonXContent.jsonXContent.createParser(null, null, json);
+        SearchQueryRecord parsedRecord = SearchQueryRecord.fromXContent(parser);
+
+        originalRecord.getAttributes().remove(Attribute.TOP_N_QUERY);
+        assertEquals(originalRecord, parsedRecord);
+    }
+
+    public void testToXContentForExport() throws IOException {
+        SearchQueryRecord originalRecord = QueryInsightsTestUtils.createFixedSearchQueryRecord("id");
+
+        // Serialize with toXContentForExport
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        originalRecord.toXContentForExport(builder, null);
+        builder.flush();
+
+        // Deserialize with fromXContent
+        String json = builder.toString();
+        XContentParser parser = JsonXContent.jsonXContent.createParser(null, null, json);
+        SearchQueryRecord parsedRecord = SearchQueryRecord.fromXContent(parser);
+
+        assertEquals(originalRecord, parsedRecord);
     }
 
     public void testFromXContent() {


### PR DESCRIPTION
### Description
1. Add a new attribute in SearchQueryRecord called `top_n_query`. It is a Map<String, Boolean> with a key for each metric type.
```
    "top_n_query": {
        "latency" : false,
        "cpu" : false,
        "memory" : false
    }
```
2. Update `top_n_query` to reflect records which were in the top N
3. Add filter in LocalIndexReader to only read data for the requested metric. All top_queries API requests already carry a single metric type (`type` param, default is latency).
4. Update local indices index template
5. Add UT and IT for reader and exporter

Notes:
- This attribute is for internal-use only. It is not visible to users because queries in the top N are constantly changing. Labels are added before export, after the current window passes.

### Issues Resolved
Resolves https://github.com/opensearch-project/query-insights/issues/301

### Testing
1. Disable cpu & memory top_queries
```
% curl -X PUT "localhost:9200/_cluster/settings?pretty&flat_settings" -H 'Content-Type: application/json' -d '
{
  "transient" : {
    "search.insights.top_queries.latency.enabled" : true,
    "search.insights.top_queries.cpu.enabled" : false,
    "search.insights.top_queries.memory.enabled" : false
  }
}'
```
2. Send a search request
```
% curl -X GET -u username:password "http://localhost:9200/*/_search?pretty" -H 'Content-Type: application/json' -d '{
  "query": {
    "match_all": {}
  }
}'
```
3. Wait for record to be exported to the local index
```
% curl -X GET "localhost:9200/_cat/indices?v&s=index"                                                                
health status index                        uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   top_queries-2025.04.29-51492 ETdNWOYLS3mIC8P4cthArw   1   0          1            0     15.3kb         15.3kb
```
4. Verify historical top query is only returned when `type=latency`
```
% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z&verbose=false&type=cpu"
{
  "top_queries" : [ ]
}

% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z&verbose=false&type=memory"
{
  "top_queries" : [ ]
}

% curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z&verbose=false&type=latency"
{
  "top_queries" : [
    {
      "timestamp" : 1745887820533,
      "id" : "020a5cfe-ca45-4606-b691-15d95fefbc3f",
      "labels" : { },
      "node_id" : "OkYBh8z5ScONDUXjps69yg",
      "total_shards" : 0,
      "group_by" : "NONE",
      "search_type" : "query_then_fetch",
      "indices" : [
        "*"
      ],
      "measurements" : {
        "memory" : {
          "number" : 0,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 26,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "cpu" : {
          "number" : 0,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    }
  ]
}

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
