### PR TITLE
Fix excluded indices integ test

### DIFF
--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperByNoneIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperByNoneIT.java
@@ -22,6 +22,7 @@ public class MinMaxQueryGrouperByNoneIT extends QueryInsightsRestTestCase {
      */
     public void testGroupingByNone() throws IOException, InterruptedException {
 
+        updateClusterSettings(this::disableTopQueriesSettings);
         updateClusterSettings(this::groupByNoneSettings);
 
         waitForEmptyTopQueriesResponse();
@@ -38,7 +39,7 @@ public class MinMaxQueryGrouperByNoneIT extends QueryInsightsRestTestCase {
         return "{\n"
             + "    \"persistent\" : {\n"
             + "        \"search.insights.top_queries.latency.enabled\" : \"true\",\n"
-            + "        \"search.insights.top_queries.latency.window_size\" : \"1m\",\n"
+            + "        \"search.insights.top_queries.latency.window_size\" : \"5m\",\n"
             + "        \"search.insights.top_queries.latency.top_n_size\" : 100,\n"
             + "        \"search.insights.top_queries.grouping.group_by\" : \"none\",\n"
             + "        \"search.insights.top_queries.grouping.max_groups_excluding_topn\" : 5\n"

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperIT.java
@@ -27,7 +27,8 @@ public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
         doSearch("match", 6);
         doSearch("term", 4);
 
-        assertTopQueriesCount(12, "latency");
+        // defaultTopQueriesSettings is latency.top_n_size = 5
+        assertTopQueriesCount(5, "latency");
 
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
 
@@ -66,7 +67,8 @@ public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
         doSearch("match", 6);
         doSearch("term", 4);
 
-        assertTopQueriesCount(12, "latency");
+        // defaultTopQueriesSettings is latency.top_n_size = 5
+        assertTopQueriesCount(5, "latency");
     }
 
     public void testSimilarityMaxGroupsChanged() throws IOException, InterruptedException {


### PR DESCRIPTION
### Description
`assertTopQueriesCount()` subString match is failing and the method uses a soft check `topNArraySize < expectedTopQueriesCount`. This allowed the excluded indices tests to improperly pass.

### Solution
1. Fail test if `topNArraySize != expectedTopQueriesCount`
2. Use `countOccurrences` instead of `countTopQueries` when substring arg is provided
3. Update existing tests with correct values to adhere to strict assertion
4. Reset state in `testExcludedIndices` to avoid flakiness

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
