### PR TITLE
Remove index template

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -152,7 +152,6 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
             QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER,
             QueryInsightsSettings.TOP_N_EXPORTER_TYPE,
-            QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY,
             QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES,
             QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
         );

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.plugin.insights.core.exporter;
 
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TEMPLATE_PRIORITY;
-
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -76,10 +74,9 @@ public class QueryInsightsExporterFactory {
      * @param id id of the exporter so that exporters can be retrieved and reused across services
      * @param indexPattern the index pattern if creating an index exporter
      * @param indexMapping index mapping file
-     * @param templatePriority the priority value for the template
      * @return LocalIndexExporter the created exporter sink
      */
-    public LocalIndexExporter createLocalIndexExporter(String id, String indexPattern, String indexMapping, long templatePriority) {
+    public LocalIndexExporter createLocalIndexExporter(String id, String indexPattern, String indexMapping) {
         LocalIndexExporter exporter = new LocalIndexExporter(
             client,
             clusterService,
@@ -87,21 +84,8 @@ public class QueryInsightsExporterFactory {
             indexMapping,
             id
         );
-        exporter.setTemplatePriority(templatePriority);
         this.exporters.put(id, exporter);
         return exporter;
-    }
-
-    /**
-     * Create a local index exporter based on provided parameters, using default template priority
-     *
-     * @param id id of the exporter so that exporters can be retrieved and reused across services
-     * @param indexPattern the index pattern if creating an index exporter
-     * @param indexMapping index mapping file
-     * @return LocalIndexExporter the created exporter sink
-     */
-    public LocalIndexExporter createLocalIndexExporter(String id, String indexPattern, String indexMapping) {
-        return createLocalIndexExporter(id, indexPattern, indexMapping, DEFAULT_TEMPLATE_PRIORITY);
     }
 
     /**
@@ -121,14 +105,12 @@ public class QueryInsightsExporterFactory {
      *
      * @param exporter The exporter to update
      * @param indexPattern the index pattern if creating a index exporter
-     * @param templatePriority the priority value for the template (for LocalIndexExporter)
      * @return QueryInsightsExporter the updated exporter sink
      */
-    public QueryInsightsExporter updateExporter(QueryInsightsExporter exporter, String indexPattern, long templatePriority) {
+    public QueryInsightsExporter updateExporter(QueryInsightsExporter exporter, String indexPattern) {
         if (exporter.getClass() == LocalIndexExporter.class) {
             LocalIndexExporter localExporter = (LocalIndexExporter) exporter;
             localExporter.setIndexPattern(DateTimeFormatter.ofPattern(indexPattern, Locale.ROOT));
-            localExporter.setTemplatePriority(templatePriority);
         }
         return exporter;
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -17,7 +17,6 @@ import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.MAX_
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.MIN_DELETE_AFTER_VALUE;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.QUERY_INSIGHTS_EXECUTOR;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY;
 import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.TOP_N_EXPORTER_TYPE;
 
 import java.io.IOException;
@@ -191,12 +190,9 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
                 (this::setExporterDeleteAfterAndDelete),
                 (this::validateExporterDeleteAfter)
             );
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(TOP_N_EXPORTER_TEMPLATE_PRIORITY, this::setTemplatePriority, this::validateTemplatePriority);
 
         this.setExporterDeleteAfterAndDelete(clusterService.getClusterSettings().get(TOP_N_EXPORTER_DELETE_AFTER));
         this.setExporterAndReaderType(SinkType.parse(clusterService.getClusterSettings().get(TOP_N_EXPORTER_TYPE)));
-        this.setTemplatePriority(clusterService.getClusterSettings().get(TOP_N_EXPORTER_TEMPLATE_PRIORITY));
         this.searchQueryCategorizer = SearchQueryCategorizer.getInstance(metricsRegistry);
         this.enableSearchQueryMetricsFeature(false);
         this.groupingType = DEFAULT_GROUPING_TYPE;
@@ -550,38 +546,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      */
     public void validateExporterType(final String exporterType) {
         queryInsightsExporterFactory.validateExporterType(exporterType);
-    }
-
-    /**
-     * Set the template priority for all top queries exporters
-     *
-     * @param templatePriority the priority value to use for templates
-     */
-    public void setTemplatePriority(final long templatePriority) {
-        logger.info("Setting query insights index template priority to [{}]", templatePriority);
-        final QueryInsightsExporter topQueriesExporter = queryInsightsExporterFactory.getExporter(TOP_QUERIES_EXPORTER_ID);
-        if (topQueriesExporter != null && topQueriesExporter.getClass() == LocalIndexExporter.class) {
-            logger.debug("Updating query insights index template priority for top queries exporter to [{}]", templatePriority);
-            queryInsightsExporterFactory.updateExporter(
-                topQueriesExporter,
-                QueryInsightsSettings.DEFAULT_TOP_N_QUERIES_INDEX_PATTERN,
-                templatePriority
-            );
-        }
-    }
-
-    /**
-     * Validate the template priority
-     *
-     * @param templatePriority the priority value to validate
-     */
-    public void validateTemplatePriority(final long templatePriority) {
-        if (templatePriority < 0) {
-            OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.INVALID_EXPORTER_TYPE_FAILURES);
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "Invalid template priority setting [%d], value should be a non-negative long.", templatePriority)
-            );
-        }
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -260,10 +260,6 @@ public class QueryInsightsSettings {
      */
     public static final String DEFAULT_TOP_QUERIES_EXPORTER_TYPE = SinkType.LOCAL_INDEX.toString();
     /**
-     * Default template priority for top queries indices
-     */
-    public static final long DEFAULT_TEMPLATE_PRIORITY = 1847L;
-    /**
      * Default Top N local indices retention period in days
      */
     public static final int DEFAULT_DELETE_AFTER_VALUE = 7;
@@ -314,17 +310,6 @@ public class QueryInsightsSettings {
      * Index pattern glob for matching top query indices
      */
     public static final String TOP_QUERIES_INDEX_PATTERN_GLOB = TOP_QUERIES_INDEX_PREFIX + "-*";
-
-    /**
-     * Setting for Top N local indices template priority
-     */
-    public static final Setting<Long> TOP_N_EXPORTER_TEMPLATE_PRIORITY = Setting.longSetting(
-        TOP_N_QUERIES_EXPORTER_PREFIX + ".template_priority",
-        DEFAULT_TEMPLATE_PRIORITY,
-        0L, // min value is 0
-        Setting.Property.Dynamic,
-        Setting.Property.NodeScope
-    );
 
     /**
      * Get the enabled setting based on type

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsClusterIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsClusterIT.java
@@ -225,7 +225,7 @@ public class QueryInsightsClusterIT extends QueryInsightsRestTestCase {
         }
 
         // Wait for processing
-        Thread.sleep(6000);
+        Thread.sleep(10000);
 
         // Verify queries were recorded (with retries for timing issues)
         List<Map<String, Object>> allQueries = null;

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -84,7 +84,6 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
                 QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING,
                 QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER,
                 QueryInsightsSettings.TOP_N_EXPORTER_TYPE,
-                QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY,
                 QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES,
                 QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
             ),

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
@@ -610,16 +610,6 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
         client().performRequest(resetReq);
     }
 
-    protected void cleanupIndextemplate() throws IOException, InterruptedException {
-        Thread.sleep(3000);
-
-        try {
-            client().performRequest(new Request("DELETE", "/_index_template"));
-        } catch (ResponseException e) {
-            logger.warning("Failed to delete /_index_template: " + e.getMessage());
-        }
-    }
-
     protected void checkLocalIndices() throws IOException {
         // Retry logic to handle timing issues
         String fullIndexName = null;
@@ -704,51 +694,6 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
 
             List<Map<String, Object>> taskResourceUsages = (List<Map<String, Object>>) source.get("task_resource_usages");
             Assert.assertTrue("Expected non-empty task_resource_usages", taskResourceUsages.size() > 0);
-        }
-    }
-
-    protected void checkQueryInsightsIndexTemplate() throws IOException {
-        Request request = new Request("GET", "/_index_template?pretty");
-        Response response = client().performRequest(request);
-        byte[] bytes = response.getEntity().getContent().readAllBytes();
-
-        try (
-            XContentParser parser = JsonXContent.jsonXContent.createParser(
-                NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                bytes
-            )
-        ) {
-            Map<String, Object> parsed = parser.map();
-
-            List<Map<String, Object>> templates = (List<Map<String, Object>>) parsed.get("index_templates");
-            Assert.assertNotNull("Expected index_templates to exist", templates);
-            Assert.assertFalse("Expected at least one index_template", templates.isEmpty());
-
-            Map<String, Object> firstTemplate = templates.get(0);
-            Assert.assertEquals("query_insights_top_queries_template", firstTemplate.get("name"));
-
-            Map<String, Object> indexTemplate = (Map<String, Object>) firstTemplate.get("index_template");
-
-            List<String> indexPatterns = (List<String>) indexTemplate.get("index_patterns");
-            Assert.assertTrue("Expected index_patterns to include top_queries-*", indexPatterns.contains("top_queries-*"));
-
-            Map<String, Object> template = (Map<String, Object>) indexTemplate.get("template");
-            Map<String, Object> settings = (Map<String, Object>) template.get("settings");
-            Map<String, Object> indexSettings = (Map<String, Object>) settings.get("index");
-            Assert.assertEquals("1", indexSettings.get("number_of_shards"));
-            Assert.assertEquals("0-2", indexSettings.get("auto_expand_replicas"));
-
-            Map<String, Object> mappings = (Map<String, Object>) template.get("mappings");
-            Map<String, Object> meta = (Map<String, Object>) mappings.get("_meta");
-            Assert.assertEquals(1, ((Number) meta.get("schema_version")).intValue());
-            Assert.assertEquals("top_n_queries", meta.get("query_insights_feature_space"));
-
-            Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
-            Assert.assertTrue("Expected 'total_shards' in mappings", properties.containsKey("total_shards"));
-            Assert.assertTrue("Expected 'search_type' in mappings", properties.containsKey("search_type"));
-            Assert.assertTrue("Expected 'task_resource_usages' in mappings", properties.containsKey("task_resource_usages"));
-            Assert.assertTrue("Expected 'measurements' in mappings", properties.containsKey("measurements"));
         }
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -357,7 +357,6 @@ final public class QueryInsightsTestUtils {
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_NAME);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_GROUPING_FIELD_TYPE);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER);
-        clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_EXPORTER_TEMPLATE_PRIORITY);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES);
         clusterSettings.registerSetting(QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING);
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/LocalIndexExporterTests.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.DEFAULT_TEMPLATE_PRIORITY;
 
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -29,23 +28,17 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
-import org.opensearch.action.admin.indices.template.get.GetComposableIndexTemplateAction;
-import org.opensearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.opensearch.action.bulk.BulkAction;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.action.support.replication.ClusterStateCreationUtils;
 import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.metadata.ComposableIndexTemplate;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
@@ -106,6 +99,7 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
         ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         ClusterState state = ClusterStateCreationUtils.stateWithActivePrimary(indexName, true, 1, 0);
         clusterService = ClusterServiceUtils.createClusterService(threadPool, state.getNodes().getLocalNode(), clusterSettings);
+        ClusterServiceUtils.setState(clusterService, state);
 
         // Create local index exporter
         localIndexExporter = new LocalIndexExporter(client, clusterService, format, "", "id");
@@ -145,9 +139,6 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
         // bulk was called (to add records to existing index)
         verify(exporterSpy).bulk(anyString(), eq(records));
 
-        // ensureTemplateExists was NOT called
-        verify(exporterSpy, never()).ensureTemplateExists();
-
         // createIndexAndBulk was NOT called
         verify(exporterSpy, never()).createIndexAndBulk(anyString(), any());
     }
@@ -161,66 +152,15 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
 
         // to simulate index doesn't exist
         doReturn(false).when(exporterSpy).checkIndexExists(anyString());
-        CompletableFuture<Boolean> completedFuture = CompletableFuture.completedFuture(true);
-        doReturn(completedFuture).when(exporterSpy).ensureTemplateExists();
         doAnswer(invocation -> null).when(exporterSpy).createIndexAndBulk(anyString(), any());
         List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(3);
 
         exporterSpy.export(records);
 
-        // ensureTemplateExists was called (since index doesn't exist)
-        verify(exporterSpy).ensureTemplateExists();
         // createIndexAndBulk was called
         verify(exporterSpy).createIndexAndBulk(anyString(), eq(records));
         // bulk was NOT called directly (it's called inside createIndexAndBulk)
         verify(exporterSpy, never()).bulk(anyString(), any());
-    }
-
-    public void testExportWaitsForTemplateCreation() throws Exception {
-        Client mockClient = mock(Client.class);
-        ClusterService mockClusterService = mock(ClusterService.class);
-        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
-        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "{}", "id");
-        LocalIndexExporter exporterSpy = spy(exporter);
-
-        // simulate index doesn't exist
-        doReturn(false).when(exporterSpy).checkIndexExists(anyString());
-        CompletableFuture<Boolean> templateFuture = new CompletableFuture<>();
-        doReturn(templateFuture).when(exporterSpy).ensureTemplateExists();
-
-        // Use a CountDownLatch to track if createIndexAndBulk is called
-        CountDownLatch createIndexCalled = new CountDownLatch(1);
-        doAnswer(invocation -> {
-            createIndexCalled.countDown();
-            return null;
-        }).when(exporterSpy).createIndexAndBulk(anyString(), any());
-
-        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(3);
-
-        // call export in a separate thread so it doesn't block our test..
-        Thread exportThread = new Thread(() -> {
-            try {
-                exporterSpy.export(records);
-            } catch (Exception e) {
-                fail("Export should not throw an exception: " + e.getMessage());
-            }
-        });
-        exportThread.start();
-        Thread.sleep(100);
-        // createIndexAndBulk has NOT been called yet - it should be waiting for template..
-        assertEquals("createIndexAndBulk should not be called until template is created", 1, createIndexCalled.getCount());
-
-        // Complete the template future
-        templateFuture.complete(true);
-
-        // Wait for createIndexAndBulk to be called
-        boolean createIndexWasCalled = createIndexCalled.await(1, TimeUnit.SECONDS);
-
-        // Verify createIndexAndBulk was eventually called after template was created
-        assertTrue("createIndexAndBulk should be called after template is created", createIndexWasCalled);
-
-        // Clean up the thread
-        exportThread.join(1000);
     }
 
     @SuppressWarnings("unchecked")
@@ -251,87 +191,6 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
         final DateTimeFormatter newFormatter = DateTimeFormatter.ofPattern("YYYY-MM-dd", Locale.ROOT);
         localIndexExporter.setIndexPattern(newFormatter);
         assert (localIndexExporter.getIndexPattern() == newFormatter);
-    }
-
-    public void testGetAndSetTemplatePriority() {
-        final long newTemplatePriority = 2000L;
-        localIndexExporter.setTemplatePriority(newTemplatePriority);
-        assertEquals(newTemplatePriority, localIndexExporter.getTemplatePriority());
-    }
-
-    /**
-     * Test that ensureTemplateExists creates a V2 template correctly when it doesn't exist
-     */
-    public void testEnsureTemplateExistsCreatesV2Template() throws Exception {
-        Client mockClient = mock(Client.class);
-        ClusterService mockClusterService = mock(ClusterService.class);
-
-        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
-        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "{}", "id");
-        LocalIndexExporter exporterSpy = spy(exporter);
-
-        // Set a custom priority to verify it's used in the template
-        exporterSpy.setTemplatePriority(5000L);
-
-        // make ensureTemplateExists to complete successfully
-        CompletableFuture<Boolean> completedFuture = CompletableFuture.completedFuture(true);
-        doReturn(completedFuture).when(exporterSpy).ensureTemplateExists();
-
-        CompletableFuture<Boolean> future = exporterSpy.ensureTemplateExists();
-        assertTrue(future.get(5, TimeUnit.SECONDS));
-
-        assertEquals("Template priority should be set correctly", 5000L, exporterSpy.getTemplatePriority());
-    }
-
-    /**
-     * Test that ensureTemplateExists skips creating a template when it already exists
-     */
-    public void testEnsureTemplateExistsSkipsWhenTemplateExists() throws Exception {
-        Client mockClient = mock(Client.class);
-
-        ClusterService mockClusterService = mock(ClusterService.class);
-        ClusterState mockState = mock(ClusterState.class);
-        org.opensearch.cluster.metadata.Metadata metadata = mock(org.opensearch.cluster.metadata.Metadata.class);
-        when(metadata.templates()).thenReturn(Map.of());
-        when(metadata.templatesV2()).thenReturn(Map.of());
-        when(mockState.getMetadata()).thenReturn(metadata);
-        when(mockClusterService.state()).thenReturn(mockState);
-
-        // Mock the GetComposableIndexTemplateAction call to return that the template exists
-        doAnswer(invocation -> {
-            GetComposableIndexTemplateAction.Response mockResponse = mock(GetComposableIndexTemplateAction.Response.class);
-            ComposableIndexTemplate mockTemplate = mock(ComposableIndexTemplate.class);
-            when(mockTemplate.priority()).thenReturn(DEFAULT_TEMPLATE_PRIORITY);
-            when(mockResponse.indexTemplates()).thenReturn(Map.of("query_insights_top_queries_template", mockTemplate));
-
-            ActionListener listener = invocation.getArgument(2);
-            listener.onResponse(mockResponse);
-
-            return null;
-        }).when(mockClient)
-            .execute(
-                eq(GetComposableIndexTemplateAction.INSTANCE),
-                any(GetComposableIndexTemplateAction.Request.class),
-                any(ActionListener.class)
-            );
-
-        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "{}", "id");
-
-        CompletableFuture<Boolean> future = exporter.ensureTemplateExists();
-        Boolean result = future.get(5, TimeUnit.SECONDS);
-
-        assertTrue("Template check should be successful", result);
-
-        verify(mockClient).execute(
-            eq(GetComposableIndexTemplateAction.INSTANCE),
-            any(GetComposableIndexTemplateAction.Request.class),
-            any(org.opensearch.core.action.ActionListener.class)
-        );
-        verify(mockClient, never()).execute(
-            eq(PutComposableIndexTemplateAction.INSTANCE),
-            any(PutComposableIndexTemplateAction.Request.class),
-            any(org.opensearch.core.action.ActionListener.class)
-        );
     }
 
     /**
@@ -403,4 +262,71 @@ public class LocalIndexExporterTests extends OpenSearchTestCase {
         // Verify there is no number_of_replicas setting.
         assertNull(settings.get("index.number_of_replicas"));
     }
+
+    /**
+     * Test that export flow directly creates index with mapping when index doesn't exist
+     */
+    public void testExportDirectlyCreatesIndexWithMapping() throws IOException {
+        Client mockClient = mock(Client.class);
+        ClusterService mockClusterService = mock(ClusterService.class);
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
+        String customMapping = "{\"properties\":{\"test_field\":{\"type\":\"keyword\"}}}";
+        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, customMapping, "id");
+        LocalIndexExporter exporterSpy = spy(exporter);
+
+        // Mock index doesn't exist
+        doReturn(false).when(exporterSpy).checkIndexExists(anyString());
+        doAnswer(invocation -> null).when(exporterSpy).createIndexAndBulk(anyString(), any());
+
+        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(2);
+        exporterSpy.export(records);
+
+        // Verify createIndexAndBulk was called with the custom mapping
+        verify(exporterSpy).createIndexAndBulk(anyString(), eq(records));
+    }
+
+    /**
+     * Test that createIndexAndBulk sets the correct mapping in CreateIndexRequest
+     */
+    public void testCreateIndexAndBulkSetsMapping() throws IOException {
+        String customMapping = "{\"properties\":{\"custom_field\":{\"type\":\"text\"}}}";
+        LocalIndexExporter exporterSpy = spy(new LocalIndexExporter(client, clusterService, format, customMapping, "id"));
+
+        ArgumentCaptor<CreateIndexRequest> requestCaptor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+
+        // Mock the client.admin().indices().create() call
+        AdminClient adminClient = mock(AdminClient.class);
+        IndicesAdminClient indicesClient = mock(IndicesAdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesClient);
+
+        doNothing().when(indicesClient).create(requestCaptor.capture(), any(ActionListener.class));
+        exporterSpy.createIndexAndBulk("test-index", Collections.emptyList());
+
+        // Verify the captured request has the correct mapping
+        CreateIndexRequest capturedRequest = requestCaptor.getValue();
+        assertEquals("test-index", capturedRequest.index());
+        assertEquals(customMapping, capturedRequest.mappings());
+    }
+
+    /**
+     * Test that export works correctly when mapping is empty
+     */
+    public void testExportWithEmptyMapping() throws IOException {
+        Client mockClient = mock(Client.class);
+        ClusterService mockClusterService = mock(ClusterService.class);
+        DateTimeFormatter format = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT);
+        LocalIndexExporter exporter = new LocalIndexExporter(mockClient, mockClusterService, format, "", "id");
+        LocalIndexExporter exporterSpy = spy(exporter);
+
+        doReturn(false).when(exporterSpy).checkIndexExists(anyString());
+        doAnswer(invocation -> null).when(exporterSpy).createIndexAndBulk(anyString(), any());
+
+        List<SearchQueryRecord> records = QueryInsightsTestUtils.generateQueryInsightRecords(1);
+        exporterSpy.export(records);
+
+        // Verify createIndexAndBulk was called with empty mapping converted to {}
+        verify(exporterSpy).createIndexAndBulk(anyString(), eq(records));
+    }
+
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactoryTests.java
@@ -19,7 +19,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
-import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.telemetry.metrics.Counter;
 import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.test.ClusterServiceUtils;
