### PR TITLE
Add integTestRemote target to support remote cluster testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,8 +282,25 @@ integTest {
   }
   systemProperty 'tests.security.manager', 'false'
   systemProperty 'project.root', project.projectDir.absolutePath
+
+  // Pass through system properties for remote cluster testing
+  systemProperty "https", System.getProperty("https")
+  systemProperty "user", System.getProperty("user")
+  systemProperty "password", System.getProperty("password")
+
   // Set default query size limit
   systemProperty 'defaultQuerySizeLimit', '10000'
+
+  // Only REST-based integration tests can run with remote cluster
+  if (System.getProperty("tests.rest.cluster") != null) {
+    filter {
+      includeTestsMatching 'org.opensearch.plugin.insights.*IT'
+      // Exclude tests that require multi-node cluster or internal cluster access
+      excludeTestsMatching 'org.opensearch.plugin.insights.QueryInsightsClusterIT'
+      excludeTestsMatching 'org.opensearch.plugin.insights.QueryInsightsPluginTransportIT'
+    }
+  }
+
   // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
   // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
   doFirst {
@@ -412,6 +429,48 @@ task integTestWithSecurity(type: RestIntegTestTask) {
     includeTestsMatching 'org.opensearch.plugin.insights.*IT'
     // QueryInsightsClusterIT requires 2+ nodes; excluded because demo SSL certs don't support multi-node in Java 21
     excludeTestsMatching 'org.opensearch.plugin.insights.QueryInsightsClusterIT'
+  }
+}
+
+task integTestRemote(type: RestIntegTestTask) {
+  testClassesDirs = sourceSets.test.output.classesDirs
+  classpath = sourceSets.test.runtimeClasspath
+  systemProperty 'tests.security.manager', 'false'
+  systemProperty 'project.root', project.projectDir.absolutePath
+
+  // Pass through system properties for remote cluster connection
+  systemProperty "https", System.getProperty("https")
+  systemProperty "user", System.getProperty("user")
+  systemProperty "password", System.getProperty("password")
+
+  // Set default query size limit
+  systemProperty 'defaultQuerySizeLimit', '10000'
+
+  // Only REST-based integration tests can run with remote cluster
+  if (System.getProperty("tests.rest.cluster") != null) {
+    filter {
+      includeTestsMatching 'org.opensearch.plugin.insights.*IT'
+      // Exclude tests that require multi-node cluster or internal cluster access
+      excludeTestsMatching 'org.opensearch.plugin.insights.QueryInsightsClusterIT'
+      excludeTestsMatching 'org.opensearch.plugin.insights.QueryInsightsPluginTransportIT'
+    }
+  }
+
+  if (System.getProperty("https") == null || System.getProperty("https") == "false") {
+    // No specific exclusions for non-HTTPS tests currently
+  }
+
+  // Set number of nodes system property to be used in tests
+  doFirst {
+    def numNodes = findProperty('numNodes') as Integer ?: 1
+    systemProperty 'cluster.number_of_nodes', "${numNodes}"
+  }
+
+  testLogging {
+    events "passed", "skipped", "failed"
+  }
+  afterTest { desc, result ->
+    logger.quiet "${desc.className}.${desc.name}: ${result.resultType} ${(result.getEndTime() - result.getStartTime())/1000}s"
   }
 }
 


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/opensearch-build/pull/5917 tried to add multi-node test set up for QI but the tests are all failing. 

This PR fixed the underlying issue by implementing Gradle target to run integration tests against existing OpenSearch clusters instead of spinning up test clusters on the fly.

Changes:
  - Add integTestRemote task for remote cluster testing
  - Update integTest task to support remote cluster mode via system properties
  - Support HTTPS and authentication via system properties

 Usage:
```
  ./gradlew integTestRemote \
    -Dtests.rest.cluster=localhost:9200 \
    -Dtests.cluster=localhost:9200 \
    -Dtests.clustername=integTest \
    -Dhttps=false \
    -Duser=admin \
    -Dpassword=admin \
    -PnumNodes=2
```


### Issues Resolved
https://github.com/opensearch-project/query-insights/issues/526
https://github.com/opensearch-project/opensearch-build/issues/5868

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
