### PR TITLE
fix flaky test testTimeFilterIncludesSomeRecords

### DIFF
--- a/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/TopQueriesServiceTests.java
@@ -540,6 +540,9 @@ public class TopQueriesServiceTests extends OpenSearchTestCase {
         // Set a reasonable window size instead of Long.MAX_VALUE to avoid window calculation issues
         topQueriesService.setWindowSize(TimeValue.timeValueHours(1));
 
+        // Force initialize windowStart
+        topQueriesService.consumeRecords(new ArrayList<>());
+
         // Use current time to ensure records are in the current window
         long currentTime = System.currentTimeMillis();
 


### PR DESCRIPTION
### Description
fix flaky test testTimeFilterIncludesSomeRecords, it fails when running at the end of 1 hour.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
