### PR TITLE
Added isCancelled field in Live Queries API

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -72,7 +72,12 @@ public enum Attribute {
     /**
      * A map indicating for which metric type(s) this record was in the Top N
      */
-    TOP_N_QUERY;
+    TOP_N_QUERY,
+
+    /**
+     * The cancelled of the search query, often used in live queries.
+     */
+    IS_CANCELLED;
 
     /**
      * Read an Attribute from a StreamInput

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -49,7 +49,6 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
     private final String id;
     private final boolean isCancelled;
 
-
     /**
      * Timestamp
      */
@@ -158,6 +157,7 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
         this.attributes = Attribute.readAttributeMap(in);
         this.isCancelled = false;
     }
+
     /**
      * Constructor of SearchQueryRecord
      *
@@ -177,7 +177,13 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      * @param attributes A list of Attributes associated with this query
      * @param id unique id for a search query record
      */
-    public SearchQueryRecord(long timestamp, Map<MetricType, Measurement> measurements, Map<Attribute, Object> attributes, String id, boolean isCancelled) {
+    public SearchQueryRecord(
+        long timestamp,
+        Map<MetricType, Measurement> measurements,
+        Map<Attribute, Object> attributes,
+        String id,
+        boolean isCancelled
+    ) {
         this.timestamp = timestamp;
         this.measurements = measurements;
         this.attributes = attributes;

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -185,9 +185,12 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
         final Map<Attribute, Object> attributes,
         String id
     ) {
-        this.timestamp = timestamp;
+        if (measurements == null) {
+            throw new IllegalArgumentException("Measurements cannot be null");
+        }
         this.measurements = measurements;
         this.attributes = attributes;
+        this.timestamp = timestamp;
         this.id = id;
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -155,7 +155,11 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
             });
         }
         this.attributes = Attribute.readAttributeMap(in);
-        this.isCancelled = false;
+        if (in.getVersion().onOrAfter(Version.V_3_1_0)) {
+            this.isCancelled = in.readBoolean();
+        } else {
+            this.isCancelled = false;
+        }
     }
 
     /**
@@ -178,9 +182,9 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      * @param id unique id for a search query record
      */
     public SearchQueryRecord(
-        long timestamp,
+        final long timestamp,
         Map<MetricType, Measurement> measurements,
-        Map<Attribute, Object> attributes,
+        final Map<Attribute, Object> attributes,
         String id,
         boolean isCancelled
     ) {
@@ -538,6 +542,9 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
             (stream, attribute) -> Attribute.writeTo(out, attribute),
             (stream, attributeValue) -> Attribute.writeValueTo(out, attributeValue)
         );
+        if (out.getVersion().onOrAfter(Version.V_3_1_0)) {
+            out.writeBoolean(isCancelled);
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -98,14 +98,14 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                         attributes.put(Attribute.NODE_ID, nodeId);
                         if (request.isVerbose()) {
                             attributes.put(Attribute.DESCRIPTION, taskInfo.getDescription());
+                            attributes.put(Attribute.IS_CANCELLED, taskInfo.isCancelled());
                         }
 
                         SearchQueryRecord record = new SearchQueryRecord(
                             timestamp,
                             measurements,
                             attributes,
-                            taskInfo.getTaskId().toString(),
-                            taskInfo.isCancelled()
+                            taskInfo.getTaskId().toString()
                         );
                         allFilteredRecords.add(record);
                     }

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -104,7 +104,8 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                             timestamp,
                             measurements,
                             attributes,
-                            taskInfo.getTaskId().toString()
+                            taskInfo.getTaskId().toString(),
+                            taskInfo.isCancelled()
                         );
                         allFilteredRecords.add(record);
                     }

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -178,7 +178,7 @@ final public class QueryInsightsTestUtils {
                 )
             );
 
-            records.add(new SearchQueryRecord(timestamp, measurements, attributes, id));
+            records.add(new SearchQueryRecord(timestamp, measurements, attributes, id, false));
             timestamp += interval;
         }
         return records;
@@ -275,7 +275,7 @@ final public class QueryInsightsTestUtils {
         );
         attributes.put(Attribute.TOP_N_QUERY, DEFAULT_TOP_N_QUERY_MAP);
 
-        return new SearchQueryRecord(timestamp, measurements, attributes, id);
+        return new SearchQueryRecord(timestamp, measurements, attributes, id, false);
     }
 
     public static void compareJson(ToXContent param1, ToXContent param2) throws IOException {

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -178,7 +178,7 @@ final public class QueryInsightsTestUtils {
                 )
             );
 
-            records.add(new SearchQueryRecord(timestamp, measurements, attributes, id, false));
+            records.add(new SearchQueryRecord(timestamp, measurements, attributes, id));
             timestamp += interval;
         }
         return records;
@@ -275,7 +275,7 @@ final public class QueryInsightsTestUtils {
         );
         attributes.put(Attribute.TOP_N_QUERY, DEFAULT_TOP_N_QUERY_MAP);
 
