### PR TITLE
Fix cluster setting validation

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactory.java
@@ -18,8 +18,6 @@ import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
-import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -60,27 +58,6 @@ public class QueryInsightsExporterFactory {
         this.threadPool = threadPool;
         this.repositoriesServiceSupplier = repositoriesServiceSupplier;
         this.exporters = new HashMap<>();
-    }
-
-    /**
-     * Validate exporter sink config
-     *
-     * @param exporterType exporter sink type
-     * @throws IllegalArgumentException if provided exporter sink config settings are invalid
-     */
-    public void validateExporterType(final String exporterType) throws IllegalArgumentException {
-        // Disable exporter if the EXPORTER_TYPE setting is null
-        if (exporterType == null) {
-            return;
-        }
-        try {
-            SinkType.parse(exporterType);
-        } catch (IllegalArgumentException e) {
-            OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.INVALID_EXPORTER_TYPE_FAILURES);
-            throw new IllegalArgumentException(
-                String.format(Locale.ROOT, "Invalid exporter type [%s], type should be one of %s", exporterType, SinkType.allSinkTypes())
-            );
-        }
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -54,7 +54,6 @@ import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
-import reactor.util.annotation.NonNull;
 
 /**
  * The listener for query insights services.
@@ -118,51 +117,26 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
             clusterService.getClusterSettings()
                 .addSettingsUpdateConsumer(getTopNEnabledSetting(type), v -> this.setEnableTopQueries(type, v));
             clusterService.getClusterSettings()
-                .addSettingsUpdateConsumer(
-                    getTopNSizeSetting(type),
-                    v -> this.queryInsightsService.setTopNSize(type, v),
-                    v -> this.queryInsightsService.validateTopNSize(type, v)
-                );
+                .addSettingsUpdateConsumer(getTopNSizeSetting(type), v -> this.queryInsightsService.setTopNSize(type, v));
             clusterService.getClusterSettings()
-                .addSettingsUpdateConsumer(
-                    getTopNWindowSizeSetting(type),
-                    v -> this.queryInsightsService.setWindowSize(type, v),
-                    v -> this.queryInsightsService.validateWindowSize(type, v)
-                );
+                .addSettingsUpdateConsumer(getTopNWindowSizeSetting(type), v -> this.queryInsightsService.setWindowSize(type, v));
 
             this.setEnableTopQueries(type, clusterService.getClusterSettings().get(getTopNEnabledSetting(type)));
-            this.queryInsightsService.validateTopNSize(type, clusterService.getClusterSettings().get(getTopNSizeSetting(type)));
             this.queryInsightsService.setTopNSize(type, clusterService.getClusterSettings().get(getTopNSizeSetting(type)));
-            this.queryInsightsService.validateWindowSize(type, clusterService.getClusterSettings().get(getTopNWindowSizeSetting(type)));
             this.queryInsightsService.setWindowSize(type, clusterService.getClusterSettings().get(getTopNWindowSizeSetting(type)));
         }
 
         // Settings endpoints set for grouping top n queries
         clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                TOP_N_QUERIES_GROUP_BY,
-                v -> this.queryInsightsService.setGrouping(v),
-                v -> this.queryInsightsService.validateGrouping(v)
-            );
-        this.queryInsightsService.validateGrouping(clusterService.getClusterSettings().get(TOP_N_QUERIES_GROUP_BY));
+            .addSettingsUpdateConsumer(TOP_N_QUERIES_GROUP_BY, v -> this.queryInsightsService.setGrouping(v));
         this.queryInsightsService.setGrouping(clusterService.getClusterSettings().get(TOP_N_QUERIES_GROUP_BY));
 
         clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N,
-                v -> this.queryInsightsService.setMaximumGroups(v),
-                v -> this.queryInsightsService.validateMaximumGroups(v)
-            );
-        this.queryInsightsService.validateMaximumGroups(clusterService.getClusterSettings().get(TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N));
+            .addSettingsUpdateConsumer(TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N, v -> this.queryInsightsService.setMaximumGroups(v));
         this.queryInsightsService.setMaximumGroups(clusterService.getClusterSettings().get(TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N));
 
         clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES,
-                this::setExcludedIndices,
-                this::validateExcludedIndices
-            );
-        validateExcludedIndices(clusterService.getClusterSettings().get(TOP_N_QUERIES_EXCLUDED_INDICES));
+            .addSettingsUpdateConsumer(QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES, this::setExcludedIndices);
         setExcludedIndices(clusterService.getClusterSettings().get(TOP_N_QUERIES_EXCLUDED_INDICES));
 
         // Internal settings for grouping attributes
@@ -396,24 +370,6 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         } catch (Exception e) {
             OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.DATA_INGEST_EXCEPTIONS);
             log.error(String.format(Locale.ROOT, "fail to ingest query insight data, error: %s", e));
-        }
-    }
-
-    /**
-     * Validate the index name for excluded indices
-     * @param excludedIndices list of index to validate
-     */
-    public void validateExcludedIndices(@NonNull List<String> excludedIndices) {
-        for (String index : excludedIndices) {
-            if (index == null) {
-                throw new IllegalArgumentException("Excluded index name cannot be null.");
-            }
-            if (index.isBlank()) {
-                throw new IllegalArgumentException("Excluded index name cannot be blank.");
-            }
-            if (index.chars().anyMatch(Character::isUpperCase)) {
-                throw new IllegalArgumentException("Index name must be lowercase.");
-            }
         }
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/LocalIndexLifecycleManager.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/LocalIndexLifecycleManager.java
@@ -13,7 +13,6 @@ import static org.opensearch.plugin.insights.core.service.TopQueriesService.isTo
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -88,26 +87,6 @@ class LocalIndexLifecycleManager {
             deleteAllTopNIndices();
         } else {
             deleteExpiredTopNIndices();
-        }
-    }
-
-    /**
-     * Validate the delete after value
-     *
-     * @param deleteAfter the number of days after which Top N local indices should be deleted
-     */
-    void validateDeleteAfter(final int deleteAfter) {
-        if (deleteAfter < QueryInsightsSettings.MIN_DELETE_AFTER_VALUE || deleteAfter > QueryInsightsSettings.MAX_DELETE_AFTER_VALUE) {
-            OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.INVALID_EXPORTER_TYPE_FAILURES);
-            throw new IllegalArgumentException(
-                String.format(
-                    Locale.ROOT,
-                    "Invalid delete_after_days setting [%d], value should be an integer between %d and %d.",
-                    deleteAfter,
-                    QueryInsightsSettings.MIN_DELETE_AFTER_VALUE,
-                    QueryInsightsSettings.MAX_DELETE_AFTER_VALUE
-                )
-            );
         }
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -176,22 +176,14 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
             );
         }
         clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                TOP_N_EXPORTER_TYPE,