@@ -90,36 +89,8 @@ public class QueryInsightsExporterFactoryTests extends OpenSearchTestCase {
             "",
             "id"
         );
-        queryInsightsExporterFactory.updateExporter(exporter, "yyyy-MM-dd-HH", 0L);
+        queryInsightsExporterFactory.updateExporter(exporter, "yyyy-MM-dd-HH");
         assertEquals(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH", Locale.ROOT).toString(), exporter.getIndexPattern().toString());
-    }
-
-    public void testCreateLocalIndexExporterWithPriority() {
-        QueryInsightsExporterFactory factory = new QueryInsightsExporterFactory(client, clusterService);
-        LocalIndexExporter exporter = factory.createLocalIndexExporter("test-id", "YYYY.MM.dd", "mapping.json", 3000L);
-
-        assertEquals(3000L, exporter.getTemplatePriority());
-        assertEquals("test-id", exporter.getId());
-        assertNotNull(exporter.getIndexPattern());
-    }
-
-    public void testUpdateExporterWithPriority() {
-        // Create a new factory
-        Client mockClient = mock(Client.class);
-        ClusterService mockClusterService = mock(ClusterService.class);
-        QueryInsightsExporterFactory factory = new QueryInsightsExporterFactory(mockClient, mockClusterService);
-
-        // Create a new exporter with default priority
-        LocalIndexExporter exporter = factory.createLocalIndexExporter("test-id", "YYYY.MM.dd", "mapping.json");
-
-        // Verify default priority
-        assertEquals(QueryInsightsSettings.DEFAULT_TEMPLATE_PRIORITY, exporter.getTemplatePriority());
-
-        // Update with new priority
-        factory.updateExporter(exporter, "YYYY.MM.dd", 5000L);
-
-        // Verify updated priority
-        assertEquals(5000L, exporter.getTemplatePriority());
     }
 
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterIT.java
@@ -38,8 +38,6 @@ public class QueryInsightsExporterIT extends QueryInsightsRestTestCase {
 
         Thread.sleep(70000); // Allow time for export to local index
         checkLocalIndices();
-        checkQueryInsightsIndexTemplate();
-        cleanupIndextemplate();
         disableLocalIndexExporter();
         defaultExporterSettings();// Re-enabling the Local Index
         setLocalIndexToDebug();// Ensuring it is able to toggle Local to Debug


### PR DESCRIPTION
### Description
Removed index template from LocalIndexExporter to solely rely on explicit index mappings to create new indexes. Mapping is always applied during index creation and takes precedence over index templates in  OpenSearch, meaning that as long as our mapping has everything we need in our index, it will be there for index creation. User index templates would still be applied for any fields not defined in our mapping, only filling in the gaps in fields that we do not use in query insights. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Sub PR of https://github.com/opensearch-project/query-insights/pull/424