### PR TITLE
Fix 2.19 CI, security IT, eclipse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       WORKING_DIR: ${{ matrix.working_directory }}.
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
         os: [ windows-latest, macos-latest ]
         include:
           - os: windows-latest

--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, macos-13 ]
+        os: [ windows-latest, macos-latest ]
         java: [ 11, 17, 21 ]
 
     runs-on: ${{ matrix.os }}

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ spotless {
     }
     removeUnusedImports()
     importOrder()
-    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('config/formatterConfig.xml')
+    eclipse().configFile rootProject.file('config/formatterConfig.xml')
     trimTrailingWhitespace()
     endWithNewline()
   }


### PR DESCRIPTION
### Description
According to [OpenSearch documentation](https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/#java-compatibility), versions 2.12-2.19 support JDK 11, 17, 21. The Linux CI matrix already included JDK 21, but the Windows and macOS matrix only had JDK 11 and 17. This mismatch caused the required status check "Build and Test query-insights plugin with JDK 21 on windows-latest" to remain in a perpetual "expected — waiting for status" state, blocking all PRs on the 2.19 branch.

This PR includes three fixes:

1. Add JDK 21 to the `build-windows-macos` job matrix in `ci.yml` so the required check can run.
2. Replace deprecated `macos-13` runner with `macos-latest` in `integ-tests-with-security.yml` to fix the "configuration not supported" CI failure.
3. Fix Spotless config in `build.gradle` — remove the `withP2Mirrors` call on the Eclipse formatter.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
