### PR TITLE
Increase group it retries to 20 [draft]

### DIFF
--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperBySimilarityIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperBySimilarityIT.java
@@ -131,8 +131,8 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
         Thread.sleep(QueryInsightsSettings.QUERY_RECORD_QUEUE_DRAIN_INTERVAL.millis());
 
         List<Map<String, Object>> topQueries = null;
-        // run ten times to make sure the records are drained to the top queries services
-        for (int i = 0; i < 10; i++) {
+        // run twenty times to make sure the records are drained to the top queries services
+        for (int i = 0; i < 20; i++) {
             // Parse the response to validate group structure
             Request request = new Request("GET", "/_insights/top_queries?type=latency");
             Response response = client().performRequest(request);
@@ -175,12 +175,12 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
                 return;
             }
 
-            if (i < 9) {
+            if (i < 19) {
                 Thread.sleep(QueryInsightsSettings.QUERY_RECORD_QUEUE_DRAIN_INTERVAL.millis());
             }
         }
         fail(
-            "Failed to validate groups after 10 attempts. Expected groups: "
+            "Failed to validate groups after 20 attempts. Expected groups: "
                 + Arrays.toString(expectedGroupSizes)
                 + ", but got: "
                 + (topQueries != null ? topQueries.size() : "null")


### PR DESCRIPTION
### Description
Increase grouper IT retries to 20 so that top n queries can be updated in time

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
