### PR TITLE
Use codecov v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           cp ./build/distributions/*.zip query-insights-artifacts
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
### Description
Error with `codecov/codecov-action@v5`
```
==> Running upload-coverage
      ./codecov  upload-coverage -t <redacted> --git-service github --gcov-executable gcov
[PYI-2039:ERROR] Failed to load Python shared library '/tmp/_MEIPSdhhp/libpython3.9.so.1.0': /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /tmp/_MEIPSdhhp/libpython3.9.so.1.0)
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
