### PR TITLE
Move logic to configure the security plugin so that it does not eagerly run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -362,10 +362,6 @@ task integTestWithSecurity(type: RestIntegTestTask) {
   systemProperty "cluster.names",
     getClusters().stream().map(cluster -> cluster.getName()).collect(Collectors.joining(","))
 
-  getClusters().forEach { cluster ->
-    configureSecurityPlugin(cluster)
-  }
-
   dependsOn project.tasks.bundlePlugin
   testLogging {
     events "passed", "skipped", "failed"
@@ -385,6 +381,7 @@ task integTestWithSecurity(type: RestIntegTestTask) {
   doFirst {
     systemProperty 'cluster.debug', getDebug()
     getClusters().forEach { cluster ->
+      configureSecurityPlugin(cluster)
 
       String allTransportSocketURI = cluster.nodes.stream().flatMap { node ->
         node.getAllTransportPortURI().stream()


### PR DESCRIPTION
### Description

QI was always trying to download the security plugin regardless of what task was run. This PR moves the logic to only download it for integ tests w/ security.

### Issues Resolved

Resolves https://github.com/opensearch-project/query-insights/issues/473

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
