### PR TITLE
[Draft][feat] Add finished query tracking to live queries API

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/CompletedLiveQueriesService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/CompletedLiveQueriesService.java
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+
+/**
+ * Service to manage finished live queries (completed/cancelled) with automatic cleanup after 30 seconds
+ */
+public class CompletedLiveQueriesService {
+    private static final int RETENTION_SECONDS = 30;
+    private static final int MAX_COMPLETED_QUERIES = 1000;
+    private static volatile CompletedLiveQueriesService instance;
+    private final ConcurrentLinkedQueue<CompletedQueryEntry> completedQueries = new ConcurrentLinkedQueue<>();
+    private final ScheduledExecutorService cleanupExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "completed-live-queries-cleanup");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private CompletedLiveQueriesService() {
+        // Schedule cleanup every 10 seconds
+        cleanupExecutor.scheduleAtFixedRate(this::cleanup, 10, 10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Get singleton instance
+     */
+    public static CompletedLiveQueriesService getInstance() {
+        if (instance == null) {
+            synchronized (CompletedLiveQueriesService.class) {
+                if (instance == null) {
+                    instance = new CompletedLiveQueriesService();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Add a finished query (completed or cancelled) to the store
+     */
+    public void addCompletedQuery(SearchQueryRecord record) {
+        completedQueries.offer(new CompletedQueryEntry(record, System.currentTimeMillis()));
+
+        // Remove oldest entries if we exceed the maximum limit
+        while (completedQueries.size() > MAX_COMPLETED_QUERIES) {
+            completedQueries.poll();
+        }
+    }
+
+    /**
+     * Get all finished queries (completed/cancelled) that are still within retention period
+     */
+    public List<SearchQueryRecord> getCompletedQueries() {
+        long cutoffTime = System.currentTimeMillis() - (RETENTION_SECONDS * 1000L);
+        return completedQueries.stream()
+            .filter(entry -> entry.timestamp > cutoffTime)
+            .map(entry -> entry.record)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Get the maximum number of finished queries that can be stored
+     */
+    public int getMaxCompletedQueries() {
+        return MAX_COMPLETED_QUERIES;
+    }
+
+    /**
+     * Get the current number of finished queries in the store
+     */
+    public int getCurrentSize() {
+        return completedQueries.size();
+    }
+
+    /**
+     * Clean up expired entries
+     */
+    private void cleanup() {
+        long cutoffTime = System.currentTimeMillis() - (RETENTION_SECONDS * 1000L);
+        while (!completedQueries.isEmpty() && completedQueries.peek().timestamp <= cutoffTime) {
+            completedQueries.poll();
+        }
+    }
+
+    /**
+     * Shutdown the service
+     */
+    public void shutdown() {
+        cleanupExecutor.shutdown();
+    }
+
+    /**
+     * Reset singleton instance for testing
+     */
+    public static void resetForTesting() {
+        if (instance != null) {
+            instance.shutdown();
+            instance = null;
+        }
+    }
+
+    private static class CompletedQueryEntry {
+        final SearchQueryRecord record;
+        final long timestamp;
+
+        CompletedQueryEntry(SearchQueryRecord record, long timestamp) {
+            this.record = record;
+            this.timestamp = timestamp;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -82,7 +82,22 @@ public enum Attribute {
     /**
      * The cancelled of the search query, often used in live queries.
      */
-    IS_CANCELLED;
+    IS_CANCELLED,
+
+    /**
+     * Query status (running, completed, cancelled)
+     */
+    STATUS,
+
+    /**
+     * Query start timestamp
+     */
+    START_TIMESTAMP,
+
+    /**
+     * Query end timestamp
+     */
+    END_TIMESTAMP;
 
     /**
      * Read an Attribute from a StreamInput

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -117,6 +117,18 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      */
     public static final String WLM_GROUP_ID = "wlm_group_id";
     /**
+     * Query status (running, completed, cancelled)
+     */
+    public static final String STATUS = "status";
+    /**
+     * Query start timestamp
+     */
+    public static final String START_TIMESTAMP = "start_timestamp";
+    /**
+     * Query end timestamp
+     */
+    public static final String END_TIMESTAMP = "end_timestamp";
+    /**
      * Default, immutable `top_n_query` map. All values initialized to {@code false}
      */
     public static final Map<String, Boolean> DEFAULT_TOP_N_QUERY_MAP = Collections.unmodifiableMap(
@@ -291,6 +303,15 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
                         break;
                     case WLM_GROUP_ID:
                         attributes.put(Attribute.WLM_GROUP_ID, parser.text());
+                        break;
+                    case STATUS:
+                        attributes.put(Attribute.STATUS, parser.text());
+                        break;
+                    case START_TIMESTAMP:
+                        attributes.put(Attribute.START_TIMESTAMP, parser.longValue());
+                        break;
+                    case END_TIMESTAMP:
+                        attributes.put(Attribute.END_TIMESTAMP, parser.longValue());
                         break;
                     case TASK_RESOURCE_USAGES:
                         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/CompletedLiveQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/CompletedLiveQueriesServiceTests.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to\n * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.plugin.insights.rules.model.Attribute;
+import org.opensearch.plugin.insights.rules.model.Measurement;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for the {@link CompletedLiveQueriesService} class.
+ */
+public class CompletedLiveQueriesServiceTests extends OpenSearchTestCase {
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        CompletedLiveQueriesService.resetForTesting();
+    }
+
+    private SearchQueryRecord createTestRecord(String id) {
+        Map<MetricType, Measurement> measurements = new HashMap<>();
+        measurements.put(MetricType.LATENCY, new Measurement(100L));
+        measurements.put(MetricType.CPU, new Measurement(50L));
+        measurements.put(MetricType.MEMORY, new Measurement(1024L));
+
+        Map<Attribute, Object> attributes = new HashMap<>();
+        attributes.put(Attribute.NODE_ID, "test-node");
+
+        return new SearchQueryRecord(System.currentTimeMillis(), measurements, attributes, id);
+    }
+
+    public void testSingletonInstance() {
+        CompletedLiveQueriesService service1 = CompletedLiveQueriesService.getInstance();
+        CompletedLiveQueriesService service2 = CompletedLiveQueriesService.getInstance();
+        assertSame(service1, service2);
+    }
+
+    public void testAddAndRetrieveCompletedQueries() {
+        CompletedLiveQueriesService service = CompletedLiveQueriesService.getInstance();
+
+        SearchQueryRecord record1 = createTestRecord("query1");
+        SearchQueryRecord record2 = createTestRecord("query2");
+
+        service.addCompletedQuery(record1);
+        service.addCompletedQuery(record2);
+
+        List<SearchQueryRecord> completedQueries = service.getCompletedQueries();
+        assertEquals(2, completedQueries.size());
+        assertTrue(completedQueries.stream().anyMatch(r -> "query1".equals(r.getId())));
+        assertTrue(completedQueries.stream().anyMatch(r -> "query2".equals(r.getId())));
+    }
+
+    public void testEmptyCompletedQueries() {
+        CompletedLiveQueriesService service = CompletedLiveQueriesService.getInstance();
+        List<SearchQueryRecord> completedQueries = service.getCompletedQueries();
+        assertNotNull(completedQueries);
+    }
+
+    public void testMaximumLimit() {
+        CompletedLiveQueriesService service = CompletedLiveQueriesService.getInstance();
+        assertEquals(1000, service.getMaxCompletedQueries());
+    }
+
+    public void testCurrentSize() {
+        CompletedLiveQueriesService service = CompletedLiveQueriesService.getInstance();
+        int initialSize = service.getCurrentSize();
+
+        SearchQueryRecord record = createTestRecord("test-size");
+        service.addCompletedQuery(record);
+
+        assertTrue(service.getCurrentSize() >= initialSize);
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesActionTests.java
@@ -61,6 +61,12 @@ import org.opensearch.transport.client.ClusterAdminClient;
 @SuppressWarnings("unchecked")
 public class TransportLiveQueriesActionTests extends OpenSearchTestCase {
 
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        org.opensearch.plugin.insights.core.service.CompletedLiveQueriesService.resetForTesting();
+    }
+
     private TransportLiveQueriesAction transportLiveQueriesAction;
     private Client client;
     private ClusterService clusterService;


### PR DESCRIPTION
### Description

Enhances the live queries API to store and return recently finished (completed/cancelled) queries for 30 seconds, providing complete query lifecycle visibility.

Retention: 30 seconds maximum for finished queries
Capacity: 1000 query limit with automatic cleanup

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
