### PR TITLE
Fix a bug in creating node level top queries request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,6 +299,10 @@ testClusters.all {
     plugin(project.tasks.bundlePlugin.archiveFile)
 }
 
+testClusters.integTest {
+    numberOfNodes = 2
+}
+
 run {
     useCluster testClusters.integTest
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugin.insights.rules.action.top_queries;
 
 import java.io.IOException;
+import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodesRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -34,10 +35,17 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     public TopQueriesRequest(final StreamInput in) throws IOException {
         super(in);
         this.metricType = MetricType.readFromStream(in);
-        this.from = in.readOptionalString();
-        this.to = in.readOptionalString();
-        this.id = in.readOptionalString();
-        this.verbose = in.readOptionalBoolean();
+        if (in.getVersion().onOrAfter(Version.V_3_1_0)) {
+            this.from = in.readOptionalString();
+            this.to = in.readOptionalString();
+            this.id = in.readOptionalString();
+            this.verbose = in.readOptionalBoolean();
+        } else {
+            this.from = null;
+            this.to = null;
+            this.id = null;
+            this.verbose = null;
+        }
     }
 
     /**
@@ -111,9 +119,11 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(metricType.toString());
-        out.writeOptionalString(from);
-        out.writeOptionalString(to);
-        out.writeOptionalString(id);
-        out.writeOptionalBoolean(verbose);
+        if (out.getVersion().onOrAfter(Version.V_3_1_0)) {
+            out.writeOptionalString(from);
+            out.writeOptionalString(to);
+            out.writeOptionalString(id);
+            out.writeOptionalBoolean(verbose);
+        }
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -34,10 +34,10 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     public TopQueriesRequest(final StreamInput in) throws IOException {
         super(in);
         this.metricType = MetricType.readFromStream(in);
-        this.from = null;
-        this.to = null;
-        this.verbose = null;
-        this.id = null;
+        this.from = in.readOptionalString();
+        this.to = in.readOptionalString();
+        this.id = in.readOptionalString();
+        this.verbose = in.readOptionalBoolean();
     }
 
     /**
@@ -111,5 +111,9 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(metricType.toString());
+        out.writeOptionalString(from);
+        out.writeOptionalString(to);
+        out.writeOptionalString(id);
+        out.writeOptionalBoolean(verbose);
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
@@ -510,10 +510,14 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
         String searchJson = "{ \"query\": { \"match\": { \"title\": \"Test Document\" } } }";
         Request req = new Request("POST", "/my-index-0/_search?size=20");
         req.setJsonEntity(searchJson);
-        Response response = client().performRequest(req);
-        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-        String content = new String(response.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
-        Assert.assertTrue("Expected search result for title", content.contains("\"Test Document\""));
+
+        // Use first node client to ensure consistent node targeting in multi-node setup
+        try (RestClient firstNodeClient = getFirstNodeClient()) {
+            Response response = firstNodeClient.performRequest(req);
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            String content = new String(response.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+            Assert.assertTrue("Expected search result for title", content.contains("\"Test Document\""));
+        }
     }
 
     protected void setLatencyWindowSize(String size) throws IOException {

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/MultiIndexDateRangeIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/MultiIndexDateRangeIT.java
@@ -175,6 +175,7 @@ public class MultiIndexDateRangeIT extends QueryInsightsRestTestCase {
         Request searchTest = new Request("GET", "/" + indexName + "/_search");
         searchTest.setJsonEntity("{ \"query\": { \"match_all\": {} } }");
         Response searchResp = client().performRequest(searchTest);
+        Assert.assertEquals(200, searchResp.getStatusLine().getStatusCode());
 
     }
 


### PR DESCRIPTION
### Description
Fix a bug in creating node level top queries request and change default integ test node number to 2 (and fixed the failed integ tests because of this change) so that we can capture similar issues in the future.

The bug is the request parameters are not passed correctly to other nodes.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
