### PR TITLE
Fix flaky testTopQueriesResponses by clearing stale records from queues when disabling metrics

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -272,6 +272,12 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     public void enableCollection(final MetricType metricType, final boolean enable) {
         this.enableCollect.put(metricType, enable);
         this.topQueriesServices.get(metricType).setEnabled(enable);
+
+        // Clear the queue when all features are disabled to prevent stale records from being processed
+        // when features are re-enabled
+        if (!enable && !isAnyFeatureEnabled()) {
+            queryRecordsQueue.clear();
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -207,6 +207,10 @@ public class TopQueriesService {
      */
     public void setEnabled(final boolean enabled) {
         this.enabled = enabled;
+        // Clear all snapshots when disabling to prevent stale queries from appearing when re-enabled
+        if (!enabled) {
+            drain();
+        }
     }
 
     /**
@@ -317,6 +321,12 @@ public class TopQueriesService {
                     .addTag(METRIC_TYPE_TAG, this.metricType.name())
                     .addTag(GROUPBY_TAG, this.queryGrouper.getGroupingType().name())
             );
+
+        // Return empty results when service is disabled
+        if (!enabled) {
+            return new ArrayList<>();
+        }
+
         // read from window snapshots
         final List<SearchQueryRecord> queries = new ArrayList<>(topQueriesCurrentSnapshot.get());
         if (includeLastWindow) {

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRestIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRestIT.java
@@ -49,7 +49,7 @@ public class TopQueriesRestIT extends QueryInsightsRestTestCase {
     public void testTopQueriesResponses() throws IOException, InterruptedException {
         // Disable all features first to clear any existing queries
         updateClusterSettings(this::disableTopQueriesSettings);
-        Thread.sleep(1000);
+        waitForEmptyTopQueriesResponse();
 
         // Enable only Top N Queries by latency feature
         updateClusterSettings(this::defaultTopQueriesSettings);
@@ -60,7 +60,7 @@ public class TopQueriesRestIT extends QueryInsightsRestTestCase {
 
         // Disable all features to clear queries
         updateClusterSettings(this::disableTopQueriesSettings);
-        Thread.sleep(1000);
+        waitForEmptyTopQueriesResponse();
 
         // Enable Top N Queries by resource usage
         updateClusterSettings(this::topQueriesByResourceUsagesSettings);


### PR DESCRIPTION
### Description
The TopQueriesRestIT.testTopQueriesResponses test was failing intermittently with assertion errors like:
```
AssertionError: expected:<5> but was:<6>
```
The test had a race condition (or more appropriately, issues in how we drain the records) caused by the interaction between two components:

1. QueryInsightsService maintains a shared `queryRecordsQueue` that buffers search query records
2. A background task drains this queue every 5 seconds and passes records to `TopQueriesService`
3. TopQueriesService stores and manages the top N queries

The race condition occurred as follows:

1. Search queries → Records added to `queryRecordsQueue`
2. Test disables all metrics → we don't clear `TopQueriesService` internal stores, nor the `queryRecordsQueue`
3. Test calls waitForEmptyTopQueriesResponse() → will probably time out because default window size is 5 minute.
4. Say above passes, the test then enables metrics and performs 5 new searches → 5 new records added to queue
5. Background drain task runs → Because we don't clean the `queryRecordsQueue`, it processes both old stale records (from step 1) + 5 new records
6. Assertion fails: expected 5, got 5+ records

So, the problem was that disabling the service didn't clear the shared queue, so stale records from previous test runs.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
