### PR TITLE
Fix validation check for positive size parameter in live queries

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesAction.java
@@ -71,6 +71,11 @@ public class RestLiveQueriesAction extends BaseRestHandler {
         }
         final MetricType sortBy = MetricType.fromString(sortParam);
         final int size = request.paramAsInt("size", QueryInsightsSettings.DEFAULT_LIVE_QUERIES_SIZE);
+        if (size <= 0) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "request [%s] contains invalid size parameter [%d]. size must be positive", request.path(), size)
+            );
+        }
         return new LiveQueriesRequest(verbose, sortBy, size, nodesIds);
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/LiveQueriesRestIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/LiveQueriesRestIT.java
@@ -121,7 +121,7 @@ public class LiveQueriesRestIT extends QueryInsightsRestTestCase {
         Map<String, Object> nodes = (Map<String, Object>) nodesMap.get("nodes");
         String nodeId = nodes.keySet().iterator().next();
 
-        String[] params = new String[] { "?size=1", "", "?size=0", "?sort=cpu", "?verbose=false", "?nodeId=" + nodeId };
+        String[] params = new String[] { "?size=1", "", "?sort=cpu", "?verbose=false", "?nodeId=" + nodeId };
         Map<String, Boolean> foundParams = new java.util.HashMap<>();
         for (String param : params) {
             foundParams.put(param, false);
@@ -267,7 +267,7 @@ public class LiveQueriesRestIT extends QueryInsightsRestTestCase {
         String nodeId = nodes.keySet().iterator().next();
 
         // Define parameter combinations to test
-        String[] params = new String[] { "", "?verbose=false", "?sort=cpu", "?size=1", "?size=0", "?nodeId=" + nodeId };
+        String[] params = new String[] { "", "?verbose=false", "?sort=cpu", "?size=1", "?nodeId=" + nodeId };
         for (String param : params) {
             String uri = QueryInsightsSettings.LIVE_QUERIES_BASE_URI + param;
             Request req = new Request("GET", uri);

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesActionTests.java
@@ -141,8 +141,16 @@ public class RestLiveQueriesActionTests extends OpenSearchTestCase {
             .withParams(params)
             .withMethod(RestRequest.Method.GET)
             .build();
-        LiveQueriesRequest req = RestLiveQueriesAction.prepareRequest(request);
-        assertEquals(0, req.getSize());
+        assertThrows(IllegalArgumentException.class, () -> RestLiveQueriesAction.prepareRequest(request));
+    }
+
+    public void testPrepareRequestWithNegativeSize() {
+        Map<String, String> params = Map.of("size", "-1");
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath(QueryInsightsSettings.LIVE_QUERIES_BASE_URI)
+            .withParams(params)
+            .withMethod(RestRequest.Method.GET)
+            .build();
+        assertThrows(IllegalArgumentException.class, () -> RestLiveQueriesAction.prepareRequest(request));
     }
 
     public void testPrepareRequestInvalidVerbose() {


### PR DESCRIPTION
### Description
This PR updates the size validation for live queries so that it ensures that the size of live queries requested is a positive integer. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
