### PR TITLE
Consolidate grouping settings

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -135,7 +135,7 @@ public class QueryInsightsSettings {
      * Define the group_by option for Top N queries to group queries.
      */
     public static final Setting<String> TOP_N_QUERIES_GROUP_BY = Setting.simpleString(
-        TOP_N_QUERIES_SETTING_PREFIX + ".group_by",
+        TOP_N_QUERIES_GROUPING_SETTING_PREFIX + ".group_by",
         DEFAULT_GROUPING_TYPE.getValue(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
@@ -145,7 +145,7 @@ public class QueryInsightsSettings {
      * Define the max_groups_excluding_topn option for Top N queries to group queries.
      */
     public static final Setting<Integer> TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N = Setting.intSetting(
-        TOP_N_QUERIES_SETTING_PREFIX + ".max_groups_excluding_topn",
+        TOP_N_QUERIES_GROUPING_SETTING_PREFIX + ".max_groups_excluding_topn",
         DEFAULT_GROUPS_EXCLUDING_TOPN_LIMIT,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
@@ -213,7 +213,7 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
             + "        \"search.insights.top_queries.latency.top_n_size\" : 5,\n"
             + "        \"search.insights.top_queries.memory.enabled\" : \"false\",\n"
             + "        \"search.insights.top_queries.cpu.enabled\" : \"false\",\n"
-            + "        \"search.insights.top_queries.group_by\" : \"none\"\n"
+            + "        \"search.insights.top_queries.grouping.group_by\" : \"none\"\n"
             + "    }\n"
             + "}";
     }
@@ -224,8 +224,8 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
             + "        \"search.insights.top_queries.latency.enabled\" : \"true\",\n"
             + "        \"search.insights.top_queries.latency.window_size\" : \"1m\",\n"
             + "        \"search.insights.top_queries.latency.top_n_size\" : 5,\n"
-            + "        \"search.insights.top_queries.group_by\" : \"similarity\",\n"
-            + "        \"search.insights.top_queries.max_groups_excluding_topn\" : 5\n"
+            + "        \"search.insights.top_queries.grouping.group_by\" : \"similarity\",\n"
+            + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : 5\n"
             + "    }\n"
             + "}";
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperByNoneIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperByNoneIT.java
@@ -40,8 +40,8 @@ public class MinMaxQueryGrouperByNoneIT extends QueryInsightsRestTestCase {
             + "        \"search.insights.top_queries.latency.enabled\" : \"true\",\n"
             + "        \"search.insights.top_queries.latency.window_size\" : \"1m\",\n"
             + "        \"search.insights.top_queries.latency.top_n_size\" : 100,\n"
-            + "        \"search.insights.top_queries.group_by\" : \"none\",\n"
-            + "        \"search.insights.top_queries.max_groups_excluding_topn\" : 5\n"
+            + "        \"search.insights.top_queries.grouping.group_by\" : \"none\",\n"
+            + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : 5\n"
             + "    }\n"
             + "}";
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperBySimilarityIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperBySimilarityIT.java
@@ -74,21 +74,21 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
             // Invalid max_groups: below minimum (-1)
             "{\n"
                 + "    \"persistent\" : {\n"
-                + "        \"search.insights.top_queries.max_groups_excluding_topn\" : -1\n"
+                + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : -1\n"
                 + "    }\n"
                 + "}",
 
             // Invalid max_groups: above maximum (10001)
             "{\n"
                 + "    \"persistent\" : {\n"
-                + "        \"search.insights.top_queries.max_groups_excluding_topn\" : 10001\n"
+                + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : 10001\n"
                 + "    }\n"
                 + "}",
 
             // Invalid group_by: unsupported value
             "{\n"
                 + "    \"persistent\" : {\n"
-                + "        \"search.insights.top_queries.group_by\" : \"unsupported_value\"\n"
+                + "        \"search.insights.top_queries.grouping.group_by\" : \"unsupported_value\"\n"
                 + "    }\n"
                 + "}" };
     }
@@ -98,19 +98,23 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
             // Valid max_groups: minimum value (0)
             "{\n"
                 + "    \"persistent\" : {\n"
-                + "        \"search.insights.top_queries.max_groups_excluding_topn\" : 0\n"
+                + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : 0\n"
                 + "    }\n"
                 + "}",
 
             // Valid max_groups: maximum value (10000)
             "{\n"
                 + "    \"persistent\" : {\n"
-                + "        \"search.insights.top_queries.max_groups_excluding_topn\" : 10000\n"
+                + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : 10000\n"
                 + "    }\n"
                 + "}",
 
             // Valid group_by: supported value (SIMILARITY)
-            "{\n" + "    \"persistent\" : {\n" + "        \"search.insights.top_queries.group_by\" : \"SIMILARITY\"\n" + "    }\n" + "}" };
+            "{\n"
+                + "    \"persistent\" : {\n"
+                + "        \"search.insights.top_queries.grouping.group_by\" : \"SIMILARITY\"\n"
+                + "    }\n"
+                + "}" };
     }
 
     private String groupByNoneSettings() {
@@ -119,8 +123,8 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
             + "        \"search.insights.top_queries.latency.enabled\" : \"true\",\n"
             + "        \"search.insights.top_queries.latency.window_size\" : \"1m\",\n"
             + "        \"search.insights.top_queries.latency.top_n_size\" : 100,\n"
-            + "        \"search.insights.top_queries.group_by\" : \"none\",\n"
-            + "        \"search.insights.top_queries.max_groups_excluding_topn\" : 5\n"
+            + "        \"search.insights.top_queries.grouping.group_by\" : \"none\",\n"
+            + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : 5\n"
             + "    }\n"
             + "}";
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperIT.java
@@ -99,7 +99,7 @@ public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
     protected String updateMaxGroupsExcludingTopNSetting() {
         return "{\n"
             + "    \"persistent\" : {\n"
-            + "        \"search.insights.top_queries.max_groups_excluding_topn\" : 1\n"
+            + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : 1\n"
             + "    }\n"
             + "}";
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRestIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRestIT.java
@@ -90,7 +90,7 @@ public class TopQueriesRestIT extends QueryInsightsRestTestCase {
             + "        \"search.insights.top_queries.cpu.enabled\" : \"true\",\n"
             + "        \"search.insights.top_queries.cpu.window_size\" : \"1m\",\n"
             + "        \"search.insights.top_queries.cpu.top_n_size\" : 5,\n"
-            + "        \"search.insights.top_queries.group_by\" : \"none\"\n"
+            + "        \"search.insights.top_queries.grouping.group_by\" : \"none\"\n"
             + "    }\n"
             + "}";
     }


### PR DESCRIPTION
### Description
Change grouping related setting names:
```
search.insights.top_queries.group_by -> search.insights.top_queries.grouping.group_by
search.insights.top_queries.max_groups_excluding_topn -> search.insights.top_queries.grouping.max_groups_excluding_topn
```

### Issues Resolved
Resolves https://github.com/opensearch-project/query-insights/issues/136

### Testing
```
% curl -X GET "localhost:9200/_cluster/settings?include_defaults&pretty"
...
    "search" : {
      "default_search_timeout" : "-1",
      "max_aggregation_rewrite_filters" : "3000",
      "max_open_pit_context" : "300",
      "insights" : {
        "top_queries" : {
          "cpu" : {
            "top_n_size" : "10",
            "window_size" : "5m",
            "enabled" : "true"
          },
          "exporter" : {
            "type" : "local_index",
            "template_priority" : "1847",
            "delete_after_days" : "7"
          },
          "memory" : {
            "top_n_size" : "10",
            "window_size" : "5m",
            "enabled" : "true"
          },
          "grouping" : {
            "group_by" : "none",
            "max_groups_excluding_topn" : "100",
            "attributes" : {
              "field_type" : "true",
              "field_name" : "true"
            }
          },
          "latency" : {
            "top_n_size" : "10",
            "window_size" : "5m",
            "enabled" : "true"
          }
        }
      },
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