-        return new SearchQueryRecord(timestamp, measurements, attributes, id, false);
+        return new SearchQueryRecord(timestamp, measurements, attributes, id);
     }
 
     public static void compareJson(ToXContent param1, ToXContent param2) throws IOException {

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseTests.java
@@ -45,7 +45,7 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
             if (randomBoolean()) {
                 attributes.put(Attribute.DESCRIPTION, "desc_" + baseLatency + "_" + i);
             }
-            return new SearchQueryRecord(System.currentTimeMillis(), measurements, attributes, "query_" + baseLatency + "_" + i, false);
+            return new SearchQueryRecord(System.currentTimeMillis(), measurements, attributes, "query_" + baseLatency + "_" + i);
         }).collect(Collectors.toList());
     }
 
@@ -70,9 +70,9 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
             MetricType.MEMORY,
             new Measurement(30L)
         );
-        SearchQueryRecord rec1 = new SearchQueryRecord(1L, measurements, emptyMap(), "id1", false);
-        SearchQueryRecord rec2 = new SearchQueryRecord(2L, measurements, emptyMap(), "id2", false);
-        SearchQueryRecord rec3 = new SearchQueryRecord(3L, measurements, emptyMap(), "id3", false);
+        SearchQueryRecord rec1 = new SearchQueryRecord(1L, measurements, emptyMap(), "id1");
+        SearchQueryRecord rec2 = new SearchQueryRecord(2L, measurements, emptyMap(), "id2");
+        SearchQueryRecord rec3 = new SearchQueryRecord(3L, measurements, emptyMap(), "id3");
         List<SearchQueryRecord> records = List.of(rec2, rec1, rec3);
         LiveQueriesResponse response = new LiveQueriesResponse(records);
         XContentBuilder builder = XContentFactory.jsonBuilder();

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseTests.java
@@ -45,8 +45,7 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
             if (randomBoolean()) {
                 attributes.put(Attribute.DESCRIPTION, "desc_" + baseLatency + "_" + i);
             }
-
-            return new SearchQueryRecord(System.currentTimeMillis(), measurements, attributes, "query_" + baseLatency + "_" + i);
+            return new SearchQueryRecord(System.currentTimeMillis(), measurements, attributes, "query_" + baseLatency + "_" + i, false);
         }).collect(Collectors.toList());
     }
 
@@ -71,9 +70,9 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
             MetricType.MEMORY,
             new Measurement(30L)
         );
-        SearchQueryRecord rec1 = new SearchQueryRecord(1L, measurements, emptyMap(), "id1");
-        SearchQueryRecord rec2 = new SearchQueryRecord(2L, measurements, emptyMap(), "id2");
-        SearchQueryRecord rec3 = new SearchQueryRecord(3L, measurements, emptyMap(), "id3");
+        SearchQueryRecord rec1 = new SearchQueryRecord(1L, measurements, emptyMap(), "id1", false);
+        SearchQueryRecord rec2 = new SearchQueryRecord(2L, measurements, emptyMap(), "id2", false);
+        SearchQueryRecord rec3 = new SearchQueryRecord(3L, measurements, emptyMap(), "id3",false);
         List<SearchQueryRecord> records = List.of(rec2, rec1, rec3);
         LiveQueriesResponse response = new LiveQueriesResponse(records);
         XContentBuilder builder = XContentFactory.jsonBuilder();

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseTests.java
@@ -72,7 +72,7 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
         );
         SearchQueryRecord rec1 = new SearchQueryRecord(1L, measurements, emptyMap(), "id1", false);
         SearchQueryRecord rec2 = new SearchQueryRecord(2L, measurements, emptyMap(), "id2", false);
-        SearchQueryRecord rec3 = new SearchQueryRecord(3L, measurements, emptyMap(), "id3",false);
+        SearchQueryRecord rec3 = new SearchQueryRecord(3L, measurements, emptyMap(), "id3", false);
         List<SearchQueryRecord> records = List.of(rec2, rec1, rec3);
         LiveQueriesResponse response = new LiveQueriesResponse(records);
         XContentBuilder builder = XContentFactory.jsonBuilder();


### PR DESCRIPTION
### Description

This PR introduces an isCancelled boolean field in the Live Queries API response to indicate whether a query has been cancelled.

### Changes Introduced:

- Added isCancelled field to the LiveSearchQueryResponse model.
- Updated LiveQueriesTransportAction to populate the isCancelled value.

Testing Done:

Verified API responses include the isCancelled field with correct values.

### Example response

```
{
  "ok": true,
  "response": {
    "live_queries": [
      {
        "timestamp": 1749187466964,
        "id": "node-A1B2C3D4E5:3600",
        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
        "node_id": "node-A1B2C3D4E5",
        "measurements": {
          "latency": {
            "number": 7990852130,
            "count": 1,
            "aggregationType": "NONE"
          },
          "cpu": {
            "number": 89951,
            "count": 1,
            "aggregationType": "NONE"
          },
          "memory": {
            "number": 3818,
            "count": 1,
            "aggregationType": "NONE"
          },
          "is_cancelled": true
        }
      }
}
```

### Issues Resolved
Closes [#354]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
