### PR TITLE
Add username and user roles to top n queries

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -95,7 +95,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             new QueryInsightsExporterFactory(client, clusterService),
             new QueryInsightsReaderFactory(client)
         );
-        return List.of(queryInsightsService, new QueryInsightsListener(clusterService, queryInsightsService, false));
+        return List.of(queryInsightsService, new QueryInsightsListener(clusterService, queryInsightsService, threadPool, false));
     }
 
     @Override

--- a/src/main/java/org/opensearch/plugin/insights/core/auth/PrincipalExtractor.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/auth/PrincipalExtractor.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.auth;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.common.Strings;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * Extracts the principal (username and roles) from the thread context when security plugin is available
+ */
+public class PrincipalExtractor {
+    private static final String SECURITY_USER_INFO_THREAD_CONTEXT = "_opendistro_security_user_info";
+    private static final Pattern PIPE_DELIMITER_PATTERN = Pattern.compile("(?<!\\\\)\\|");
+
+    private final ThreadPool threadPool;
+
+    public PrincipalExtractor(ThreadPool threadPool) {
+        this.threadPool = threadPool;
+    }
+
+    /**
+     * Extract username and roles from thread context
+     * @return UserPrincipalInfo containing username and roles, or null if not available
+     */
+    public UserPrincipalInfo extractUserInfo() {
+        return parseUserInfo();
+    }
+
+    /**
+     * Parses a user string into {@link UserPrincipalInfo}.
+     * User String format is pipe separated: user_name|backendroles|roles|...
+     * We only extract the username (index 0) and roles (index 2).
+     */
+    private UserPrincipalInfo parseUserInfo() {
+        ThreadContext threadContext = threadPool.getThreadContext();
+        String userStr = threadContext.getTransient(SECURITY_USER_INFO_THREAD_CONTEXT);
+
+        if (Strings.isNullOrEmpty(userStr)) {
+            return null;
+        }
+
+        String[] strs = PIPE_DELIMITER_PATTERN.split(userStr);
+        if (strs.length == 0 || Strings.isNullOrEmpty(strs[0])) {
+            return null;
+        }
+
+        String userName = unescapePipe(strs[0].trim());
+        List<String> roles = List.of();
+
+        if (strs.length > 2 && !Strings.isNullOrEmpty(strs[2])) {
+            roles = Arrays.stream(strs[2].split(",")).map(this::unescapePipe).toList();
+        }
+
+        return new UserPrincipalInfo(userName, roles);
+    }
+
+    private String unescapePipe(String input) {
+        return input == null ? "" : input.replace("\\|", "|");
+    }
+
+    /**
+     * Holds parsed user information (username and roles).
+     */
+    public static class UserPrincipalInfo {
+        private final String userName;
+        private final List<String> roles;
+
+        UserPrincipalInfo(String userName, List<String> roles) {
+            this.userName = userName;
+            this.roles = List.copyOf(roles);
+        }
+
+        public String getUserName() {
+            return userName;
+        }
+
+        public List<String> getRoles() {
+            return roles;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/core/auth/package-info.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/auth/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Authentication and authorization utilities for Query Insights.
+ *
+ * This package contains classes for extracting user principal information
+ * from the thread context when the security plugin is available.
+ */
+package org.opensearch.plugin.insights.core.auth;

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -82,7 +82,17 @@ public enum Attribute {
     /**
      * The cancelled of the search query, often used in live queries.
      */
-    IS_CANCELLED;
+    IS_CANCELLED,
+
+    /**
+     * The username who initiated the search query.
+     */
+    USERNAME,
+
+    /**
+     * The roles of the user who initiated the search query.
+     */
+    USER_ROLES;
 
     /**
      * Read an Attribute from a StreamInput

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -117,6 +117,14 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      */
     public static final String WLM_GROUP_ID = "wlm_group_id";
     /**
+     * The username who initiated the search query
+     */
+    public static final String USERNAME = "username";
+    /**
+     * The roles of the user who initiated the search query
+     */
+    public static final String USER_ROLES = "user_roles";
+    /**
      * Default, immutable `top_n_query` map. All values initialized to {@code false}
      */
     public static final Map<String, Boolean> DEFAULT_TOP_N_QUERY_MAP = Collections.unmodifiableMap(
@@ -291,6 +299,18 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
                         break;
                     case WLM_GROUP_ID:
                         attributes.put(Attribute.WLM_GROUP_ID, parser.text());
+                        break;
+                    case USERNAME:
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.currentToken(), parser);
+                        attributes.put(Attribute.USERNAME, parser.text());
+                        break;
+                    case USER_ROLES:
+                        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+                        List<String> userRoles = new ArrayList<>();
+                        while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                            userRoles.add(parser.text());
+                        }
+                        attributes.put(Attribute.USER_ROLES, userRoles.toArray(new String[0]));
                         break;
                     case TASK_RESOURCE_USAGES:
                         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);

--- a/src/main/resources/mappings/top-queries-record.json
+++ b/src/main/resources/mappings/top-queries-record.json
@@ -17,6 +17,12 @@
         }
       }
     },
