### PR TITLE
Tag failed queries

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -256,12 +256,12 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
 
     @Override
     public void onRequestEnd(final SearchPhaseContext context, final SearchRequestContext searchRequestContext) {
-        constructSearchQueryRecord(context, searchRequestContext);
+        constructSearchQueryRecord(context, searchRequestContext, false);
     }
 
     @Override
     public void onRequestFailure(final SearchPhaseContext context, final SearchRequestContext searchRequestContext) {
-        constructSearchQueryRecord(context, searchRequestContext);
+        constructSearchQueryRecord(context, searchRequestContext, true);
     }
 
     private boolean skipSearchRequest(final SearchRequestContext searchRequestContext) {
@@ -298,7 +298,11 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         return excludedIndicesPattern.stream().anyMatch(pattern -> pattern.matcher(indexName).matches());
     }
 
-    private void constructSearchQueryRecord(final SearchPhaseContext context, final SearchRequestContext searchRequestContext) {
+    private void constructSearchQueryRecord(
+        final SearchPhaseContext context,
+        final SearchRequestContext searchRequestContext,
+        final boolean failed
+    ) {
         if (skipSearchRequest(searchRequestContext)) {
             return;
         }
@@ -346,6 +350,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
             attributes.put(Attribute.NODE_ID, clusterService.localNode().getId());
             attributes.put(Attribute.TOP_N_QUERY, new HashMap<>(DEFAULT_TOP_N_QUERY_MAP));
             attributes.put(Attribute.WLM_GROUP_ID, searchTask.getWorkloadGroupId());
+            attributes.put(Attribute.FAILED, failed);
             if (queryInsightsService.isGroupingEnabled() || log.isTraceEnabled()) {
                 // Generate the query shape only if grouping is enabled or trace logging is enabled
                 final String queryShape = queryShapeGenerator.buildShape(

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -102,7 +102,12 @@ public enum Attribute {
     /**
      * Indicates if the source was truncated due to length limits.
      */
-    SOURCE_TRUNCATED;
+    SOURCE_TRUNCATED,
+
+    /**
+     * Indicates if the search request failed during execution.
+     */
+    FAILED;
 
     /**
      * Read an Attribute from a StreamInput

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -142,6 +142,10 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      * Query Group hashcode
      */
     public static final String QUERY_GROUP_HASHCODE = "query_group_hashcode";
+    /**
+     * Indicates if the search request failed during execution
+     */
+    public static final String FAILED = "failed";
 
     public static final String MEASUREMENTS = "measurements";
     private String groupingId;
@@ -329,6 +333,9 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
                         break;
                     case IS_CANCELLED:
                         attributes.put(Attribute.IS_CANCELLED, parser.booleanValue());
+                        break;
+                    case FAILED:
+                        attributes.put(Attribute.FAILED, parser.booleanValue());
                         break;
                     case WLM_GROUP_ID:
                         attributes.put(Attribute.WLM_GROUP_ID, parser.text());

--- a/src/main/resources/mappings/top-queries-record.json
+++ b/src/main/resources/mappings/top-queries-record.json
@@ -93,6 +93,9 @@
     "source_truncated" : {
       "type" : "boolean"
     },
+    "failed" : {
+      "type" : "boolean"
+    },
     "task_resource_usages" : {
       "properties" : {
         "action" : {

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsTestUtils.java
@@ -224,6 +224,8 @@ final public class QueryInsightsTestUtils {
             attributes.put(Attribute.WLM_GROUP_ID, randomAlphaOfLengthBetween(5, 10));
             // Add is_cancelled attribute
             attributes.put(Attribute.IS_CANCELLED, random().nextBoolean());
+            // Add failed attribute
+            attributes.put(Attribute.FAILED, random().nextBoolean());
 
             SearchQueryRecord record = new SearchQueryRecord(
                 timestamp,
@@ -333,6 +335,7 @@ final public class QueryInsightsTestUtils {
         attributes.put(Attribute.TOP_N_QUERY, DEFAULT_TOP_N_QUERY_MAP);
         attributes.put(Attribute.USERNAME, "testuser");
         attributes.put(Attribute.USER_ROLES, new String[] { "admin", "user" });
+        attributes.put(Attribute.FAILED, false);
 
         return new SearchQueryRecord(
             timestamp,

--- a/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListenerTests.java
@@ -147,6 +147,47 @@ public class QueryInsightsListenerTests extends OpenSearchTestCase {
         assertEquals(searchSourceBuilder.toString(), generatedRecord.getSearchSourceBuilder().toString());
         Map<String, String> labels = (Map<String, String>) generatedRecord.getAttributes().get(Attribute.LABELS);
         assertEquals("userLabel", labels.get(Task.X_OPAQUE_ID));
+        assertEquals(false, generatedRecord.getAttributes().get(Attribute.FAILED));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testOnRequestFailure() {
+        Long timestamp = System.currentTimeMillis() - 100L;
+        SearchType searchType = SearchType.QUERY_THEN_FETCH;
+
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.size(0);
+        SearchTask task = new SearchTask(
+            0,
+            "n/a",
+            "n/a",
+            () -> "test",
+            TaskId.EMPTY_TASK_ID,
+            Collections.singletonMap(Task.X_OPAQUE_ID, "userLabel")
+        );
+
+        String[] indices = new String[] { "index-1", "index-2" };
+        Map<String, Long> phaseLatencyMap = new HashMap<>();
+        phaseLatencyMap.put("query", 20L);
+
+        QueryInsightsListener queryInsightsListener = new QueryInsightsListener(clusterService, queryInsightsService, threadPool);
+
+        when(searchRequest.getOrCreateAbsoluteStartMillis()).thenReturn(timestamp);
+        when(searchRequest.searchType()).thenReturn(searchType);
+        when(searchRequest.source()).thenReturn(searchSourceBuilder);
+        when(searchRequest.indices()).thenReturn(indices);
+        when(searchRequestContext.phaseTookMap()).thenReturn(phaseLatencyMap);
+        when(searchPhaseContext.getRequest()).thenReturn(searchRequest);
+        when(searchPhaseContext.getNumShards()).thenReturn(10);
+        when(searchPhaseContext.getTask()).thenReturn(task);
+
+        ArgumentCaptor<SearchQueryRecord> captor = ArgumentCaptor.forClass(SearchQueryRecord.class);
+
+        queryInsightsListener.onRequestFailure(searchPhaseContext, searchRequestContext);
+
+        verify(queryInsightsService, times(1)).addRecord(captor.capture());
+        SearchQueryRecord generatedRecord = captor.getValue();
+        assertEquals(true, generatedRecord.getAttributes().get(Attribute.FAILED));
     }
 
     public void testConcurrentOnRequestEnd() throws InterruptedException {

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
@@ -71,6 +71,7 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
             + "}"
             + "}],"
             + "\"search_type\":\"query_then_fetch\","
+            + "\"failed\":false,"
             + "\"username\":\"testuser\","
             + "\"user_roles\":[\"admin\",\"user\"],"
             + "\"measurements\":{"

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
@@ -225,6 +225,31 @@ public class SearchQueryRecordTests extends OpenSearchTestCase {
         assertEquals("toString should return the wrapped value", testValue, sourceString.toString());
     }
 
+    public void testFromXContentWithFailedField() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.field("timestamp", 1706574180000L);
+        builder.field("id", "test-id");
+        builder.field(SearchQueryRecord.FAILED, true);
+        builder.startObject("measurements");
+        builder.startObject("latency");
+        builder.field("number", 1L);
+        builder.field("count", 1);
+        builder.field("aggregationType", "NONE");
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.IGNORE_DEPRECATIONS,
+            builder.toString()
+        );
+        SearchQueryRecord record = SearchQueryRecord.fromXContent(parser);
+
+        assertEquals(true, record.getAttributes().get(Attribute.FAILED));
+    }
+
     /**
      * Test that all fields added to SearchQueryRecord code are properly mapped in top-queries-record.json.
      * This test validates enum values to ensure mapping completeness independent of test data generation.


### PR DESCRIPTION
### Description
Adds support for tracking failed queries by setting the `failed` attribute. This PR supersedes #515.

### Issues Resolved
Closes #253

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
