### PR TITLE
Increase reader search limit to 500 and fix sort by metric type

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -34,7 +34,6 @@ import reactor.util.annotation.NonNull;
  * Local index reader for reading query insights data from local OpenSearch indices.
  */
 public final class LocalIndexReader implements QueryInsightsReader {
-    private final static int MAX_TOP_N_INDEX_READ_SIZE = 50;
     /**
      * Logger of the local index reader
      */

--- a/src/main/java/org/opensearch/plugin/insights/core/utils/QueryInsightsQueryBuilder.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/utils/QueryInsightsQueryBuilder.java
@@ -30,6 +30,7 @@ import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
+import reactor.util.annotation.NonNull;
 
 /**
  * Utility class for building search queries for Query Insights operations.
@@ -38,8 +39,7 @@ import org.opensearch.search.sort.SortOrder;
  */
 public final class QueryInsightsQueryBuilder {
 
-    private static final int MAX_TOP_N_INDEX_READ_SIZE = 50;
-    private static final String MEASUREMENTS_LATENCY_NUMBER = MEASUREMENTS + "." + MetricType.LATENCY + "." + NUMBER;
+    private static final int MAX_TOP_N_INDEX_READ_SIZE = 500;
 
     private QueryInsightsQueryBuilder() {}
 
@@ -135,7 +135,7 @@ public final class QueryInsightsQueryBuilder {
         final ZonedDateTime end,
         final String id,
         final Boolean verbose,
-        final MetricType metricType
+        @NonNull final MetricType metricType
     ) {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(MAX_TOP_N_INDEX_READ_SIZE);
 
@@ -151,8 +151,8 @@ public final class QueryInsightsQueryBuilder {
             );
         }
 
-        // Add sorting by latency in descending order
-        searchSourceBuilder.sort(SortBuilders.fieldSort(MEASUREMENTS_LATENCY_NUMBER).order(SortOrder.DESC));
+        // Add sorting by requested metric type in descending order
+        searchSourceBuilder.sort(SortBuilders.fieldSort(MEASUREMENTS + "." + metricType + "." + NUMBER).order(SortOrder.DESC));
 
         return searchSourceBuilder;
     }

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponse.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponse.java
@@ -114,6 +114,7 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
         final List<SearchQueryRecord> all_records = results.stream()
             .map(TopQueries::getTopQueriesRecord)
             .flatMap(Collection::stream)
+            // sort again to combine historical + in memory records
             .sorted((a, b) -> SearchQueryRecord.compare(a, b, metricType) * -1)
             .collect(Collectors.toList());
         builder.startArray(CLUSTER_LEVEL_RESULTS_KEY);

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterIT.java
@@ -32,7 +32,7 @@ public class QueryInsightsExporterIT extends QueryInsightsRestTestCase {
 
         // Perform multiple searches to ensure query insights data is collected
         for (int i = 0; i < 5; i++) {
-            performSearch();
+            performSearch(5);
             Thread.sleep(2000); // Small delay between searches
         }
 

--- a/src/test/java/org/opensearch/plugin/insights/core/utils/QueryInsightsQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/utils/QueryInsightsQueryBuilderTests.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.plugin.insights.core.utils;
 
+import static org.opensearch.plugin.insights.rules.model.Measurement.NUMBER;
+import static org.opensearch.plugin.insights.rules.model.SearchQueryRecord.MEASUREMENTS;
 import static org.opensearch.plugin.insights.rules.model.SearchQueryRecord.TOP_N_QUERY;
 
 import java.time.ZoneOffset;
@@ -22,6 +24,8 @@ import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.sort.SortBuilders;
+import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.OpenSearchTestCase;
 
 /**
@@ -255,6 +259,9 @@ public class QueryInsightsQueryBuilderTests extends OpenSearchTestCase {
 
         // Verify sorting is configured
         assertNotNull(sourceBuilder.sorts());
+        assertTrue(
+            sourceBuilder.sorts().contains(SortBuilders.fieldSort(MEASUREMENTS + "." + metricType + "." + NUMBER).order(SortOrder.DESC))
+        );
         assertFalse(sourceBuilder.sorts().isEmpty());
     }
 
@@ -309,6 +316,9 @@ public class QueryInsightsQueryBuilderTests extends OpenSearchTestCase {
         }
 
         assertTrue("Should find range query for timestamp field", foundRangeQuery);
+        assertTrue(
+            sourceBuilder.sorts().contains(SortBuilders.fieldSort(MEASUREMENTS + "." + metricType + "." + NUMBER).order(SortOrder.DESC))
+        );
     }
 
     public void testBuildTopNSearchRequestWithSameStartAndEndTime() {
@@ -354,6 +364,9 @@ public class QueryInsightsQueryBuilderTests extends OpenSearchTestCase {
         }
 
         assertTrue("Should find range query for timestamp field", foundRangeQuery);
+        assertTrue(
+            sourceBuilder.sorts().contains(SortBuilders.fieldSort(MEASUREMENTS + "." + metricType + "." + NUMBER).order(SortOrder.DESC))
+        );
     }
 
     public void testBuildTopNSearchRequestWithCachingEnabled() {


### PR DESCRIPTION
### Description
- Increase `MAX_TOP_N_INDEX_READ_SIZE` from 50 to 500
- Fix reader search request to sort by type instead of always latency

### Testing
```
% time curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z&verbose=false&type=latency" | grep -A1 "latency"

% time curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z&verbose=false&type=cpu" | grep -A1 "cpu"

% time curl -XGET "http://localhost:9200/_insights/top_queries?pretty&from=2025-01-01T00:00:00.000Z&to=2026-01-01T00:00:00.000Z&verbose=false&type=memory" | grep -A1 "memory"
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
