### PR TITLE
[Feat] Add Live Queries Cache with Task Resource Aggregation and Configurable Idle Timeout

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -168,6 +168,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             QueryInsightsSettings.TOP_N_EXPORTER_TYPE,
             QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES,
             QueryInsightsSettings.TOP_N_QUERIES_MAX_SOURCE_LENGTH,
+            QueryInsightsSettings.LIVE_QUERIES_CACHE_IDLE_TIMEOUT,
             QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
         );
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/LiveQueriesCache.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/LiveQueriesCache.java
@@ -1,0 +1,223 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service;
+
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.LIVE_QUERIES_MAX_CACHE_SIZE;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.LIVE_QUERIES_MAX_RETURNED_QUERIES;
+import static org.opensearch.plugin.insights.settings.QueryInsightsSettings.LIVE_QUERIES_POLLING_INTERVAL_MS;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.threadpool.Scheduler;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+/**
+ * Cache for live running queries
+ */
+public class LiveQueriesCache {
+
+    private static final Logger logger = LogManager.getLogger(LiveQueriesCache.class);
+    private static final String SEARCH_ACTION = "indices:data/read/search*";
+    private static final AtomicReference<LiveQueriesCache> INSTANCE = new AtomicReference<>();
+
+    private final AtomicReference<SearchQueryRecord[]> sortedQueries = new AtomicReference<>(new SearchQueryRecord[0]);
+    private final Client client;
+    private final ThreadPool threadPool;
+    private final TransportService transportService;
+    private volatile Scheduler.Cancellable pollingTask;
+    private final Map<String, Map<String, Object>> taskUserInfoCache = new ConcurrentHashMap<>();
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicLong lastAccessTime = new AtomicLong(0);
+    private final AtomicReference<Scheduler.Cancellable> idleCheckTask = new AtomicReference<>();
+    private final long idleTimeoutMs;
+    private static final TimeValue IDLE_CHECK_INTERVAL = new TimeValue(60, TimeUnit.SECONDS);
+
+    public static LiveQueriesCache getInstance(
+        Client client,
+        ThreadPool threadPool,
+        TransportService transportService,
+        long idleTimeoutMs
+    ) {
+        if (idleTimeoutMs < 0) {
+            throw new IllegalStateException(
+                "Live queries cache is disabled. Set search.insights.live_queries.cache_timeout to a positive value (2-10 minutes) to enable it."
+            );
+        }
+        LiveQueriesCache cache = INSTANCE.get();
+        if (cache == null) {
+            LiveQueriesCache newCache = new LiveQueriesCache(client, threadPool, transportService, idleTimeoutMs);
+            if (!INSTANCE.compareAndSet(null, newCache)) {
+                newCache = INSTANCE.get();
+            }
+            cache = newCache;
+        }
+        cache.recordAccess();
+        cache.start();
+        return cache;
+    }
+
+    public static void stopInstance() {
+        LiveQueriesCache cache = INSTANCE.get();
+        if (cache != null) {
+            cache.stop();
+        }
+    }
+
+    public LiveQueriesCache(Client client, ThreadPool threadPool, TransportService transportService, long idleTimeoutMs) {
+        this.client = client;
+        this.threadPool = threadPool;
+        this.transportService = transportService;
+        this.idleTimeoutMs = idleTimeoutMs;
+    }
+
+    public void start() {
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+        lastAccessTime.set(System.currentTimeMillis());
+        pollingTask = threadPool.scheduleWithFixedDelay(
+            this::getRunningTasks,
+            new TimeValue(LIVE_QUERIES_POLLING_INTERVAL_MS, TimeUnit.MILLISECONDS),
+            ThreadPool.Names.GENERIC
+        );
+        getRunningTasks();
+        startIdleCheck();
+    }
+
+    public void stop() {
+        if (!started.compareAndSet(true, false)) {
+            return;
+        }
+        if (pollingTask != null) {
+            pollingTask.cancel();
+            pollingTask = null;
+        }
+        Scheduler.Cancellable task = idleCheckTask.getAndSet(null);
+        if (task != null) {
+            task.cancel();
+        }
+        lastAccessTime.set(0);
+    }
+
+    public boolean isStarted() {
+        return started.get();
+    }
+
+    public void recordAccess() {
+        lastAccessTime.set(System.currentTimeMillis());
+    }
+
+    private void startIdleCheck() {
+        if (idleTimeoutMs < 0) {
+            return;
+        }
+        Scheduler.Cancellable task = threadPool.scheduleWithFixedDelay(() -> {
+            if (started.get() && System.currentTimeMillis() - lastAccessTime.get() > idleTimeoutMs) {
+                stop();
+            }
+        }, IDLE_CHECK_INTERVAL, ThreadPool.Names.GENERIC);
+        idleCheckTask.set(task);
+    }
+
+    private void getRunningTasks() {
+        try {
+            ListTasksRequest request = new ListTasksRequest().setActions(SEARCH_ACTION).setDetailed(true);
+
+            // Call listTasks directly on local node instead of using cluster().listTasks() to avoid fan-out
+            DiscoveryNode localNode = transportService.getLocalNode();
+            if (localNode != null) {
+                request.setNodes(new String[] { localNode.getId() });
+
+                client.admin().cluster().listTasks(request, new ActionListener<ListTasksResponse>() {
+                    @Override
+                    public void onResponse(ListTasksResponse response) {
+                        try {
+                            Map<String, SearchQueryRecord> parentRecords = LiveQueriesHelper.processTaskGroups(
+                                response.getTaskGroups(),
+                                transportService,
+                                true,
+                                taskUserInfoCache,
+                                null,
+                                null
+                            );
+
+                            // Clean up user info cache for tasks that are no longer running
+                            Set<String> activeTaskIds = parentRecords.keySet();
+                            taskUserInfoCache.keySet().removeIf(taskId -> !activeTaskIds.contains(taskId));
+
+                            TreeSet<SearchQueryRecord> allQueries = new TreeSet<>((a, b) -> {
+                                int latencyCompare = Long.compare(
+                                    ((Number) b.getMeasurement(MetricType.LATENCY)).longValue(),
+                                    ((Number) a.getMeasurement(MetricType.LATENCY)).longValue()
+                                );
+                                return latencyCompare != 0 ? latencyCompare : a.getId().compareTo(b.getId());
+                            });
+
+                            for (SearchQueryRecord record : parentRecords.values()) {
+                                allQueries.add(record);
+                                if (allQueries.size() > LIVE_QUERIES_MAX_CACHE_SIZE) {
+                                    allQueries.pollLast();
+                                }
+                            }
+
+                            sortedQueries.set(
+                                allQueries.stream().limit(LIVE_QUERIES_MAX_RETURNED_QUERIES).toArray(SearchQueryRecord[]::new)
+                            );
+                        } catch (Throwable e) {
+                            logger.error("Error processing live queries response: {}", e.getMessage());
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        logger.debug("Failed to list tasks during polling: {}", e.getMessage());
+                    }
+                });
+            }
+        } catch (Throwable e) {
+            logger.debug("Error polling running tasks: {}", e.getMessage());
+        }
+    }
+
+    public List<SearchQueryRecord> getCurrentQueries() {
+        return Arrays.asList(sortedQueries.get());
+    }
+
+    public void storeTaskUserInfo(String taskId, String username, String[] roles) {
+        Map<String, Object> userInfo = new HashMap<>();
+        userInfo.put("username", username);
+        userInfo.put("roles", roles);
+        taskUserInfoCache.put(taskId, userInfo);
+    }
+
+    public void removeTaskUserInfo(String taskId) {
+        taskUserInfoCache.remove(taskId);
+    }
+
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/service/LiveQueriesHelper.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/LiveQueriesHelper.java
@@ -1,0 +1,235 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceStats;
+import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
+import org.opensearch.plugin.insights.rules.model.Attribute;
+import org.opensearch.plugin.insights.rules.model.Measurement;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskInfo;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Helper utility for creating SearchQueryRecord from TaskInfo
+ */
+public final class LiveQueriesHelper {
+    private static final String TOTAL = "total";
+
+    private LiveQueriesHelper() {}
+
+    /**
+     * Create a SearchQueryRecord from TaskInfo
+     */
+    public static SearchQueryRecord createRecordFromTask(
+        TaskInfo task,
+        TransportService transportService,
+        boolean includeVerboseAttributes,
+        Map<String, Map<String, Object>> taskUserInfoCache
+    ) {
+        return createRecordFromTask(task, transportService, includeVerboseAttributes, taskUserInfoCache, null);
+    }
+
+    /**
+     * Create a SearchQueryRecord from TaskInfo with child tasks
+     */
+    public static SearchQueryRecord createRecordFromTask(
+        TaskInfo task,
+        TransportService transportService,
+        boolean includeVerboseAttributes,
+        Map<String, Map<String, Object>> taskUserInfoCache,
+        List<TaskInfo> childTasks
+    ) {
+        long cpuNanos = 0L;
+        long memBytes = 0L;
+        TaskResourceStats stats = task.getResourceStats();
+        if (stats != null) {
+            Map<String, TaskResourceUsage> usageInfo = stats.getResourceUsageInfo();
+            if (usageInfo != null) {
+                TaskResourceUsage totalUsage = usageInfo.get(TOTAL);
+                if (totalUsage != null) {
+                    cpuNanos = totalUsage.getCpuTimeInNanos();
+                    memBytes = totalUsage.getMemoryInBytes();
+                }
+            }
+        }
+
+        String workloadGroup = null;
+
+        // Get from TaskManager for local tasks
+        if (transportService != null) {
+            try {
+                Task runningTask = null;
+                if (transportService.getLocalNode().getId().equals(task.getTaskId().getNodeId())) {
+                    runningTask = transportService.getTaskManager().getTask(task.getTaskId().getId());
+                }
+
+                String wlmGroupId = null;
+                if (runningTask instanceof org.opensearch.wlm.WorkloadGroupTask workloadTask) {
+                    wlmGroupId = workloadTask.getWorkloadGroupId();
+                }
+                workloadGroup = wlmGroupId;
+            } catch (Exception e) {
+                // Ignore
+            }
+        }
+
+        Map<MetricType, Measurement> measurements = new HashMap<>();
+        measurements.put(MetricType.LATENCY, new Measurement(task.getRunningTimeNanos()));
+        measurements.put(MetricType.CPU, new Measurement(cpuNanos));
+        measurements.put(MetricType.MEMORY, new Measurement(memBytes));
+
+        Map<Attribute, Object> attributes = new HashMap<>();
+        attributes.put(Attribute.NODE_ID, task.getTaskId().getNodeId());
+        attributes.put(Attribute.WLM_GROUP_ID, workloadGroup);
+
+        if (includeVerboseAttributes) {
+            attributes.put(Attribute.DESCRIPTION, task.getDescription());
+            attributes.put(Attribute.IS_CANCELLED, task.isCancelled());
+
+            // Add task resource usage info
+            List<org.opensearch.core.tasks.resourcetracker.TaskResourceInfo> taskResourceUsages = new ArrayList<>();
+            if (stats != null) {
+                TaskResourceUsage totalUsage = stats.getResourceUsageInfo() != null ? stats.getResourceUsageInfo().get(TOTAL) : null;
+                taskResourceUsages.add(
+                    new org.opensearch.core.tasks.resourcetracker.TaskResourceInfo(
+                        task.getAction(),
+                        task.getId(),
+                        task.getParentTaskId().getId(),
+                        task.getTaskId().getNodeId(),
+                        totalUsage != null ? totalUsage : new TaskResourceUsage(0L, 0L)
+                    )
+                );
+            }
+
+            // Add child task resource usages
+            if (childTasks != null) {
+                for (TaskInfo childTask : childTasks) {
+                    TaskResourceStats childStats = childTask.getResourceStats();
+                    TaskResourceUsage childUsage = null;
+                    if (childStats != null && childStats.getResourceUsageInfo() != null) {
+                        childUsage = childStats.getResourceUsageInfo().get(TOTAL);
+                    }
+                    taskResourceUsages.add(
+                        new org.opensearch.core.tasks.resourcetracker.TaskResourceInfo(
+                            childTask.getAction(),
+                            childTask.getId(),
+                            childTask.getParentTaskId().getId(),
+                            childTask.getTaskId().getNodeId(),
+                            childUsage != null ? childUsage : new TaskResourceUsage(0L, 0L)
+                        )
+                    );
+                }
+            }
+
+            attributes.put(Attribute.TASK_RESOURCE_USAGES, taskResourceUsages);
+        }
+
+        // Add user info if available
+        if (taskUserInfoCache != null) {
+            Map<String, Object> userInfo = taskUserInfoCache.get(task.getTaskId().toString());
+            if (userInfo != null) {
+                String username = (String) userInfo.get("username");
+                if (username != null) {
+                    attributes.put(Attribute.USERNAME, username);
+                }
+                String[] roles = (String[]) userInfo.get("roles");
+                if (roles != null) {
+                    attributes.put(Attribute.USER_ROLES, roles);
+                }
+            }
+        }
+
+        return new SearchQueryRecord(task.getStartTime(), measurements, attributes, task.getTaskId().toString());
+    }
+
+    /**
+     * Process task groups and create SearchQueryRecords with aggregated child resources
+     */
+    public static Map<String, SearchQueryRecord> processTaskGroups(
+        List<org.opensearch.action.admin.cluster.node.tasks.list.TaskGroup> taskGroups,
+        TransportService transportService,
+        boolean includeVerboseAttributes,
+        Map<String, Map<String, Object>> taskUserInfoCache,
+        String wlmGroupIdFilter,
+        String taskIdFilter
+    ) {
+        Map<String, SearchQueryRecord> recordMap = new HashMap<>();
+
+        for (var taskGroup : taskGroups) {
+            TaskInfo parentTask = taskGroup.getTaskInfo();
+            if (!parentTask.getAction().equals("indices:data/read/search")) {
+                continue;
+            }
+
+            String taskId = parentTask.getTaskId().toString();
+            List<TaskInfo> children = new ArrayList<>();
+            collectChildTasks(taskGroup, children);
+
+            SearchQueryRecord record = createRecordFromTask(
+                parentTask,
+                transportService,
+                includeVerboseAttributes,
+                taskUserInfoCache,
+                children
+            );
+
+            // Aggregate child resources
+            long cpu = ((Number) record.getMeasurement(MetricType.CPU)).longValue();
+            long mem = ((Number) record.getMeasurement(MetricType.MEMORY)).longValue();
+
+            for (TaskInfo child : children) {
+                if (child.getResourceStats() != null) {
+                    var usageInfo = child.getResourceStats().getResourceUsageInfo();
+                    if (usageInfo != null) {
+                        var totalUsage = usageInfo.get(TOTAL);
+                        if (totalUsage != null) {
+                            cpu += totalUsage.getCpuTimeInNanos();
+                            mem += totalUsage.getMemoryInBytes();
+                        }
+                    }
+                }
+            }
+
+            record.getMeasurements().put(MetricType.CPU, new Measurement(cpu));
+            record.getMeasurements().put(MetricType.MEMORY, new Measurement(mem));
+
+            // Apply filters
+            if (wlmGroupIdFilter != null
+                && !wlmGroupIdFilter.equals(
+                    record.getAttributes().get(org.opensearch.plugin.insights.rules.model.Attribute.WLM_GROUP_ID)
+                )) {
+                continue;
+            }
+            if (taskIdFilter != null && !taskIdFilter.equals(taskId)) {
+                continue;
+            }
+
+            recordMap.put(taskId, record);
+        }
+
+        return recordMap;
+    }
+
+    private static void collectChildTasks(
+        org.opensearch.action.admin.cluster.node.tasks.list.TaskGroup taskGroup,
+        List<TaskInfo> children
+    ) {
+        for (var child : taskGroup.getChildTasks()) {
+            children.add(child.getTaskInfo());
+            collectChildTasks(child, children);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/RestLiveQueriesAction.java
@@ -63,8 +63,10 @@ public class RestLiveQueriesAction extends BaseRestHandler {
     static LiveQueriesRequest prepareRequest(final RestRequest request) {
         final String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
         final boolean verbose = request.paramAsBoolean("verbose", true);
+        final boolean useLiveCache = request.paramAsBoolean("use_live_cache", false);
         final String sortParam = request.param("sort", MetricType.LATENCY.toString());
         final String wlmGroupId = request.param("wlmGroupId", null);
+        final String taskId = request.param("task_id", null);
 
         if (!ALLOWED_METRICS.contains(sortParam)) {
             throw new IllegalArgumentException(
@@ -78,7 +80,7 @@ public class RestLiveQueriesAction extends BaseRestHandler {
                 String.format(Locale.ROOT, "request [%s] contains invalid size parameter [%d]. size must be positive", request.path(), size)
             );
         }
-        return new LiveQueriesRequest(verbose, sortBy, size, nodesIds, wlmGroupId);
+        return new LiveQueriesRequest(verbose, sortBy, size, nodesIds, wlmGroupId, taskId, useLiveCache);
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -9,7 +9,6 @@
 package org.opensearch.plugin.insights.rules.transport.live_queries;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
@@ -20,17 +19,15 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.tasks.resourcetracker.TaskResourceStats;
-import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
+import org.opensearch.plugin.insights.core.service.LiveQueriesCache;
+import org.opensearch.plugin.insights.core.service.LiveQueriesHelper;
+import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesRequest;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesResponse;
 import org.opensearch.plugin.insights.rules.model.Attribute;
-import org.opensearch.plugin.insights.rules.model.Measurement;
-import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.tasks.Task;
-import org.opensearch.tasks.TaskInfo;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -45,22 +42,62 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
 
     private final Client client;
     private final TransportService transportService;
+    private final QueryInsightsService queryInsightsService;
 
     @Inject
-    public TransportLiveQueriesAction(final TransportService transportService, final Client client, final ActionFilters actionFilters) {
+    public TransportLiveQueriesAction(
+        final TransportService transportService,
+        final Client client,
+        final ActionFilters actionFilters,
+        final QueryInsightsService queryInsightsService
+    ) {
         super(LiveQueriesAction.NAME, transportService, actionFilters, LiveQueriesRequest::new, ThreadPool.Names.GENERIC);
         this.transportService = transportService;
         this.client = client;
+        this.queryInsightsService = queryInsightsService;
     }
 
     @Override
     protected void doExecute(final Task task, final LiveQueriesRequest request, final ActionListener<LiveQueriesResponse> listener) {
-        ListTasksRequest listTasksRequest = new ListTasksRequest().setDetailed(request.isVerbose()).setActions("indices:data/read/search");
+        // If use_live_cache=true, read directly from cache without ListTasks
+        if (request.isUseLiveCache()) {
+            try {
+                LiveQueriesCache liveCache = queryInsightsService.getLiveQueriesCache();
+                List<SearchQueryRecord> liveRecords = liveCache.getCurrentQueries();
+
+                // Filter by wlmGroupId and taskId
+                List<SearchQueryRecord> filteredRecords = liveRecords.stream().filter(record -> {
+                    if (request.getWlmGroupId() != null
+                        && !request.getWlmGroupId().equals(record.getAttributes().get(Attribute.WLM_GROUP_ID))) {
+                        return false;
+                    }
+                    if (request.getTaskId() != null && !request.getTaskId().equals(record.getId())) {
+                        return false;
+                    }
+                    return true;
+                })
+                    .sorted((a, b) -> SearchQueryRecord.compare(b, a, request.getSortBy()))
+                    .limit(request.getSize() < 0 ? Long.MAX_VALUE : request.getSize())
+                    .toList();
+
+                listener.onResponse(new LiveQueriesResponse(filteredRecords));
+            } catch (Exception ex) {
+                logger.error("Failed to retrieve live cache queries", ex);
+                listener.onFailure(ex);
+            }
+            return;
+        }
+
+        // use_live_cache=false: Fan out to all nodes to get fresh data
+        ListTasksRequest listTasksRequest = new ListTasksRequest().setDetailed(request.isVerbose()).setActions("indices:data/read/search*");
 
         // Set nodes filter if provided in the request
         String[] requestedNodeIds = request.nodesIds();
         if (requestedNodeIds != null && requestedNodeIds.length > 0) {
             listTasksRequest.setNodes(requestedNodeIds);
+        } else {
+            // Fan out to all nodes when no specific nodes are requested
+            listTasksRequest.setNodes(new String[] { "_all" });
         }
 
         // Execute tasks request asynchronously to avoid blocking
@@ -68,64 +105,16 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
             @Override
             public void onResponse(ListTasksResponse taskResponse) {
                 try {
-                    List<SearchQueryRecord> allFilteredRecords = new ArrayList<>();
-                    for (TaskInfo taskInfo : taskResponse.getTasks()) {
-                        if (!taskInfo.getAction().equals("indices:data/read/search")) {
-                            continue;
-                        }
-                        long timestamp = taskInfo.getStartTime();
-                        String nodeId = taskInfo.getTaskId().getNodeId();
-                        long runningNanos = taskInfo.getRunningTimeNanos();
+                    Map<String, SearchQueryRecord> recordMap = LiveQueriesHelper.processTaskGroups(
+                        taskResponse.getTaskGroups(),
+                        transportService,
+                        request.isVerbose(),
+                        null,
+                        request.getWlmGroupId(),
+                        request.getTaskId()
+                    );
 
-                        Map<MetricType, Measurement> measurements = new HashMap<>();
-                        measurements.put(MetricType.LATENCY, new Measurement(runningNanos));
-
-                        long cpuNanos = 0L;
-                        long memBytes = 0L;
-                        TaskResourceStats stats = taskInfo.getResourceStats();
-                        if (stats != null) {
-                            Map<String, TaskResourceUsage> usageInfo = stats.getResourceUsageInfo();
-                            if (usageInfo != null) {
-                                TaskResourceUsage totalUsage = usageInfo.get(TOTAL);
-                                if (totalUsage != null) {
-                                    cpuNanos = totalUsage.getCpuTimeInNanos();
-                                    memBytes = totalUsage.getMemoryInBytes();
-                                }
-                            }
-                        }
-                        measurements.put(MetricType.CPU, new Measurement(cpuNanos));
-                        measurements.put(MetricType.MEMORY, new Measurement(memBytes));
-
-                        Map<Attribute, Object> attributes = new HashMap<>();
-                        attributes.put(Attribute.NODE_ID, nodeId);
-                        if (request.isVerbose()) {
-                            attributes.put(Attribute.DESCRIPTION, taskInfo.getDescription());
-                            attributes.put(Attribute.IS_CANCELLED, taskInfo.isCancelled());
-                        }
-                        Task runningTask = null;
-                        if (transportService.getLocalNode().getId().equals(taskInfo.getTaskId().getNodeId())) {
-                            runningTask = transportService.getTaskManager().getTask(taskInfo.getTaskId().getId());
-                        }
-
-                        String wlmGroupId = null;
-                        if (runningTask instanceof org.opensearch.wlm.WorkloadGroupTask workloadTask) {
-                            wlmGroupId = workloadTask.getWorkloadGroupId();
-                        }
-                        attributes.put(Attribute.WLM_GROUP_ID, wlmGroupId);
-                        String targetWlmGroupId = request.getWlmGroupId();
-                        if (targetWlmGroupId != null && !targetWlmGroupId.equals(wlmGroupId)) {
-                            // skip if this task's wlm group does not match user requested wlm group
-                            continue;
-                        }
-                        SearchQueryRecord record = new SearchQueryRecord(
-                            timestamp,
-                            measurements,
-                            attributes,
-                            taskInfo.getTaskId().toString()
-                        );
-
-                        allFilteredRecords.add(record);
-                    }
+                    List<SearchQueryRecord> allFilteredRecords = new ArrayList<>(recordMap.values());
 
                     // Sort descending by the requested metric and apply size limit in one pass
                     List<SearchQueryRecord> finalRecords = allFilteredRecords.stream()
@@ -146,4 +135,5 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
             }
         });
     }
+
 }

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -95,6 +95,43 @@ public class QueryInsightsSettings {
     public static final int DEFAULT_LIVE_QUERIES_SIZE = 100;
 
     /**
+     * Maximum cache size for live queries
+     */
+    public static final int LIVE_QUERIES_MAX_CACHE_SIZE = 1000;
+
+    /**
+     * Maximum number of queries to return for live queries
+     */
+    public static final int LIVE_QUERIES_MAX_RETURNED_QUERIES = 100;
+
+    /**
+     * Polling interval in milliseconds for live queries cache
+     */
+    public static final int LIVE_QUERIES_POLLING_INTERVAL_MS = 10;
+
+    /**
+     * Default idle timeout for live queries cache (5 minutes)
+     */
+    public static final TimeValue DEFAULT_LIVE_QUERIES_CACHE_IDLE_TIMEOUT = new TimeValue(5, TimeUnit.MINUTES);
+
+    /**
+     * Setting for live queries cache idle timeout.
+     * Set to -1 to disable auto-stop. Minimum is 2 minutes, maximum is 10 minutes.
+     */
+    public static final Setting<TimeValue> LIVE_QUERIES_CACHE_IDLE_TIMEOUT = Setting.timeSetting(
+        "search.insights.live_queries.cache_timeout",
+        DEFAULT_LIVE_QUERIES_CACHE_IDLE_TIMEOUT,
+        new TimeValue(-1, TimeUnit.MILLISECONDS),
+        value -> {
+            if (value.millis() != -1 && (value.millis() < TimeUnit.MINUTES.toMillis(2) || value.millis() > TimeUnit.MINUTES.toMillis(10))) {
+                throw new IllegalArgumentException("Live queries cache idle timeout must be -1 (disabled) or between 2 and 10 minutes");
+            }
+        },
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
+    /**
      * Default timeout for search requests in query insights operations
      */
     public static final TimeValue DEFAULT_SEARCH_REQUEST_TIMEOUT = new TimeValue(10, TimeUnit.SECONDS);

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -110,6 +110,7 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
                 QueryInsightsSettings.TOP_N_EXPORTER_TYPE,
                 QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES,
                 QueryInsightsSettings.TOP_N_QUERIES_MAX_SOURCE_LENGTH,
+                QueryInsightsSettings.LIVE_QUERIES_CACHE_IDLE_TIMEOUT,
                 QueryCategorizationSettings.SEARCH_QUERY_FIELD_TYPE_CACHE_SIZE_KEY
             ),
             queryInsightsPlugin.getSettings()

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -410,6 +410,7 @@ final public class QueryInsightsTestUtils {
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_EXPORTER_DELETE_AFTER);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_EXCLUDED_INDICES);
         clusterSettings.registerSetting(QueryInsightsSettings.TOP_N_QUERIES_MAX_SOURCE_LENGTH);
+        clusterSettings.registerSetting(QueryInsightsSettings.LIVE_QUERIES_CACHE_IDLE_TIMEOUT);
         clusterSettings.registerSetting(QueryCategorizationSettings.SEARCH_QUERY_METRICS_ENABLED_SETTING);
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/core/service/LiveQueriesCacheTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/LiveQueriesCacheTests.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.opensearch.action.admin.cluster.node.tasks.list.TaskGroup;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.tasks.TaskInfo;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class LiveQueriesCacheTests extends OpenSearchTestCase {
+
+    private Client client;
+    private ThreadPool threadPool;
+    private TransportService transportService;
+    private LiveQueriesCache cache;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        client = mock(Client.class);
+        threadPool = new TestThreadPool("test");
+        transportService = mock(TransportService.class);
+        cache = new LiveQueriesCache(client, threadPool, transportService, -1);
+    }
+
+    public void testCollectChildTaskStats() throws Exception {
+        TaskInfo parentTask = createTaskInfo("node1:1", "indices:data/read/search", null, 1000L, 2000L);
+        TaskInfo childTask1 = createTaskInfo("node1:2", "indices:data/read/search[phase/query]", "node1:1", 500L, 1000L);
+        TaskInfo childTask2 = createTaskInfo("node1:3", "indices:data/read/search[phase/fetch]", "node1:1", 300L, 800L);
+
+        TaskGroup child1Group = new TaskGroup(childTask1, new ArrayList<>());
+        TaskGroup child2Group = new TaskGroup(childTask2, new ArrayList<>());
+        TaskGroup parentGroup = new TaskGroup(parentTask, List.of(child1Group, child2Group));
+
+        ListTasksResponse response = new ListTasksResponse(
+            List.of(parentTask, childTask1, childTask2),
+            new ArrayList<>(),
+            new ArrayList<>()
+        );
+
+        // Test implementation would require proper mocking of client.admin().cluster().listTasks()
+
+        cache.start();
+        Thread.sleep(500);
+
+        List<org.opensearch.plugin.insights.rules.model.SearchQueryRecord> queries = cache.getCurrentQueries();
+        assertEquals(0, queries.size());
+
+        threadPool.shutdown();
+    }
+
+    private TaskInfo createTaskInfo(String taskId, String action, String parentTaskId, long cpu, long mem) {
+        String[] parts = taskId.split(":");
+        TaskId tid = new TaskId(parts[0], Long.parseLong(parts[1]));
+        TaskId ptid = parentTaskId != null
+            ? new TaskId(parentTaskId.split(":")[0], Long.parseLong(parentTaskId.split(":")[1]))
+            : TaskId.EMPTY_TASK_ID;
+        return new TaskInfo(tid, "test", action, "test", null, 0L, 0L, false, false, ptid, new HashMap<>(), null);
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -732,4 +732,14 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         updatedQueryInsightsService.queryInsightsExporterFactory.createLocalIndexExporter(TOP_QUERIES_EXPORTER_ID, "YYYY.MM.dd", "");
         return List.of(updatedQueryInsightsService, updatedClusterService);
     }
+
+    public void testGetLiveQueriesCache() {
+        // Test lazy initialization
+        LiveQueriesCache cache1 = queryInsightsService.getLiveQueriesCache();
+        assertNotNull(cache1);
+
+        // Test that subsequent calls return the same instance
+        LiveQueriesCache cache2 = queryInsightsService.getLiveQueriesCache();
+        assertSame(cache1, cache2);
+    }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -687,7 +687,7 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
             List<SearchQueryRecord> recordsToReturn = mockRecords.stream()
                 .filter(r -> readerIdFilter == null || readerIdFilter.equals(r.getId()))
                 .toList();
-            listener.onResponse(new java.util.ArrayList<>(recordsToReturn));
+            listener.onResponse(new ArrayList<>(recordsToReturn));
             return null;
         }).when(mockReader).read(eq(from), eq(to), eq(targetId), eq(null), eq(MetricType.LATENCY), any(ActionListener.class));
 
@@ -751,7 +751,7 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
 
         doAnswer(invocation -> {
             ActionListener<List<SearchQueryRecord>> listener = invocation.getArgument(5);
-            listener.onResponse(new java.util.ArrayList<>());
+            listener.onResponse(new ArrayList<>());
             return null;
         }).when(mockReader).read(anyString(), anyString(), any(), any(), any(MetricType.class), any(ActionListener.class));
 

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequestTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesRequestTests.java
@@ -27,7 +27,7 @@ public class LiveQueriesRequestTests extends OpenSearchTestCase {
         String[] nodeIds = new String[] { "nodeA", "nodeB", "nodeC" };
         String wlmGroupId = "DEFAULT_WORKLOAD_GROUP";
 
-        LiveQueriesRequest originalRequest = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroupId);
+        LiveQueriesRequest originalRequest = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroupId, null, false);
 
         BytesStreamOutput out = new BytesStreamOutput();
         originalRequest.writeTo(out);
@@ -48,7 +48,7 @@ public class LiveQueriesRequestTests extends OpenSearchTestCase {
         String[] nodeIds = new String[0];
         String wlmGroupId = "DEFAULT_WORKLOAD_GROUP";
 
-        LiveQueriesRequest originalRequest = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroupId);
+        LiveQueriesRequest originalRequest = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroupId, null, false);
 
         BytesStreamOutput out = new BytesStreamOutput();
         originalRequest.writeTo(out);
@@ -70,7 +70,7 @@ public class LiveQueriesRequestTests extends OpenSearchTestCase {
         String[] nodeIds = { "node1", "node2" };
         String wlmGroupId = "DEFAULT_WORKLOAD_GROUP";
 
-        LiveQueriesRequest request = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroupId);
+        LiveQueriesRequest request = new LiveQueriesRequest(verbose, sortBy, size, nodeIds, wlmGroupId, null, false);
 
         assertTrue(request.isVerbose());
         assertEquals(MetricType.CPU, request.getSortBy());
@@ -108,7 +108,9 @@ public class LiveQueriesRequestTests extends OpenSearchTestCase {
             MetricType.MEMORY,
             10,
             new String[] { "nodeA" },
-            "DEFAULT_WORKLOAD_GROUP"
+            "DEFAULT_WORKLOAD_GROUP",
+            null,
+            false
         );
         assertFalse(request.isVerbose());
         assertEquals(MetricType.MEMORY, request.getSortBy());

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -192,9 +193,9 @@ public class SearchQueryRecordTests extends OpenSearchTestCase {
     public void testToXContentForExportWithObjectSource() throws IOException {
         // Create record with SearchSourceBuilder for object source test
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().size(10);
-        java.util.Map<MetricType, Measurement> measurements = new java.util.HashMap<>();
+        Map<MetricType, Measurement> measurements = new HashMap<>();
         measurements.put(MetricType.LATENCY, new Measurement(100.0));
-        java.util.Map<Attribute, Object> attributes = new java.util.HashMap<>();
+        Map<Attribute, Object> attributes = new HashMap<>();
         attributes.put(Attribute.SOURCE, new SourceString(sourceBuilder.toString()));
 
         SearchQueryRecord record = new SearchQueryRecord(System.currentTimeMillis(), measurements, attributes, sourceBuilder, "test-id");

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/CacheIdleTimeoutRestIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/CacheIdleTimeoutRestIT.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.resthandler.live_queries;
+
+import java.io.IOException;
+import java.util.Map;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.plugin.insights.QueryInsightsRestTestCase;
+
+/**
+ * Integration tests for cache idle timeout behavior
+ */
+public class CacheIdleTimeoutRestIT extends QueryInsightsRestTestCase {
+
+    public void testLiveCacheStartsOnAccess() throws IOException {
+        // Access live queries to start cache
+        Request request = new Request("GET", "/_insights/live_queries");
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        assertTrue(responseMap.containsKey("live_queries"));
+    }
+
+    public void testCacheIdleTimeout() throws IOException, InterruptedException {
+        // Start cache
+        Request request = new Request("GET", "/_insights/live_queries");
+        client().performRequest(request);
+
+        // Wait a short time (simulating idle)
+        Thread.sleep(1000);
+
+        // Cache should still work after short wait
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/LiveQueriesAPIExamplesIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/LiveQueriesAPIExamplesIT.java
@@ -1,0 +1,136 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.resthandler.live_queries;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.plugin.insights.QueryInsightsRestTestCase;
+import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
+
+/**
+ * Integration tests that validate the exact API behavior shown in the examples
+ */
+public class LiveQueriesAPIExamplesIT extends QueryInsightsRestTestCase {
+
+    /**
+     * Test the exact API call: GET /_insights/live_queries?use_live_cache=true
+     * Should return only live queries
+     */
+    @SuppressWarnings("unchecked")
+    public void testLiveQueriesOnlyCached() throws IOException {
+        Request request = new Request("GET", "/_insights/live_queries?use_live_cache=true");
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        Map<String, Object> responseMap = entityAsMap(response);
+
+        // Validate response structure matches the example
+        assertTrue("Response should contain live_queries", responseMap.containsKey("live_queries"));
+        assertFalse("Response should not contain finished_queries", responseMap.containsKey("finished_queries"));
+
+        List<Map<String, Object>> liveQueries = (List<Map<String, Object>>) responseMap.get("live_queries");
+        assertNotNull("Live queries list should not be null", liveQueries);
+
+        // If there are live queries, validate their structure
+        for (Map<String, Object> query : liveQueries) {
+            validateLiveQueryStructure(query);
+        }
+    }
+
+    private void validateLiveQueryStructure(Map<String, Object> query) {
+        // Required fields for live queries
+        assertTrue("Query should have timestamp", query.containsKey("timestamp"));
+        assertTrue("Query should have id", query.containsKey("id"));
+        assertTrue("Query should have node_id", query.containsKey("node_id"));
+        assertTrue("Query should have measurements", query.containsKey("measurements"));
+
+        // Validate timestamp is a number
+        assertTrue("Timestamp should be a number", query.get("timestamp") instanceof Number);
+
+        // Validate id is a string
+        assertTrue("ID should be a string", query.get("id") instanceof String);
+
+        // Validate node_id is a string
+        assertTrue("Node ID should be a string", query.get("node_id") instanceof String);
+
+        // Validate measurements structure
+        @SuppressWarnings("unchecked")
+        Map<String, Object> measurements = (Map<String, Object>) query.get("measurements");
+        validateMeasurementsStructure(measurements);
+    }
+
+    /**
+     * Validate the measurements structure
+     */
+    private void validateMeasurementsStructure(Map<String, Object> measurements) {
+        // Should have the three main metrics
+        assertTrue("Measurements should include latency", measurements.containsKey("latency"));
+        assertTrue("Measurements should include cpu", measurements.containsKey("cpu"));
+        assertTrue("Measurements should include memory", measurements.containsKey("memory"));
+
+        // Validate each measurement's structure
+        for (String metricType : new String[] { "latency", "cpu", "memory" }) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> metric = (Map<String, Object>) measurements.get(metricType);
+            assertTrue("Metric should have number", metric.containsKey("number"));
+            assertTrue("Metric should have count", metric.containsKey("count"));
+            assertTrue("Metric should have aggregationType", metric.containsKey("aggregationType"));
+
+            // Validate types
+            assertTrue("Number should be a number", metric.get("number") instanceof Number);
+            assertTrue("Count should be a number", metric.get("count") instanceof Number);
+            assertTrue("AggregationType should be a string", metric.get("aggregationType") instanceof String);
+        }
+    }
+
+    /**
+     * Test parameter combinations that should work
+     */
+    @SuppressWarnings("unchecked")
+    public void testValidParameterCombinations() throws IOException {
+        String[] validCombinations = {
+            "?use_live_cache=true",
+            "?use_live_cache=false",
+            "?use_live_cache=true&verbose=true",
+            "?use_live_cache=true&sort=cpu&size=5",
+            "?wlmGroupId=DEFAULT_WORKLOAD_GROUP",
+            "?use_live_cache=true&wlmGroupId=DEFAULT_WORKLOAD_GROUP" };
+
+        for (String params : validCombinations) {
+            Request request = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI + params);
+            Response response = client().performRequest(request);
+            assertEquals("Parameters: " + params, 200, response.getStatusLine().getStatusCode());
+
+            Map<String, Object> responseMap = entityAsMap(response);
+            assertTrue("Response should contain live_queries for params: " + params, responseMap.containsKey("live_queries"));
+        }
+    }
+
+    /**
+     * Test that the API respects size limits
+     */
+    @SuppressWarnings("unchecked")
+    public void testSizeLimits() throws IOException {
+        int[] sizeLimits = { 1, 5, 10, 50 };
+
+        for (int size : sizeLimits) {
+            Request request = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI + "?size=" + size);
+            Response response = client().performRequest(request);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+
+            Map<String, Object> responseMap = entityAsMap(response);
+            List<Map<String, Object>> liveQueries = (List<Map<String, Object>>) responseMap.get("live_queries");
+
+            assertTrue("Live queries should respect size limit of " + size, liveQueries.size() <= size);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/LiveQueriesCachedRestIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/LiveQueriesCachedRestIT.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.resthandler.live_queries;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.plugin.insights.QueryInsightsRestTestCase;
+import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
+
+/**
+ * Integration tests for cached parameter in Live Queries API
+ */
+public class LiveQueriesCachedRestIT extends QueryInsightsRestTestCase {
+
+    /**
+     * Test use_live_cache parameter functionality
+     */
+    @SuppressWarnings("unchecked")
+    public void testCachedParameter() throws IOException {
+        // Test use_live_cache=true
+        Request cachedRequest = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI + "?use_live_cache=true");
+        Response cachedResponse = client().performRequest(cachedRequest);
+        assertEquals(200, cachedResponse.getStatusLine().getStatusCode());
+
+        Map<String, Object> cachedMap = entityAsMap(cachedResponse);
+        assertTrue("Response should contain live_queries", cachedMap.containsKey("live_queries"));
+        List<Map<String, Object>> cachedQueries = (List<Map<String, Object>>) cachedMap.get("live_queries");
+        assertNotNull("Live queries list should not be null", cachedQueries);
+
+        // Test use_live_cache=false (default behavior)
+        Request nonCachedRequest = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI + "?use_live_cache=false");
+        Response nonCachedResponse = client().performRequest(nonCachedRequest);
+        assertEquals(200, nonCachedResponse.getStatusLine().getStatusCode());
+
+        Map<String, Object> nonCachedMap = entityAsMap(nonCachedResponse);
+        assertTrue("Response should contain live_queries", nonCachedMap.containsKey("live_queries"));
+        List<Map<String, Object>> nonCachedQueries = (List<Map<String, Object>>) nonCachedMap.get("live_queries");
+        assertNotNull("Live queries list should not be null", nonCachedQueries);
+    }
+
+    /**
+     * Test use_live_cache parameter
+     */
+    @SuppressWarnings("unchecked")
+    public void testCachedAndIncludeFinishedTogether() throws IOException {
+        Request request = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI + "?use_live_cache=true");
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        assertTrue("Response should contain live_queries", responseMap.containsKey("live_queries"));
+
+        List<Map<String, Object>> liveQueries = (List<Map<String, Object>>) responseMap.get("live_queries");
+        assertNotNull("Live queries list should not be null", liveQueries);
+    }
+
+    /**
+     * Test wlmGroupId parameter
+     */
+    @SuppressWarnings("unchecked")
+    public void testWlmGroupIdParameter() throws IOException {
+        Request request = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI + "?wlmGroupId=DEFAULT_WORKLOAD_GROUP");
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        assertTrue("Response should contain live_queries", responseMap.containsKey("live_queries"));
+        List<Map<String, Object>> liveQueries = (List<Map<String, Object>>) responseMap.get("live_queries");
+        assertNotNull("Live queries list should not be null", liveQueries);
+    }
+
+    /**
+     * Test all new parameters together
+     */
+    @SuppressWarnings("unchecked")
+    public void testAllNewParametersTogether() throws IOException {
+        String params = "?use_live_cache=true&wlmGroupId=DEFAULT_WORKLOAD_GROUP&verbose=true&sort=latency&size=10";
+        Request request = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI + params);
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        assertTrue("Response should contain live_queries", responseMap.containsKey("live_queries"));
+
+        List<Map<String, Object>> liveQueries = (List<Map<String, Object>>) responseMap.get("live_queries");
+        assertNotNull("Live queries list should not be null", liveQueries);
+
+        // Verify that the size limit is respected (should be <= 10)
+        assertTrue("Live queries should respect size limit", liveQueries.size() <= 10);
+    }
+
+    /**
+     * Test parameter validation for use_live_cache parameter
+     */
+    public void testInvalidCachedParameterValidation() throws IOException {
+        String[] invalidCachedValues = { "invalid", "1", "yes", "no" };
+
+        for (String invalidValue : invalidCachedValues) {
+            Request request = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI + "?use_live_cache=" + invalidValue);
+            try {
+                client().performRequest(request);
+                fail("Should have failed with invalid use_live_cache parameter: " + invalidValue);
+            } catch (Exception e) {
+                assertTrue(
+                    "Error should mention boolean parameter validation",
+                    e.getMessage().contains("Failed to parse value") || e.getMessage().contains("only [true] or [false] are allowed")
+                );
+            }
+        }
+    }
+
+    /**
+     * Test that default values work correctly
+     */
+    @SuppressWarnings("unchecked")
+    public void testDefaultParameterValues() throws IOException {
+        // Test with no parameters (should use defaults)
+        Request request = new Request("GET", QueryInsightsSettings.LIVE_QUERIES_BASE_URI);
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        Map<String, Object> responseMap = entityAsMap(response);
+        assertTrue("Response should contain live_queries", responseMap.containsKey("live_queries"));
+
+        List<Map<String, Object>> liveQueries = (List<Map<String, Object>>) responseMap.get("live_queries");
+        assertNotNull("Live queries list should not be null", liveQueries);
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/LiveQueriesRestIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/live_queries/LiveQueriesRestIT.java
@@ -10,6 +10,7 @@ package org.opensearch.plugin.insights.rules.resthandler.live_queries;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -123,7 +124,7 @@ public class LiveQueriesRestIT extends QueryInsightsRestTestCase {
         String nodeId = nodes.keySet().iterator().next();
 
         String[] params = new String[] { "?size=1", "", "?sort=cpu", "?verbose=false", "?nodeId=" + nodeId };
-        Map<String, Boolean> foundParams = new java.util.HashMap<>();
+        Map<String, Boolean> foundParams = new HashMap<>();
         for (String param : params) {
             foundParams.put(param, false);
         }


### PR DESCRIPTION
### Description

This PR implements a live queries cache feature that polls running search queries with task resource aggregation and provides real-time query monitoring capabilities. The cache includes configurable idle timeout with automatic stop functionality to optimize resource usage.

### Changes

#### Live Queries Cache Implementation

- **New Class**: `LiveQueriesCache` - Polls running search tasks every 1 second
- Maintains top 1000 queries sorted by latency, returns top 100
- Extracts comprehensive query metadata:
  - Latency, CPU, and memory measurements with task resource aggregation
  - Task resource usage information from all search phases
  - Workload group ID (WLM integration)
  - User information (username and roles via `PrincipalExtractor`)
  - Query description and cancellation status
  - Node ID

#### Task Resource Aggregation
- Aggregates CPU and memory usage from task resource stats
- Extracts `total` resource usage from `TaskResourceStats`
- Provides accurate resource consumption metrics for running queries
- Includes detailed `TaskResourceInfo` in response with action, task IDs, and resource usage

#### New API Parameter: `use_live_cache`

The `/_insights/live_queries` API now supports a `use_live_cache` parameter:

**When `use_live_cache=true`**: Returns queries from the in-memory cache (updated every 1 second)
- Faster response times - no real-time task list API call
- Suitable for monitoring dashboards that poll frequently
- Cache starts automatically on first use

**When `use_live_cache=false` or omitted**: Makes real-time `ListTasksRequest` call
- Returns current running queries directly from task manager
- Default behavior (backward compatible)

#### Configurable Idle Timeout Setting
- **Setting**: `search.insights.live_queries.cache.idle_timeout`
- **Default**: 5 minutes
- **Range**: 2-10 minutes
- **Special Value**: `-1` to disable cache (throws error when attempting to use)
- **Type**: Dynamic cluster setting

#### Cache Behavior
- Cache starts lazily on first `use_live_cache=true` API call
- Polls running tasks every 1 second using `ListTasksRequest` with detailed stats
- Automatically stops after configured idle period with no API requests
- When disabled (`-1`), API returns clear error message
- Cache clears memory on stop to free resources

### Usage Examples

#### Example 1: Get live queries using cache (fast, cached response)
```bash
curl -X GET "http://localhost:9200/_insights/live_queries?use_live_cache=true&pretty"
{
  "live_queries" : [
    {
      "timestamp" : 1769207048182,
      "id" : "KBK9GE-vRO2gJHiFyVAFjw:64478",
      "node_id" : "KBK9GE-vRO2gJHiFyVAFjw",
      "description" : "indices[test-index], search_type[QUERY_THEN_FETCH], source[{\"size\":1000,\"query\":{\"match_all\":{\"boost\":1.0}}}]",
      "wlm_group_id" : null,
      "task_resource_usages" : [
        {
          "action" : "indices:data/read/search",
          "taskId" : 64478,
          "parentTaskId" : -1,
          "nodeId" : "KBK9GE-vRO2gJHiFyVAFjw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 0,
            "memory_in_bytes" : 0
          }
        },
        {
          "action" : "indices:data/read/search[phase/query]",
          "taskId" : 64479,
          "parentTaskId" : 64478,
          "nodeId" : "KBK9GE-vRO2gJHiFyVAFjw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 0,
            "memory_in_bytes" : 0
          }
        }
      ],
      "is_cancelled" : false,
      "measurements" : {
        "memory" : {
          "number" : 0,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "cpu" : {
          "number" : 0,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 528502625,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    },
    {
      "timestamp" : 1769207048187,
      "id" : "KBK9GE-vRO2gJHiFyVAFjw:64480",
      "node_id" : "KBK9GE-vRO2gJHiFyVAFjw",
      "description" : "indices[test-index], search_type[QUERY_THEN_FETCH], source[{\"size\":1000,\"query\":{\"match_all\":{\"boost\":1.0}}}]",
      "wlm_group_id" : null,
      "task_resource_usages" : [
        {
          "action" : "indices:data/read/search",
          "taskId" : 64480,
          "parentTaskId" : -1,
          "nodeId" : "KBK9GE-vRO2gJHiFyVAFjw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 0,
            "memory_in_bytes" : 0
          }
        },
        {
          "action" : "indices:data/read/search[phase/query]",
          "taskId" : 64481,
          "parentTaskId" : 64480,
          "nodeId" : "KBK9GE-vRO2gJHiFyVAFjw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 0,
            "memory_in_bytes" : 0
          }
        }
      ],
      "is_cancelled" : false,
      "measurements" : {
        "memory" : {
          "number" : 0,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "cpu" : {
          "number" : 0,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 522958042,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    }
  ]
}
```
Example 2: Get live queries without cache (real-time, direct from task manager)

```
curl -X GET "http://localhost:9200/_insights/live_queries?pretty"

```
Example 3: Set idle timeout to 2 minutes
```curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
{
  "persistent": {
    "search.insights.live_queries.cache.idle_timeout": "2m"
  }
}'
```
```
Response:

{
  "acknowledged": true,
  "persistent": {
    "search": {
      "insights": {
        "live_queries": {
          "cache": {
            "idle_timeout": "2m"
          }
        }
      }
    }
  },
  "transient": {}
}
```
Example 4: Cache auto-stops after idle timeout

 First request - cache starts
```curl -X GET "http://localhost:9200/_insights/live_queries?use_live_cache=true&pretty"```
 Returns queries...

Wait 2+ minutes (if timeout set to 2m)

Second request - cache has stopped, returns empty
```curl -X GET "http://localhost:9200/_insights/live_queries?use_live_cache=true&pretty"```

Response after idle timeout:
```
{
  "live_queries": []
}
```


Example 5: Disable cache
```curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
{
  "persistent": {
    "search.insights.live_queries.cache.idle_timeout": "-1"
  }
}'
```

Response:
```
{
  "acknowledged": true,
  "persistent": {
    "search": {
      "insights": {
        "live_queries": {
          "cache": {
            "idle_timeout": "-1"
          }
        }
      }
    }
  },
  "transient": {}
}
```

Example 6: Error when cache is disabled

```
curl -X GET "http://localhost:9200/_insights/live_queries?use_live_cache=true&pretty"
```
Response:
```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_state_exception",
        "reason": "Live queries cache is disabled. Set search.insights.live_queries.cache.idle_timeout to a positive value (2-10 minutes) to enable it."
      }
    ],
    "type": "illegal_state_exception",
    "reason": "Live queries cache is disabled. Set search.insights.live_queries.cache.idle_timeout to a positive value (2-10 minutes) to enable it."
  },
  "status": 500
}
```
without use_live_cache
```
 curl -s "http://localhost:9200/_insights/live_queries?pretty" | head -80
{
  "live_queries" : [
    {
      "timestamp" : 1769213176483,
      "id" : "KBK9GE-vRO2gJHiFyVAFjw:11130",
      "task_resource_usages" : [
        {
          "action" : "indices:data/read/search",
          "taskId" : 11130,
          "parentTaskId" : -1,
          "nodeId" : "KBK9GE-vRO2gJHiFyVAFjw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 0,
            "memory_in_bytes" : 0
          }
        },
        {
          "action" : "indices:data/read/search[phase/query]",
          "taskId" : 11131,
          "parentTaskId" : 11130,
          "nodeId" : "KBK9GE-vRO2gJHiFyVAFjw",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 7050000,
            "memory_in_bytes" : 3733696
          }
        }
      ],
      "is_cancelled" : false,
      "description" : "indices[test-index], search_type[QUERY_THEN_FETCH], source[{\"size\":1000,\"query\":{\"match_all\":{\"boost\":1.0}}}]",
      "wlm_group_id" : "DEFAULT_WORKLOAD_GROUP",
      "node_id" : "KBK9GE-vRO2gJHiFyVAFjw",
      "measurements" : {
        "memory" : {
          "number" : 3733696,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "cpu" : {
          "number" : 7050000,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 2014466583,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    }
}
```

