### PR TITLE
Fix missing check for time range validation that from timestamp is before to timestamp

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
@@ -120,6 +120,17 @@ public class RestTopQueriesAction extends BaseRestHandler {
                 )
             );
         }
+        if (ZonedDateTime.parse(from).isAfter(ZonedDateTime.parse(to))) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ROOT,
+                    "request [%s] contains invalid time range. 'from' date [%s] must be before 'to' date [%s]",
+                    request.path(),
+                    from,
+                    to
+                )
+            );
+        }
     }
 
     @Override

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesActionTests.java
@@ -90,6 +90,27 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
         );
     }
 
+    public void testFromAfterTo() {
+        Map<String, String> params = new HashMap<>();
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        String from = now.plusHours(1).format(DateTimeFormatter.ISO_DATE_TIME);
+        String to = now.format(DateTimeFormatter.ISO_DATE_TIME);
+        params.put("from", from);
+        params.put("to", to);
+        RestRequest restRequest = buildRestRequest(params);
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> { RestTopQueriesAction.prepareRequest(restRequest); });
+        assertEquals(
+            String.format(
+                Locale.ROOT,
+                "request [%s] contains invalid time range. 'from' date [%s] must be before 'to' date [%s]",
+                restRequest.path(),
+                from,
+                to
+            ),
+            exception.getMessage()
+        );
+    }
+
     public void testMissingOneTimeParam() {
         Map<String, String> params = new HashMap<>();
         params.put("from", ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME));


### PR DESCRIPTION
### Description
This PR updates the time range validation for the Top N queries API. The validation now includes test coverage to ensure that requests with timestamp ranges have valid time ranges where the from date is before the to date.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