-                (v -> setExporterAndReaderType(SinkType.parse(v))),
-                (this::validateExporterType)
-            );
+            .addSettingsUpdateConsumer(TOP_N_EXPORTER_TYPE, (v -> setExporterAndReaderType(SinkType.parse(v))));
         this.localIndexLifecycleManager = new LocalIndexLifecycleManager(
             threadPool,
             client,
             clusterService.getClusterSettings().get(TOP_N_EXPORTER_DELETE_AFTER)
         );
         clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(
-                TOP_N_EXPORTER_DELETE_AFTER,
-                (localIndexLifecycleManager::setDeleteAfterAndDelete),
-                (localIndexLifecycleManager::validateDeleteAfter)
-            );
+            .addSettingsUpdateConsumer(TOP_N_EXPORTER_DELETE_AFTER, (localIndexLifecycleManager::setDeleteAfterAndDelete));
         queryInsightsExporterFactory.createRemoteRepositoryExporter(
             TOP_QUERIES_REMOTE_EXPORTER_ID,
             clusterService.getClusterSettings().get(REMOTE_EXPORTER_REPOSITORY),
@@ -204,8 +196,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(REMOTE_EXPORTER_REPOSITORY, this::updateRemoteExporterRepository);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(REMOTE_EXPORTER_PATH, this::updateRemoteExporterPath);
 
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(TOP_N_QUERIES_FILTER_BY_MODE, this::setFilterByMode, this::validateFilterByMode);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(TOP_N_QUERIES_FILTER_BY_MODE, this::setFilterByMode);
         this.filterByMode = FilterByMode.fromString(clusterService.getClusterSettings().get(TOP_N_QUERIES_FILTER_BY_MODE));
 
         this.setExporterAndReaderType(SinkType.parse(clusterService.getClusterSettings().get(TOP_N_EXPORTER_TYPE)));
@@ -305,14 +296,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Validate grouping given grouping type setting
-     * @param groupingTypeSetting grouping setting
-     */
-    public void validateGrouping(final String groupingTypeSetting) {
-        GroupingType.getGroupingTypeFromSettingAndValidate(groupingTypeSetting);
-    }
-
-    /**
      * Set grouping
      * @param groupingTypeSetting grouping
      */
@@ -336,23 +319,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     public void setMaximumGroups(final int maxGroups) {
         for (MetricType metricType : MetricType.allMetricTypes()) {
             this.topQueriesServices.get(metricType).setMaxGroups(maxGroups);
-        }
-    }
-
-    /**
-     * Validate max number of groups. Should be between 1 and MAX_GROUPS_LIMIT
-     * @param maxGroups maximum number of groups that should be tracked when calculating Top N groups
-     */
-    public void validateMaximumGroups(final int maxGroups) {
-        if (maxGroups < 0 || maxGroups > QueryInsightsSettings.MAX_GROUPS_EXCLUDING_TOPN_LIMIT) {
-            throw new IllegalArgumentException(
-                "Max groups setting"
-                    + " should be between 0 and "
-                    + QueryInsightsSettings.MAX_GROUPS_EXCLUDING_TOPN_LIMIT
-                    + ", was ("
-                    + maxGroups
-                    + ")"
-            );
         }
     }
 
@@ -424,18 +390,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Validate the window size config for a metricType
-     *
-     * @param type {@link MetricType}
-     * @param windowSize {@link TimeValue}
-     */
-    public void validateWindowSize(final MetricType type, final TimeValue windowSize) {
-        if (topQueriesServices.containsKey(type)) {
-            topQueriesServices.get(type).validateWindowSize(windowSize);
-        }
-    }
-
-    /**
      * Set window size for a metricType
      *
      * @param type {@link MetricType}
@@ -444,18 +398,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     public void setWindowSize(final MetricType type, final TimeValue windowSize) {
         if (topQueriesServices.containsKey(type)) {
             topQueriesServices.get(type).setWindowSize(windowSize);
-        }
-    }
-
-    /**
-     * Validate the top n size config for a metricType
-     *
-     * @param type {@link MetricType}
-     * @param topNSize top n size
-     */
-    public void validateTopNSize(final MetricType type, final int topNSize) {
-        if (topQueriesServices.containsKey(type)) {
-            topQueriesServices.get(type).validateTopNSize(topNSize);
         }
     }
 
@@ -529,15 +471,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     }
 
     /**
-     * Validate the exporter type config
-     *
-     * @param exporterType exporter type
-     */
-    public void validateExporterType(final String exporterType) {
-        queryInsightsExporterFactory.validateExporterType(exporterType);
-    }
-
-    /**
      * Get the current RBAC filter mode for top queries
      *
      * @return the current {@link FilterByMode}
@@ -553,15 +486,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      */
     public void setFilterByMode(final String filterByModeSetting) {
         this.filterByMode = FilterByMode.fromString(filterByModeSetting);
-    }
-
-    /**
-     * Validate the filter by mode setting
-     *
-     * @param filterByModeSetting the filter mode string value to validate
-     */
-    public void validateFilterByMode(final String filterByModeSetting) {
-        FilterByMode.fromString(filterByModeSetting);
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/TopQueriesService.java
@@ -198,26 +198,6 @@ public class TopQueriesService {
     }
 
     /**
-     * Validate the top N size based on the internal constrains
-     *
-     * @param size the wanted top N size
-     */
-    public void validateTopNSize(final int size) {
-        if (size < 1 || size > QueryInsightsSettings.MAX_N_SIZE) {
-            throw new IllegalArgumentException(
-                "Top N size setting for ["
-                    + metricType
-                    + "]"
-                    + " should be between 1 and "
-                    + QueryInsightsSettings.MAX_N_SIZE
-                    + ", was ("
-                    + size
-                    + ")"
-            );
-        }
-    }
-
-    /**
      * Set enable flag for the service
      *
      * @param enabled boolean
@@ -252,42 +232,6 @@ public class TopQueriesService {
         boolean changed = queryGrouper.setMaxGroups(maxGroups);
         if (changed) {
             drain();
-        }
-    }
-
-    /**
-     * Validate if the window size is valid, based on internal constrains.
-     *
-     * @param windowSize the window size to validate
-     */
-    public void validateWindowSize(final TimeValue windowSize) {
-        if (windowSize.compareTo(QueryInsightsSettings.MAX_WINDOW_SIZE) > 0
-            || windowSize.compareTo(QueryInsightsSettings.MIN_WINDOW_SIZE) < 0) {
-            throw new IllegalArgumentException(
-                "Window size setting for ["
-                    + metricType
-                    + "]"
-                    + " should be between ["
-                    + QueryInsightsSettings.MIN_WINDOW_SIZE
-                    + ","
-                    + QueryInsightsSettings.MAX_WINDOW_SIZE
-                    + "]"
-                    + "was ("
-                    + windowSize
-                    + ")"
-            );
-        }
-        if (!(QueryInsightsSettings.VALID_WINDOW_SIZES_IN_MINUTES.contains(windowSize) || windowSize.getMinutes() % 60 == 0)) {
-            throw new IllegalArgumentException(
-                "Window size setting for ["
-                    + metricType
-                    + "]"
-                    + " should be multiple of 1 hour, or one of "
-                    + QueryInsightsSettings.VALID_WINDOW_SIZES_IN_MINUTES
-                    + ", was ("
-                    + windowSize
-                    + ")"
-            );
         }
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -12,12 +12,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.plugin.insights.core.exporter.SinkType;
+import org.opensearch.plugin.insights.rules.model.FilterByMode;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 
@@ -125,6 +127,8 @@ public class QueryInsightsSettings {
     public static final Setting<Integer> TOP_N_LATENCY_QUERIES_SIZE = Setting.intSetting(
         TOP_N_LATENCY_QUERIES_PREFIX + ".top_n_size",
         DEFAULT_TOP_N_SIZE,
+        1,
+        MAX_N_SIZE,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -132,9 +136,11 @@ public class QueryInsightsSettings {
     /**
      * Time setting to define the window size in seconds for top queries by latency.
      */
-    public static final Setting<TimeValue> TOP_N_LATENCY_QUERIES_WINDOW_SIZE = Setting.positiveTimeSetting(
+    public static final Setting<TimeValue> TOP_N_LATENCY_QUERIES_WINDOW_SIZE = Setting.timeSetting(
         TOP_N_LATENCY_QUERIES_PREFIX + ".window_size",
         DEFAULT_WINDOW_SIZE,
+        MIN_WINDOW_SIZE,
+        new WindowSizeValidator(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -145,6 +151,7 @@ public class QueryInsightsSettings {
     public static final Setting<String> TOP_N_QUERIES_GROUP_BY = Setting.simpleString(
         TOP_N_QUERIES_GROUPING_SETTING_PREFIX + ".group_by",
         DEFAULT_GROUPING_TYPE.getValue(),
+        new GroupByValidator(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -155,6 +162,8 @@ public class QueryInsightsSettings {
     public static final Setting<Integer> TOP_N_QUERIES_MAX_GROUPS_EXCLUDING_N = Setting.intSetting(
         TOP_N_QUERIES_GROUPING_SETTING_PREFIX + ".max_groups_excluding_topn",
         DEFAULT_GROUPS_EXCLUDING_TOPN_LIMIT,
+        0,
+        MAX_GROUPS_EXCLUDING_TOPN_LIMIT,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -189,6 +198,8 @@ public class QueryInsightsSettings {
     public static final Setting<Integer> TOP_N_CPU_QUERIES_SIZE = Setting.intSetting(
         TOP_N_CPU_QUERIES_PREFIX + ".top_n_size",
         DEFAULT_TOP_N_SIZE,
+        1,
+        MAX_N_SIZE,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -196,9 +207,11 @@ public class QueryInsightsSettings {
     /**
      * Time setting to define the window size in seconds for top queries by cpu.
      */
-    public static final Setting<TimeValue> TOP_N_CPU_QUERIES_WINDOW_SIZE = Setting.positiveTimeSetting(
+    public static final Setting<TimeValue> TOP_N_CPU_QUERIES_WINDOW_SIZE = Setting.timeSetting(
         TOP_N_CPU_QUERIES_PREFIX + ".window_size",
         DEFAULT_WINDOW_SIZE,
+        MIN_WINDOW_SIZE,
+        new WindowSizeValidator(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -219,6 +232,8 @@ public class QueryInsightsSettings {
     public static final Setting<Integer> TOP_N_MEMORY_QUERIES_SIZE = Setting.intSetting(
         TOP_N_MEMORY_QUERIES_PREFIX + ".top_n_size",
         DEFAULT_TOP_N_SIZE,
+        1,
+        MAX_N_SIZE,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -226,9 +241,11 @@ public class QueryInsightsSettings {
     /**
      * Time setting to define the window size in seconds for top queries by memory.
      */
-    public static final Setting<TimeValue> TOP_N_MEMORY_QUERIES_WINDOW_SIZE = Setting.positiveTimeSetting(
+    public static final Setting<TimeValue> TOP_N_MEMORY_QUERIES_WINDOW_SIZE = Setting.timeSetting(
         TOP_N_MEMORY_QUERIES_PREFIX + ".window_size",
         DEFAULT_WINDOW_SIZE,
+        MIN_WINDOW_SIZE,
+        new WindowSizeValidator(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -281,6 +298,8 @@ public class QueryInsightsSettings {
     public static final Setting<Integer> TOP_N_EXPORTER_DELETE_AFTER = Setting.intSetting(
         TOP_N_QUERIES_EXPORTER_PREFIX + ".delete_after_days",
         DEFAULT_DELETE_AFTER_VALUE,
+        MIN_DELETE_AFTER_VALUE,
+        MAX_DELETE_AFTER_VALUE,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
@@ -291,6 +310,7 @@ public class QueryInsightsSettings {
     public static final Setting<String> TOP_N_EXPORTER_TYPE = Setting.simpleString(
         TOP_N_QUERIES_EXPORTER_PREFIX + ".type",
         DEFAULT_TOP_QUERIES_EXPORTER_TYPE,
+        new ExporterTypeValidator(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -325,6 +345,7 @@ public class QueryInsightsSettings {
         TOP_N_QUERIES_SETTING_PREFIX + ".excluded_indices",
         Collections.emptyList(),
         Function.identity(),
+        new ExcludedIndicesValidator(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -368,6 +389,7 @@ public class QueryInsightsSettings {
     public static final Setting<String> TOP_N_QUERIES_FILTER_BY_MODE = Setting.simpleString(
         TOP_N_QUERIES_SETTING_PREFIX + ".filter_by_mode",
         DEFAULT_FILTER_BY_MODE,
+        new FilterByModeValidator(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -424,4 +446,94 @@ public class QueryInsightsSettings {
      * Default constructor
      */
     public QueryInsightsSettings() {}
+
+    /**
+     * Validates the Query Insights window_size value.
+     * Ensures the value is a valid window size (a recognized minute value or a multiple of 1 hour).
+     */
+    static final class WindowSizeValidator implements Setting.Validator<TimeValue> {
+        @Override
+        public void validate(TimeValue windowSize) {
+            if (windowSize.compareTo(MAX_WINDOW_SIZE) > 0) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "Window size setting should be between [%s, %s], was (%s)",
+                        MIN_WINDOW_SIZE,
+                        MAX_WINDOW_SIZE,
+                        windowSize
+                    )
+                );
+            }
+            if (!(VALID_WINDOW_SIZES_IN_MINUTES.contains(windowSize) || windowSize.getMinutes() % 60 == 0)) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        Locale.ROOT,
+                        "Window size should be a multiple of 1 hour, or one of %s, was (%s)",
+                        VALID_WINDOW_SIZES_IN_MINUTES,
+                        windowSize
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Validates the Query Insights group_by value.
+     */
+    static final class GroupByValidator implements Setting.Validator<String> {
+        @Override
+        public void validate(String value) {
+            GroupingType.getGroupingTypeFromSettingAndValidate(value);
+        }
+    }
+
+    /**
+     * Validates the Query Insights excluded_indices values.
+     */
+    public static final class ExcludedIndicesValidator implements Setting.Validator<List<String>> {
+        @Override
+        public void validate(List<String> excludedIndices) {
+            for (String index : excludedIndices) {
+                if (index == null) {
+                    throw new IllegalArgumentException("Excluded index name cannot be null.");
+                }
+                if (index.isBlank()) {
+                    throw new IllegalArgumentException("Excluded index name cannot be blank.");
+                }
+                if (index.chars().anyMatch(Character::isUpperCase)) {
+                    throw new IllegalArgumentException("Index name must be lowercase.");
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the Query Insights exporter type value.
+     */
+    static final class ExporterTypeValidator implements Setting.Validator<String> {
+        @Override
+        public void validate(String value) {
+            if (value == null || value.isEmpty()) {
+                return;
+            }
+            try {
+                SinkType.parse(value);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ROOT, "Invalid exporter type [%s], type should be one of %s", value, SinkType.allSinkTypes())
+                );
+            }
+        }
+    }
+
+    /**
+     * Validates the Query Insights filter_by_mode value.
+     */
+    static final class FilterByModeValidator implements Setting.Validator<String> {
+        @Override
+        public void validate(String value) {
+            FilterByMode.fromString(value);
+        }
+    }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/QueryInsightsExporterFactoryTests.java
@@ -54,19 +54,6 @@ public class QueryInsightsExporterFactoryTests extends OpenSearchTestCase {
         OperationalMetricsCounter.initialize("cluster", metricsRegistry);
     }
 
-    public void testValidateConfigWhenResetExporter() {
-        try {
-            // empty settings
-            queryInsightsExporterFactory.validateExporterType(null);
-        } catch (Exception e) {
-            fail("No exception should be thrown when setting is null");
-        }
-    }
-
-    public void testInvalidExporterTypeConfig() {
-        assertThrows(IllegalArgumentException.class, () -> { queryInsightsExporterFactory.validateExporterType("some_invalid_type"); });
-    }
-
     public void testCreateAndCloseExporter() {
         QueryInsightsExporter exporter1 = queryInsightsExporterFactory.createLocalIndexExporter("id-index", format, "");
         assertTrue(exporter1 instanceof LocalIndexExporter);

--- a/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
@@ -50,6 +50,7 @@ import org.opensearch.plugin.insights.core.service.TopQueriesService;
 import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.search.aggregations.support.ValueType;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -526,47 +527,29 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
     }
 
     public void testExcludedIndicesValidation() {
-        QueryInsightsListener queryInsightsListener = new QueryInsightsListener(clusterService, queryInsightsService, threadPool);
+        // Validation is now enforced at the Setting level via ExcludedIndicesValidator
+        QueryInsightsSettings.ExcludedIndicesValidator validator = new QueryInsightsSettings.ExcludedIndicesValidator();
+
         List<String> containNullList = new ArrayList<>();
         containNullList.add("index1");
         containNullList.add(null);
-        assertThrows(
-            "Excluded index name cannot be null.",
-            IllegalArgumentException.class,
-            () -> queryInsightsListener.validateExcludedIndices(containNullList)
-        );
+        assertThrows("Excluded index name cannot be null.", IllegalArgumentException.class, () -> validator.validate(containNullList));
 
         List<String> containEmptyList = List.of("index1", "");
-        assertThrows(
-            "Excluded index name cannot be blank.",
-            IllegalArgumentException.class,
-            () -> queryInsightsListener.validateExcludedIndices(containEmptyList)
-        );
+        assertThrows("Excluded index name cannot be blank.", IllegalArgumentException.class, () -> validator.validate(containEmptyList));
 
         List<String> containBlankList = List.of("index1", "  ");
-        assertThrows(
-            "Excluded index name cannot be blank.",
-            IllegalArgumentException.class,
-            () -> queryInsightsListener.validateExcludedIndices(containBlankList)
-        );
+        assertThrows("Excluded index name cannot be blank.", IllegalArgumentException.class, () -> validator.validate(containBlankList));
 
         List<String> blankResetValue = List.of("");
-        assertThrows(
-            "Excluded index name cannot be blank.",
-            IllegalArgumentException.class,
-            () -> queryInsightsListener.validateExcludedIndices(blankResetValue)
-        );
+        assertThrows("Excluded index name cannot be blank.", IllegalArgumentException.class, () -> validator.validate(blankResetValue));
 
         List<String> indexNameWithUpperCaseChar = List.of("acceptedIndex", "rejectedIndex");
-        assertThrows(
-            "Index name must be lowercase.",
-            IllegalArgumentException.class,
-            () -> queryInsightsListener.validateExcludedIndices(indexNameWithUpperCaseChar)
-        );
+        assertThrows("Index name must be lowercase.", IllegalArgumentException.class, () -> validator.validate(indexNameWithUpperCaseChar));
 
         List<String> validIndicesList = List.of("first-index", "wildcard-index*");
         try {
-            queryInsightsListener.validateExcludedIndices(validIndicesList);
+            validator.validate(validIndicesList);
         } catch (Exception e) {
             fail("Expect no exception when valid excluded indices is set.");
         }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -474,18 +474,6 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         verify(mockLocalIndexLifecycleManagerSpy, times(expectedIndicesDeleted)).deleteSingleIndex(any(), any());
     }
 
-    public void testvalidateDeleteAfter() {
-        LocalIndexLifecycleManager localIndexLifecycleManager = queryInsightsService.getLocalIndexLifecycleManager();
-        localIndexLifecycleManager.validateDeleteAfter(7);
-        localIndexLifecycleManager.validateDeleteAfter(180);
-        localIndexLifecycleManager.validateDeleteAfter(0);
-        assertThrows(IllegalArgumentException.class, () -> { localIndexLifecycleManager.validateDeleteAfter(-1); });
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            localIndexLifecycleManager.validateDeleteAfter(181);
-        });
-        assertEquals("Invalid delete_after_days setting [181], value should be an integer between 0 and 180.", exception.getMessage());
-    }
-
     public void testSetDeleteAfterToNotZero() {
         queryInsightsServiceSpy.getLocalIndexLifecycleManager().setDeleteAfterAndDelete(100);
         verify(mockLocalIndexLifecycleManagerSpy, times(0)).deleteAllTopNIndices();
@@ -719,13 +707,14 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
     }
 
     public void testValidateFilterByMode_validValues() {
-        queryInsightsService.validateFilterByMode("none");
-        queryInsightsService.validateFilterByMode("username");
-        queryInsightsService.validateFilterByMode("backend_roles");
+        // Validation is now enforced at the Setting level via FilterByModeValidator
+        FilterByMode.fromString("none");
+        FilterByMode.fromString("username");
+        FilterByMode.fromString("backend_roles");
     }
 
     public void testValidateFilterByMode_invalidValue() {
-        assertThrows(IllegalArgumentException.class, () -> queryInsightsService.validateFilterByMode("invalid"));
+        assertThrows(IllegalArgumentException.class, () -> FilterByMode.fromString("invalid"));
     }
 
     // Util functions

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
@@ -148,11 +147,23 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     }
 
     public void testValidateTopNSize() {
-        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.validateTopNSize(QueryInsightsSettings.MAX_N_SIZE + 1); });
+        // Validation is now enforced at the Setting level via min/max bounds
+        assertThrows(IllegalArgumentException.class, () -> {
+            QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE.get(
+                org.opensearch.common.settings.Settings.builder()
+                    .put("search.insights.top_queries.latency.top_n_size", QueryInsightsSettings.MAX_N_SIZE + 1)
+                    .build()
+            );
+        });
     }
 
     public void testValidateNegativeTopNSize() {
-        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.validateTopNSize(-1); });
+        // Validation is now enforced at the Setting level via min/max bounds
+        assertThrows(IllegalArgumentException.class, () -> {
+            QueryInsightsSettings.TOP_N_LATENCY_QUERIES_SIZE.get(
+                org.opensearch.common.settings.Settings.builder().put("search.insights.top_queries.latency.top_n_size", -1).build()
+            );
+        });
     }
 
     public void testGetTopQueriesWhenNotEnabled() {
@@ -197,14 +208,17 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
     }
 
     public void testValidateWindowSize() {
+        // Validation is now enforced at the Setting level via min/max bounds and WindowSizeValidator
         assertThrows(IllegalArgumentException.class, () -> {
-            topQueriesService.validateWindowSize(new TimeValue(QueryInsightsSettings.MAX_WINDOW_SIZE.getSeconds() + 1, TimeUnit.SECONDS));
+            QueryInsightsSettings.TOP_N_LATENCY_QUERIES_WINDOW_SIZE.get(
+                org.opensearch.common.settings.Settings.builder().put("search.insights.top_queries.latency.window_size", "2d").build()
+            );
         });
         assertThrows(IllegalArgumentException.class, () -> {
-            topQueriesService.validateWindowSize(new TimeValue(QueryInsightsSettings.MIN_WINDOW_SIZE.getSeconds() - 1, TimeUnit.SECONDS));
+            QueryInsightsSettings.TOP_N_LATENCY_QUERIES_WINDOW_SIZE.get(
+                org.opensearch.common.settings.Settings.builder().put("search.insights.top_queries.latency.window_size", "7m").build()
+            );
         });
-        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.validateWindowSize(new TimeValue(2, TimeUnit.DAYS)); });
-        assertThrows(IllegalArgumentException.class, () -> { topQueriesService.validateWindowSize(new TimeValue(7, TimeUnit.MINUTES)); });
     }
 
     private static void runUntilTimeoutOrFinish(DeterministicTaskQueue deterministicTaskQueue, long duration) {


### PR DESCRIPTION
## Move cluster setting validation to Setting definitions

### Problem

Query Insights settings were validated using runtime callbacks passed to `addSettingsUpdateConsumer(setting, consumer, validator)`. This approach has two issues:

1. The validator callback only fires when the *effective* value changes. If a transient setting is active, updating the persistent value to something invalid doesn't change the effective value, so OpenSearch skips validation entirely. The invalid value gets stored in cluster state and takes effect after the transient is cleared or after a cluster restart.

2. Validation only runs on dynamic updates via the cluster settings API. Invalid values in `opensearch.yml` or injected through other paths bypass these callbacks.

For example, with a transient `exporter.type` of `local_index` set, you could set the persistent value to `local_index2` (invalid) without any error.

### Solution

Moved all validation into the `Setting` definitions in `QueryInsightsSettings.java`. OpenSearch's `SettingsUpdater` calls `clusterSettings.validate(persistentFinalSettings, true)` and `clusterSettings.validate(transientFinalSettings, true)` independently during cluster state updates, which invokes `setting.get(settings)` on each setting — triggering both the parser bounds and `Setting.Validator`. This means persistent settings are validated on their own, regardless of whether a transient override is active.

Specifically:

- `top_n_size` (latency/cpu/memory): uses `intSetting` with min=1, max=100 bounds
- `window_size` (latency/cpu/memory): uses `timeSetting` with min bound + `WindowSizeValidator` for the valid-window-sizes constraint and upper bound check
- `group_by`: `GroupByValidator` that delegates to `GroupingType.getGroupingTypeFromSettingAndValidate`
- `max_groups_excluding_topn`: uses `intSetting` with min=0, max=10000 bounds
- `excluded_indices`: `ExcludedIndicesValidator` (null, blank, uppercase checks)
- `exporter.type`: `ExporterTypeValidator` that delegates to `SinkType.parse`
- `exporter.delete_after_days`: uses `intSetting` with min=0, max=180 bounds
- `filter_by_mode`: `FilterByModeValidator` that delegates to `FilterByMode.fromString`

### Testing

All existing unit tests pass. Updated `TopQueriesServiceTests`, `QueryInsightsServiceTests`, and `QueryInsightsListenerTests` to test validation through the Setting-level validators instead of the removed runtime methods.


### Issues Resolved
Resolves #466 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
