### PR TITLE
Filter out shard-level tasks from live queries

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -55,7 +55,7 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
 
     @Override
     protected void doExecute(final Task task, final LiveQueriesRequest request, final ActionListener<LiveQueriesResponse> listener) {
-        ListTasksRequest listTasksRequest = new ListTasksRequest().setDetailed(request.isVerbose()).setActions("indices:data/read/search*");
+        ListTasksRequest listTasksRequest = new ListTasksRequest().setDetailed(request.isVerbose()).setActions("indices:data/read/search");
 
         // Set nodes filter if provided in the request
         String[] requestedNodeIds = request.nodesIds();
@@ -70,7 +70,7 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                 try {
                     List<SearchQueryRecord> allFilteredRecords = new ArrayList<>();
                     for (TaskInfo taskInfo : taskResponse.getTasks()) {
-                        if (!taskInfo.getAction().startsWith("indices:data/read/search")) {
+                        if (!taskInfo.getAction().equals("indices:data/read/search")) {
                             continue;
                         }
                         long timestamp = taskInfo.getStartTime();

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesActionTests.java
@@ -143,7 +143,7 @@ public class TransportLiveQueriesActionTests extends OpenSearchTestCase {
         LiveQueriesRequest request = new LiveQueriesRequest(true);
         TaskInfo task1 = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 1000000L, "desc1", 500L, 1024L);
         TaskInfo task2 = createTaskInfo(node2, "indices:data/read/search", System.currentTimeMillis(), 2000000L, "desc2", 600L, 2048L);
-        TaskInfo nonSearchTask = createTaskInfo(
+        TaskInfo nonSearchTask1 = createTaskInfo(
             node1,
             "cluster:monitor/nodes/tasks/list",
             System.currentTimeMillis(),
@@ -152,7 +152,16 @@ public class TransportLiveQueriesActionTests extends OpenSearchTestCase {
             700L,
             4096L
         );
-        List<TaskInfo> tasks = List.of(task1, task2, nonSearchTask);
+        TaskInfo nonSearchTask2 = createTaskInfo(
+            node1,
+            "indices:data/read/search[phase/query]",
+            System.currentTimeMillis(),
+            3000000L,
+            "desc3",
+            700L,
+            4096L
+        );
+        List<TaskInfo> tasks = List.of(task1, task2, nonSearchTask1, nonSearchTask2);
         ListTasksResponse listTasksResponse = new ListTasksResponse(tasks, emptyList(), emptyList());
 
         // Mock the listTasks asynchronous call


### PR DESCRIPTION
### Description
When the Query Insights Live Queries api is called, we filter for active search tasks using the pattern `indices:data/read/search*` which includes both shard and request-level tasks. We should remove the trailing wildcard to exclude shard tasks.

```
// shard task
indices:data/read/search[phase/query]

// search task
indices:data/read/search
```
More shard actions: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/search/SearchTransportService.java#L88

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
