### PR TITLE
Use ARCHIVE test distribution for testing with testclusters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -318,7 +318,7 @@ tasks.named("integTest").configure {
 }
 
 testClusters.all {
-    testDistribution = "INTEG_TEST"
+    testDistribution = "ARCHIVE"
     // This installs our plugin into the testClusters
     plugin(project.tasks.bundlePlugin.archiveFile)
 


### PR DESCRIPTION
### Description

Use ARCHIVE test distribution for testing with testclusters

The `INTEG_TEST` distribution is a very minimal distribution for testing which only includes transport modules. The ARCHIVE distribution will use the latest min distro snapshot (at least that's my understanding - not sure how it actually translates to code).

### Issues Resolved

Fixes https://github.com/opensearch-project/query-insights/actions/runs/18180056333/job/52078406568?pr=439

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
