### PR TITLE
Remove expired indices check on start-up

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/LocalIndexLifecycleManager.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/LocalIndexLifecycleManager.java
@@ -53,7 +53,7 @@ class LocalIndexLifecycleManager {
     LocalIndexLifecycleManager(final ThreadPool threadPool, final Client client, final int deleteAfter) {
         this.threadPool = threadPool;
         this.client = client;
-        setDeleteAfterAndDelete(deleteAfter);
+        setDeleteAfter(deleteAfter);
     }
 
     /**
@@ -62,6 +62,7 @@ class LocalIndexLifecycleManager {
      * @param deleteAfter the number of days after which Top N local indices should be deleted
      */
     void setDeleteAfter(final int deleteAfter) {
+        logger.info("Setting Query Insights delete after to [{}]", deleteAfter);
         this.deleteAfter = deleteAfter;
     }
 
@@ -80,7 +81,6 @@ class LocalIndexLifecycleManager {
      * @param deleteAfter the number of days after which Top N local indices should be deleted
      */
     void setDeleteAfterAndDelete(final int deleteAfter) {
-        logger.info("Setting Query Insights delete after to [{}]", deleteAfter);
         setDeleteAfter(deleteAfter);
 
         // Immediately delete all local indices when user sets value to '0'


### PR DESCRIPTION
### Description
Remove call to `deleteExpiredTopNIndices()` in `LocalIndexLifecycleManager` constructor. It is unnecessary to delete local indices immediately on node start (should be scheduled once per day around 00:05 UTC) and it is causing boot up errors:
```
[2026-01-15T15:58:24,273][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [integTest-0] uncaught exception in thread [opensearch[integTest-0][query_insights_executor][T#1]]
java.lang.IllegalStateException: NodeClient has not been initialized
        at org.opensearch.transport.client.node.NodeClient.transportAction(NodeClient.java:144)
        at org.opensearch.transport.client.node.NodeClient.executeLocally(NodeClient.java:113)
        at org.opensearch.transport.client.node.NodeClient.doExecute(NodeClient.java:100)
        at org.opensearch.transport.client.support.AbstractClient.execute(AbstractClient.java:501)
        at org.opensearch.transport.client.support.AbstractClient$ClusterAdmin.execute(AbstractClient.java:838)
        at org.opensearch.transport.client.support.AbstractClient$ClusterAdmin.state(AbstractClient.java:868)
        at org.opensearch.plugin.insights.core.service.LocalIndexLifecycleManager.lambda$deleteExpiredTopNIndices$0(LocalIndexLifecycleManager.java:121)
        at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:916)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
```

### Testing
Error does not appear with `./gradlew run` command

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
