### PR TITLE
[Bug fix] Flaky Integ test

### DIFF
--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
@@ -667,7 +667,6 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
                 if (filterNodeID != null && !filterNodeID.equals("null") && !filterNodeID.equals(nodeId)) {
                     nodeIdMismatchFound = true;
                 }
-
                 idNodePairs.add(new String[] { id, nodeId });
 
                 Map<String, Object> source = (Map<String, Object>) query.get("source");

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
@@ -646,7 +646,6 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
 
             boolean matchFound = false;
 
-
             boolean idMismatchFound = false;
             boolean nodeIdMismatchFound = false;
 
@@ -654,7 +653,6 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
 
             for (Map<String, Object> query : topQueries) {
                 assertTrue(query.containsKey("timestamp"));
-
 
                 List<?> indices = (List<?>) query.get("indices");
                 assertNotNull("Expected 'indices' field", indices);


### PR DESCRIPTION
### Description
This fix stabilizes the test under noisy environments (e.g., CI/CD or shared integration test clusters), ensures it properly make this more generic by checking the top queries array is not empty, and all the required fields exists and not check the actual values like the node name, indices names.

### Issues Resolved
Closes [#233]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
