### PR TITLE
Skip new/unknown attributes during rolling upgrades [DRAFT]

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -103,11 +103,15 @@ public enum Attribute {
      * Read an Attribute from a StreamInput
      *
      * @param in the StreamInput to read from
-     * @return Attribute
+     * @return Attribute, or null if unknown
      * @throws IOException IOException
      */
     static Attribute readFromStream(final StreamInput in) throws IOException {
-        return Attribute.valueOf(in.readString().toUpperCase(Locale.ROOT));
+        try {
+            return Attribute.valueOf(in.readString().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     /**
@@ -203,6 +207,10 @@ public enum Attribute {
 
         for (int i = 0; i < size; i++) {
             Attribute key = readFromStream(in);
+            if (key == null) {
+                in.readGenericValue();
+                continue;
+            }
             Object value = readAttributeValue(in, key);
             map.put(key, value);
         }


### PR DESCRIPTION
### Description
Added try catch to readFromStream in Attribute.java so that during rolling upgrades, an old coordinator node can skip new/unknown attributes with a higher chance of not failing. The new attributes just won't be available until the upgrades have finished. 

### Issues Resolved
Closes [#510]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