+    "username" : {
+      "type" : "keyword"
+    },
+    "user_roles" : {
+      "type" : "keyword"
+    },
     "timestamp" : {
       "type" : "long"
     },

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -158,6 +158,8 @@ final public class QueryInsightsTestUtils {
             attributes.put(Attribute.GROUP_BY, GroupingType.NONE);
             attributes.put(Attribute.NODE_ID, "node_for_top_queries_test");
             attributes.put(Attribute.TOP_N_QUERY, DEFAULT_TOP_N_QUERY_MAP);
+            attributes.put(Attribute.USERNAME, randomAlphaOfLengthBetween(5, 10));
+            attributes.put(Attribute.USER_ROLES, new String[] { randomAlphaOfLengthBetween(4, 8), randomAlphaOfLengthBetween(4, 8) });
             attributes.put(
                 Attribute.TASK_RESOURCE_USAGES,
                 List.of(
@@ -274,6 +276,8 @@ final public class QueryInsightsTestUtils {
             )
         );
         attributes.put(Attribute.TOP_N_QUERY, DEFAULT_TOP_N_QUERY_MAP);
+        attributes.put(Attribute.USERNAME, "testuser");
+        attributes.put(Attribute.USER_ROLES, new String[] { "admin", "user" });
 
         return new SearchQueryRecord(timestamp, measurements, attributes, id);
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/auth/PrincipalExtractorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/auth/PrincipalExtractorTests.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.auth;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * Unit tests for {@link PrincipalExtractor}
+ */
+public class PrincipalExtractorTests extends OpenSearchTestCase {
+    private ThreadPool threadPool;
+    private PrincipalExtractor principalExtractor;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool("PrincipalExtractorTest");
+        principalExtractor = new PrincipalExtractor(threadPool);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+    }
+
+    private PrincipalExtractor.UserPrincipalInfo extractUserInfoWithContext(String userInfoValue) {
+        ThreadContext threadContext = threadPool.getThreadContext();
+        threadContext.putTransient("_opendistro_security_user_info", userInfoValue);
+        return principalExtractor.extractUserInfo();
+    }
+
+    public void testExtractUserInfoFromThreadContext() {
+        PrincipalExtractor.UserPrincipalInfo userInfo = extractUserInfoWithContext("testuser|role1,role2|admin,user|tenant1|access1");
+        assertNotNull(userInfo);
+        assertEquals("testuser", userInfo.getUserName());
+        assertEquals(List.of("admin", "user"), userInfo.getRoles());
+    }
+
+    public void testExtractUserInfoNoThreadContext() {
+        PrincipalExtractor.UserPrincipalInfo userInfo = principalExtractor.extractUserInfo();
+        assertNull(userInfo);
+    }
+
+    public void testExtractUserInfoInvalidFormat() {
+        PrincipalExtractor.UserPrincipalInfo userInfo = extractUserInfoWithContext("|role1,role2|admin");
+        assertNull(userInfo);
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
@@ -71,6 +71,8 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
             + "}"
             + "}],"
             + "\"search_type\":\"query_then_fetch\","
+            + "\"username\":\"testuser\","
+            + "\"user_roles\":[\"admin\",\"user\"],"
             + "\"measurements\":{"
             + "\"latency\":{"
             + "\"number\":1,"


### PR DESCRIPTION
### Description
Add username and user roles to top n queries attributes to capture user information in query insights about who ran the queries. Corresponding tests were added as well.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Testing
1. Create a test user with specific roles
```
% curl -k -X PUT "localhost:9200/_plugins/_security/api/internalusers/testuser" \
-H 'Content-Type: application/json' \
-u admin:admin \
-d '{
  "password": "TestPass123!",
  "backend_roles": ["admin", "readall"]
}'
```
2. Send a search request as the test user
```
% curl -k -u testuser:TestPass123! -X GET "localhost:9200/_search" -H 'Content-Type: application/json' -d'
{
  "query": { "match_all": {} }
}'
```
3. Verify username and user_roles are captured in query insights 
```
% curl -k -u admin:admin -X GET "localhost:9200/_insights/top_queries?pretty"
```
Backend roles are mapped to user roles:
admin -> all_access
readall -> readall
and all users get own_index. 
```
{
  "top_queries" : [
    {
      "timestamp" : 1766522933488,
      "id" : "d0463734-cf13-4daf-aa39-3acd20783081",
      "wlm_group_id" : "DEFAULT_WORKLOAD_GROUP",
      "search_type" : "query_then_fetch",
      "source" : {
        "query" : {
          "match_all" : {
            "boost" : 1.0
          }
        }
      },
      "indices" : [ ],
      "total_shards" : 3,
      "phase_latency_map" : {
        "expand" : 0,
        "query" : 0,
        "fetch" : 0
      },
      "task_resource_usages" : [
        {
          "action" : "indices:data/read/search",
          "taskId" : 575,
          "parentTaskId" : -1,
          "nodeId" : "hCHQuMTaTaScUtgf3aLVlQ",
          "taskResourceUsage" : {
            "cpu_time_in_nanos" : 213000,
            "memory_in_bytes" : 23168
          }
        }
      ],
      "username" : "testuser",
      "node_id" : "hCHQuMTaTaScUtgf3aLVlQ",
      "group_by" : "NONE",
      "labels" : { },
      "user_roles" : [
        "own_index",
        "all_access",
        "readall"
      ],
      "measurements" : {
        "cpu" : {
          "number" : 213000,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "memory" : {
          "number" : 23168,
          "count" : 1,
          "aggregationType" : "NONE"
        },
        "latency" : {
          "number" : 1,
          "count" : 1,
          "aggregationType" : "NONE"
        }
      }
    }
  ]
}

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
