### PR TITLE
Change matchQuery to termQuery to correctly determine if query IDs match

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/utils/QueryInsightsQueryBuilder.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/utils/QueryInsightsQueryBuilder.java
@@ -182,7 +182,7 @@ public final class QueryInsightsQueryBuilder {
 
         // Add ID-specific or metric-type-specific filter
         if (id != null) {
-            query.must(QueryBuilders.matchQuery(ID, id));
+            query.must(QueryBuilders.termQuery(ID, id));
         } else {
             query.must(QueryBuilders.termQuery(TOP_N_QUERY + "." + metricType, true));
         }

--- a/src/main/resources/mappings/top-queries-record.json
+++ b/src/main/resources/mappings/top-queries-record.json
@@ -5,14 +5,8 @@
     "query_insights_feature_space": "top_n_queries"
   },
   "properties": {
-    "id" : {
-      "type" : "text",
-      "fields" : {
-        "keyword" : {
-          "type" : "keyword",
-          "ignore_above" : 256
-        }
-      }
+    "id": {
+      "type": "keyword"
     },
     "node_id" : {
       "type" : "text",

--- a/src/test/java/org/opensearch/plugin/insights/core/utils/QueryInsightsQueryBuilderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/utils/QueryInsightsQueryBuilderTests.java
@@ -427,4 +427,38 @@ public class QueryInsightsQueryBuilderTests extends OpenSearchTestCase {
         assertTrue("Should expand to open indices", searchRequest.indicesOptions().expandWildcardsOpen());
         assertFalse("Should not expand to closed indices", searchRequest.indicesOptions().expandWildcardsClosed());
     }
+
+    public void testIdQueryMatch() {
+        List<String> indexNames = Arrays.asList("test-index");
+        ZonedDateTime start = ZonedDateTime.now(ZoneOffset.UTC).minusHours(1);
+        ZonedDateTime end = ZonedDateTime.now(ZoneOffset.UTC);
+        Boolean verbose = true;
+        MetricType metricType = MetricType.LATENCY;
+
+        String[] testIds = {
+            "a7f3b2c8-5291-7634-9c4e-def123cd4589",
+            "b8e4c3d9-5291-8745-1a2b-abc456ef7890",
+            "c9f5d4ea-7634-5291-3c4d-fed789ab1234" };
+
+        for (String id : testIds) {
+            SearchRequest searchRequest = QueryInsightsQueryBuilder.buildTopNSearchRequest(indexNames, start, end, id, verbose, metricType);
+
+            SearchSourceBuilder sourceBuilder = searchRequest.source();
+            BoolQueryBuilder boolQuery = (BoolQueryBuilder) sourceBuilder.query();
+            List<QueryBuilder> mustClauses = boolQuery.must();
+
+            boolean foundExactIdMatch = false;
+            for (QueryBuilder mustClause : mustClauses) {
+                if (mustClause instanceof TermQueryBuilder) {
+                    TermQueryBuilder termQuery = (TermQueryBuilder) mustClause;
+                    if ("id".equals(termQuery.fieldName()) && id.equals(termQuery.value())) {
+                        foundExactIdMatch = true;
+                        break;
+                    }
+                }
+            }
+
+            assertTrue("Query should match the exact ID without tokenization: " + id, foundExactIdMatch);
+        }
+    }
 }


### PR DESCRIPTION
### Description
When requesting certain top n queries based on an ID, incorrect matches can be returned from the API as matchQuery uses OR logic, which leads to queries with similar IDs being matched (numbers between dashes). Changing to termQuery as well as changing id field mapping from "text" to "keyword" fixes this bug. 

### Issues Resolved
Closes https://github.com/opensearch-project/query-insights/issues/425.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
