### PR TITLE
Fix github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         java:
           - 21
           - 25
-    name: Build and Test query-insights plugin with JDK ${{ matrix.java }} on ubuntu-latest
+    name: Build JDK ${{ matrix.java }}, ubuntu-latest
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
@@ -89,7 +89,7 @@ jobs:
           - os: macos-latest
             os_build_args: -x jacocoTestReport
 
-    name: Build and Test query-insights plugin with JDK ${{ matrix.java }} on ${{ matrix.os }}
+    name: Build JDK ${{ matrix.java }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, macos-13 ]
+        os: [ windows-latest, macos-latest ]
         java: [ 21 ]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Description
1. Simplify build action names
2. `macos-13` image is deprecated. Use `macos-latest` instead

### Issues Resolved
```
The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more details see https://github.com/actions/runner-images/issues/13046
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
