### PR TITLE
Add Workload Management (WLM) Group Filtering for Live Queries API

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -68,7 +67,6 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     private boolean groupingFieldTypeEnabled;
     private final QueryShapeGenerator queryShapeGenerator;
     private Set<Pattern> excludedIndicesPattern;
-    public static final Supplier<String> DEFAULT_QUERY_GROUP_ID_SUPPLIER = () -> "DEFAULT_WORKLOAD_GROUP";
 
     /**
      * Constructor for QueryInsightsListener
@@ -293,7 +291,6 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         );
 
         final SearchRequest request = context.getRequest();
-
         try {
             Map<MetricType, Measurement> measurements = new HashMap<>();
             measurements.put(

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -67,6 +68,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     private boolean groupingFieldTypeEnabled;
     private final QueryShapeGenerator queryShapeGenerator;
     private Set<Pattern> excludedIndicesPattern;
+    public static final Supplier<String> DEFAULT_QUERY_GROUP_ID_SUPPLIER = () -> "DEFAULT_WORKLOAD_GROUP";
 
     /**
      * Constructor for QueryInsightsListener
@@ -291,6 +293,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         );
 
         final SearchRequest request = context.getRequest();
+
         try {
             Map<MetricType, Measurement> measurements = new HashMap<>();
             measurements.put(
@@ -320,6 +323,8 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
             attributes.put(Attribute.GROUP_BY, QueryInsightsSettings.DEFAULT_GROUPING_TYPE);
             attributes.put(Attribute.NODE_ID, clusterService.localNode().getId());
             attributes.put(Attribute.TOP_N_QUERY, new HashMap<>(DEFAULT_TOP_N_QUERY_MAP));
+            String queryGroupId = searchTask.getWorkloadGroupId();
+            attributes.put(Attribute.QUERY_GROUP_ID, queryGroupId);
 
             if (queryInsightsService.isGroupingEnabled() || log.isTraceEnabled()) {
                 // Generate the query shape only if grouping is enabled or trace logging is enabled

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequest.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.plugin.insights.rules.action.live_queries;
 
 import java.io.IOException;
@@ -8,16 +16,24 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 
+/**
+ * A request to get cluster/node level ongoing live queries information.
+ */
 public class LiveQueriesRequest extends ActionRequest {
 
     private final boolean verbose;
     private final MetricType sortBy;
+    // Maximum number of results to return
     private final int size;
+    // Node IDs to filter queries by
     private final String[] nodeIds;
     private final String wlmGroup;
 
     /**
-     * Deserialization constructor
+     * Constructor for LiveQueriesRequest
+     *
+     * @param in A {@link StreamInput} object.
+     * @throws IOException if the stream cannot be deserialized.
      */
     public LiveQueriesRequest(final StreamInput in) throws IOException {
         super(in);
@@ -29,7 +45,13 @@ public class LiveQueriesRequest extends ActionRequest {
     }
 
     /**
-     * Main constructor with all parameters
+     * Get live queries from nodes based on the nodes ids specified.
+     * If none are passed, cluster level live queries will be returned.
+     *
+     * @param verbose Whether to include verbose information about live queries (defaults to true)
+     * @param sortBy the metric to sort by (latency, cpu, memory)
+     * @param size maximum number of results
+     * @param nodeIds The node IDs specified in the request
      */
     public LiveQueriesRequest(final boolean verbose, final MetricType sortBy, final int size, final String[] nodeIds, String wlmGroup) {
         this.verbose = verbose;
@@ -40,28 +62,48 @@ public class LiveQueriesRequest extends ActionRequest {
     }
 
     /**
-     * Convenience constructor
+     * Convenience constructor using default sortBy=LATENCY and no size limit.
+     * @param verbose whether to include verbose information about live queries
+     * @param nodeIds the node IDs specified in the request
      */
     public LiveQueriesRequest(final boolean verbose, final String... nodeIds) {
         this(verbose, MetricType.LATENCY, QueryInsightsSettings.DEFAULT_LIVE_QUERIES_SIZE, nodeIds, null);
     }
 
+    /**
+     * Get whether verbose information is requested
+     * @return boolean indicating whether verbose information is requested
+     */
     public boolean isVerbose() {
         return verbose;
     }
 
+    /**
+     * Get metric type to sort by
+     */
     public MetricType getSortBy() {
         return sortBy;
     }
 
+    /**
+     * Get maximum result size
+     */
     public int getSize() {
         return size;
     }
 
+    /**
+     * Get node IDs to filter by
+     * @return array of node IDs
+     */
     public String[] nodesIds() {
         return nodeIds;
     }
 
+    /**
+     * Get Wlm Group to filter by
+     * @return array of node IDs
+     */
     public String getWlmGroup() {
         return wlmGroup;
     }

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequest.java
@@ -1,11 +1,3 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
-
 package org.opensearch.plugin.insights.rules.action.live_queries;
 
 import java.io.IOException;
@@ -16,23 +8,16 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 
-/**
- * A request to get cluster/node level ongoing live queries information.
- */
 public class LiveQueriesRequest extends ActionRequest {
 
     private final boolean verbose;
     private final MetricType sortBy;
-    // Maximum number of results to return
     private final int size;
-    // Node IDs to filter queries by
     private final String[] nodeIds;
+    private final String wlmGroup;
 
     /**
-     * Constructor for LiveQueriesRequest
-     *
-     * @param in A {@link StreamInput} object.
-     * @throws IOException if the stream cannot be deserialized.
+     * Deserialization constructor
      */
     public LiveQueriesRequest(final StreamInput in) throws IOException {
         super(in);
@@ -40,61 +25,45 @@ public class LiveQueriesRequest extends ActionRequest {
         this.sortBy = MetricType.readFromStream(in);
         this.size = in.readInt();
         this.nodeIds = in.readStringArray();
+        this.wlmGroup = in.readOptionalString();
     }
 
     /**
-     * Get live queries from nodes based on the nodes ids specified.
-     * If none are passed, cluster level live queries will be returned.
-     *
-     * @param verbose Whether to include verbose information about live queries (defaults to true)
-     * @param sortBy the metric to sort by (latency, cpu, memory)
-     * @param size maximum number of results
-     * @param nodeIds The node IDs specified in the request
+     * Main constructor with all parameters
      */
-    public LiveQueriesRequest(final boolean verbose, final MetricType sortBy, final int size, final String... nodeIds) {
+    public LiveQueriesRequest(final boolean verbose, final MetricType sortBy, final int size, final String[] nodeIds, String wlmGroup) {
         this.verbose = verbose;
         this.sortBy = sortBy;
         this.size = size;
         this.nodeIds = nodeIds;
+        this.wlmGroup = wlmGroup;
     }
 
     /**
-     * Convenience constructor using default sortBy=LATENCY and no size limit.
-     * @param verbose whether to include verbose information about live queries
-     * @param nodeIds the node IDs specified in the request
+     * Convenience constructor
      */
     public LiveQueriesRequest(final boolean verbose, final String... nodeIds) {
-        this(verbose, MetricType.LATENCY, QueryInsightsSettings.DEFAULT_LIVE_QUERIES_SIZE, nodeIds);
+        this(verbose, MetricType.LATENCY, QueryInsightsSettings.DEFAULT_LIVE_QUERIES_SIZE, nodeIds, null);
     }
 
-    /**
-     * Get whether verbose information is requested
-     * @return boolean indicating whether verbose information is requested
-     */
     public boolean isVerbose() {
         return verbose;
     }
 
-    /**
-     * Get metric type to sort by
-     */
     public MetricType getSortBy() {
         return sortBy;
     }
 
-    /**
-     * Get maximum result size
-     */
     public int getSize() {
         return size;
     }
 
-    /**
-     * Get node IDs to filter by
-     * @return array of node IDs
-     */
     public String[] nodesIds() {
         return nodeIds;
+    }
+
+    public String getWlmGroup() {
+        return wlmGroup;
     }
 
     @Override
@@ -104,6 +73,7 @@ public class LiveQueriesRequest extends ActionRequest {
         MetricType.writeTo(out, sortBy);
         out.writeInt(size);
         out.writeStringArray(nodeIds);
+        out.writeOptionalString(wlmGroup);
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -75,6 +75,12 @@ public enum Attribute {
     TOP_N_QUERY,
 
     /**
+     * The WLM query group ID associated with the query.
+     */
+    QUERY_GROUP_ID,
+
+
+    /**
      * The cancelled of the search query, often used in live queries.
      */
     IS_CANCELLED;

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -113,6 +113,10 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      */
     public static final String TOP_N_QUERY = "top_n_query";
     /**
+     * The WLM query group id
+     */
+    public static final String QUERY_GROUP_ID = "wlm_group_id";
+    /**
      * Default, immutable `top_n_query` map. All values initialized to {@code false}
      */
     public static final Map<String, Boolean> DEFAULT_TOP_N_QUERY_MAP = Collections.unmodifiableMap(
@@ -284,6 +288,9 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
                         break;
                     case IS_CANCELLED:
                         attributes.put(Attribute.IS_CANCELLED, parser.booleanValue());
+                        break;
+                    case QUERY_GROUP_ID:
+                        attributes.put(Attribute.QUERY_GROUP_ID, parser.text());
                         break;
                     case TASK_RESOURCE_USAGES:
                         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesAction.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.plugin.insights.rules.resthandler.live_queries;
 
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.LIVE_QUERIES_BASE_URI;
@@ -24,10 +32,14 @@ import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.action.RestResponseListener;
 import org.opensearch.transport.client.node.NodeClient;
 
+/**
+    * Rest action to get ongoing live queries
+ */
 public class RestLiveQueriesAction extends BaseRestHandler {
-    static final Set<String> ALLOWED_METRICS =
-        MetricType.allMetricTypes().stream().map(MetricType::toString).collect(Collectors.toSet());
-
+    static final Set<String> ALLOWED_METRICS = MetricType.allMetricTypes().stream().map(MetricType::toString).collect(Collectors.toSet());
+    /**
+     * Constructor for RestLiveQueriesAction
+     */
     public RestLiveQueriesAction() {}
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesAction.java
@@ -1,11 +1,3 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- */
-
 package org.opensearch.plugin.insights.rules.resthandler.live_queries;
 
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.LIVE_QUERIES_BASE_URI;
@@ -32,15 +24,10 @@ import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.action.RestResponseListener;
 import org.opensearch.transport.client.node.NodeClient;
 
-/**
- * Rest action to get ongoing live queries
- */
 public class RestLiveQueriesAction extends BaseRestHandler {
-    static final Set<String> ALLOWED_METRICS = MetricType.allMetricTypes().stream().map(MetricType::toString).collect(Collectors.toSet());
+    static final Set<String> ALLOWED_METRICS =
+        MetricType.allMetricTypes().stream().map(MetricType::toString).collect(Collectors.toSet());
 
-    /**
-     * Constructor for RestLiveQueriesAction
-     */
     public RestLiveQueriesAction() {}
 
     @Override
@@ -64,14 +51,18 @@ public class RestLiveQueriesAction extends BaseRestHandler {
         final String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         final boolean verbose = request.paramAsBoolean("verbose", true);
         final String sortParam = request.param("sort", MetricType.LATENCY.toString());
+        final String wlmGroup = request.param("wlm_group", null);
+
         if (!ALLOWED_METRICS.contains(sortParam)) {
             throw new IllegalArgumentException(
                 String.format(Locale.ROOT, "request [%s] contains invalid sort metric type [%s]", request.path(), sortParam)
             );
         }
+
         final MetricType sortBy = MetricType.fromString(sortParam);
         final int size = request.paramAsInt("size", QueryInsightsSettings.DEFAULT_LIVE_QUERIES_SIZE);
-        return new LiveQueriesRequest(verbose, sortBy, size, nodesIds);
+
+        return new LiveQueriesRequest(verbose, sortBy, size, nodesIds, wlmGroup);
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -34,7 +34,7 @@ import org.opensearch.tasks.TaskInfo;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
-
+import static org.opensearch.plugin.insights.core.listener.QueryInsightsListener.DEFAULT_QUERY_GROUP_ID_SUPPLIER;
 /**
  * Transport action for fetching ongoing live queries
  */
@@ -99,14 +99,22 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                         if (request.isVerbose()) {
                             attributes.put(Attribute.DESCRIPTION, taskInfo.getDescription());
                             attributes.put(Attribute.IS_CANCELLED, taskInfo.isCancelled());
+                            String queryGroupId=taskInfo.getHeaders().get("queryGroupId");
+                            if (queryGroupId == null) {
+                                queryGroupId = DEFAULT_QUERY_GROUP_ID_SUPPLIER.get();
+                            }
+                            attributes.put(Attribute.QUERY_GROUP_ID, queryGroupId);
                         }
-
                         SearchQueryRecord record = new SearchQueryRecord(
                             timestamp,
                             measurements,
                             attributes,
                             taskInfo.getTaskId().toString()
                         );
+
+                        if (request.getWlmGroup() != null && !request.getWlmGroup().equals(attributes.get(Attribute.QUERY_GROUP_ID))) {
+                            continue;
+                        }
                         allFilteredRecords.add(record);
                     }
 

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequestTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequestTests.java
@@ -26,7 +26,8 @@ public class LiveQueriesRequestTests extends OpenSearchTestCase {
         int size = 5;
         String[] nodeIds = new String[] { "nodeA", "nodeB", "nodeC" };
 
-        LiveQueriesRequest originalRequest = new LiveQueriesRequest(verbose, sortBy, size, nodeIds);
+
+        LiveQueriesRequest originalRequest = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroup);
 
         BytesStreamOutput out = new BytesStreamOutput();
         originalRequest.writeTo(out);
@@ -65,7 +66,7 @@ public class LiveQueriesRequestTests extends OpenSearchTestCase {
         int size = 50;
         String[] nodeIds = { "node1", "node2" };
 
-        LiveQueriesRequest request = new LiveQueriesRequest(verbose, sortBy, size, nodeId, wlmGroup);
+        LiveQueriesRequest request = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroup);
 
         assertTrue(request.isVerbose());
         assertEquals(MetricType.CPU, request.getSortBy());

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequestTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequestTests.java
@@ -45,7 +45,7 @@ public class LiveQueriesRequestTests extends OpenSearchTestCase {
         int size = 3;
         String[] nodeIds = new String[0];
 
-        LiveQueriesRequest originalRequest = new LiveQueriesRequest(verbose, sortBy, size, nodeIds);
+        LiveQueriesRequest originalRequest = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroup);
 
         BytesStreamOutput out = new BytesStreamOutput();
         originalRequest.writeTo(out);
@@ -65,7 +65,7 @@ public class LiveQueriesRequestTests extends OpenSearchTestCase {
         int size = 50;
         String[] nodeIds = { "node1", "node2" };
 
-        LiveQueriesRequest request = new LiveQueriesRequest(verbose, sortBy, size, nodeIds);
+        LiveQueriesRequest request = new LiveQueriesRequest(verbose, sortBy, size, nodeId, wlmGroup);
 
         assertTrue(request.isVerbose());
         assertEquals(MetricType.CPU, request.getSortBy());


### PR DESCRIPTION
### Description

This PR introduces a feature to filter live queries by a specific Workload Management (WLM) group when making requests to the /insights/live_queries endpoint. The new functionality allows querying for live queries associated with a specific WLM group by adding the wlm_group query parameter.

### Example:

- Requesting live queries without a WLM group filter:


`curl -X GET "http://localhost:9200/_insights/live_queries"`


Response:

```
{
  "live_queries": [
    {
      "timestamp": 1754027813357,
      "id": "2Hxky-V2SAiQ1ocKogBqEw:5135",
      "is_cancelled": false,
      "query_group_id": "DEFAULT_WORKLOAD_GROUP",
      "node_id": "2Hxky-V2SAiQ1ocKogBqEw",
      "description": "indices[top_queries-2025.08.01-70586], search_type[QUERY_THEN_FETCH], source[{\"size\":500,...",
      "measurements": {
        "latency": { "number": 1256906917, "count": 1, "aggregationType": "NONE" },
        "memory": { "number": 0, "count": 1, "aggregationType": "NONE" },
        "cpu": { "number": 0, "count": 1, "aggregationType": "NONE" }
      }
    }
  ]
}
```

- Requesting live queries for a specific WLM group:

`curl -X GET "http://localhost:9200/_insights/live_queries?wlm_group=DEFAULT_WORKLOAD_GROUP"`

Response:

```
{
  "live_queries": [
    {
      "timestamp": 1754027813357,
      "id": "2Hxky-V2SAiQ1ocKogBqEw:5135",
      "is_cancelled": false,
      "query_group_id": "DEFAULT_WORKLOAD_GROUP",
      "node_id": "2Hxky-V2SAiQ1ocKogBqEw",
      "description": "indices[top_queries-2025.08.01-70586], search_type[QUERY_THEN_FETCH], source[{\"size\":500,...",
      "measurements": {
        "latency": { "number": 5185696167, "count": 1, "aggregationType": "NONE" },
        "memory": { "number": 9400, "count": 1, "aggregationType": "NONE" },
        "cpu": { "number": 1990000, "count": 1, "aggregationType": "NONE" }
      }
    }
  ]
}
```

- Requesting live queries for a non-existent WLM group:

`curl -X GET "http://localhost:9200/_insights/live_queries?wlm_group=Group1"`


Response:

```
{
  "live_queries": []
}

```
### Issues Resolved
Closes [#287] 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
