### PR TITLE
[Draft] Analyze Query API for Recommendation Engine

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -34,16 +34,19 @@ import org.opensearch.plugin.insights.core.reader.QueryInsightsReaderFactory;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.health_stats.HealthStatsAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesAction;
+import org.opensearch.plugin.insights.rules.action.recommendations.AnalyzeQueryAction;
 import org.opensearch.plugin.insights.rules.action.settings.GetQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.action.settings.UpdateQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
 import org.opensearch.plugin.insights.rules.resthandler.health_stats.RestHealthStatsAction;
 import org.opensearch.plugin.insights.rules.resthandler.live_queries.RestLiveQueriesAction;
+import org.opensearch.plugin.insights.rules.resthandler.recommendations.RestAnalyzeQueryAction;
 import org.opensearch.plugin.insights.rules.resthandler.settings.RestGetQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.resthandler.settings.RestUpdateQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.resthandler.top_queries.RestTopQueriesAction;
 import org.opensearch.plugin.insights.rules.transport.health_stats.TransportHealthStatsAction;
 import org.opensearch.plugin.insights.rules.transport.live_queries.TransportLiveQueriesAction;
+import org.opensearch.plugin.insights.rules.transport.recommendations.TransportAnalyzeQueryAction;
 import org.opensearch.plugin.insights.rules.transport.settings.TransportGetQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.transport.settings.TransportUpdateQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.transport.top_queries.TransportTopQueriesAction;
@@ -131,7 +134,8 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             new RestHealthStatsAction(),
             new RestLiveQueriesAction(),
             new RestGetQueryInsightsSettingsAction(),
-            new RestUpdateQueryInsightsSettingsAction()
+            new RestUpdateQueryInsightsSettingsAction(),
+            new RestAnalyzeQueryAction()
         );
     }
 
@@ -142,7 +146,8 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             new ActionPlugin.ActionHandler<>(HealthStatsAction.INSTANCE, TransportHealthStatsAction.class),
             new ActionPlugin.ActionHandler<>(LiveQueriesAction.INSTANCE, TransportLiveQueriesAction.class),
             new ActionPlugin.ActionHandler<>(GetQueryInsightsSettingsAction.INSTANCE, TransportGetQueryInsightsSettingsAction.class),
-            new ActionPlugin.ActionHandler<>(UpdateQueryInsightsSettingsAction.INSTANCE, TransportUpdateQueryInsightsSettingsAction.class)
+            new ActionPlugin.ActionHandler<>(UpdateQueryInsightsSettingsAction.INSTANCE, TransportUpdateQueryInsightsSettingsAction.class),
+            new ActionPlugin.ActionHandler<>(AnalyzeQueryAction.INSTANCE, TransportAnalyzeQueryAction.class)
         );
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryAction.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.recommendations;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Action to analyze a query and generate recommendations
+ */
+public class AnalyzeQueryAction extends ActionType<AnalyzeQueryResponse> {
+
+    /**
+     * The AnalyzeQueryAction instance
+     */
+    public static final AnalyzeQueryAction INSTANCE = new AnalyzeQueryAction();
+
+    /**
+     * The name of this action
+     */
+    public static final String NAME = "cluster:admin/opensearch/insights/recommendations/analyze";
+
+    private AnalyzeQueryAction() {
+        super(NAME, AnalyzeQueryResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryRequest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.recommendations;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+/**
+ * Request to analyze a query and generate recommendations
+ */
+public class AnalyzeQueryRequest extends ActionRequest {
+    private final String querySource;
+    private final List<String> indices;
+
+    /**
+     * Constructor
+     * @param querySource the query source JSON
+     * @param indices the indices to analyze against
+     */
+    public AnalyzeQueryRequest(String querySource, List<String> indices) {
+        this.querySource = querySource;
+        this.indices = indices != null ? indices : Collections.emptyList();
+    }
+
+    /**
+     * Constructor from stream
+     * @param in the stream input
+     * @throws IOException if an I/O error occurs
+     */
+    public AnalyzeQueryRequest(StreamInput in) throws IOException {
+        super(in);
+        this.querySource = in.readString();
+        this.indices = in.readStringList();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(querySource);
+        out.writeStringCollection(indices);
+    }
+
+    /**
+     * Get the query source
+     * @return the query source JSON
+     */
+    public String getQuerySource() {
+        return querySource;
+    }
+
+    /**
+     * Get the indices
+     * @return the list of indices
+     */
+    public List<String> getIndices() {
+        return indices;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (querySource == null || querySource.isEmpty()) {
+            validationException = new ActionRequestValidationException();
+            validationException.addValidationError("query source must not be null or empty");
+        }
+        return validationException;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryResponse.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryResponse.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.recommendations;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
+
+/**
+ * Response containing recommendations for a query
+ */
+public class AnalyzeQueryResponse extends ActionResponse implements ToXContentObject {
+    private final List<Recommendation> recommendations;
+
+    /**
+     * Constructor
+     * @param recommendations the list of recommendations
+     */
+    public AnalyzeQueryResponse(List<Recommendation> recommendations) {
+        this.recommendations = recommendations != null ? recommendations : new ArrayList<>();
+    }
+
+    /**
+     * Constructor from stream
+     * @param in the stream input
+     * @throws IOException if an I/O error occurs
+     */
+    public AnalyzeQueryResponse(StreamInput in) throws IOException {
+        super(in);
+        this.recommendations = in.readList(Recommendation::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeList(recommendations);
+    }
+
+    /**
+     * Get the recommendations
+     * @return the list of recommendations
+     */
+    public List<Recommendation> getRecommendations() {
+        return recommendations;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("count", recommendations.size());
+        builder.startArray("recommendations");
+        for (Recommendation recommendation : recommendations) {
+            recommendation.toXContent(builder, params);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/recommendations/RestAnalyzeQueryAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/recommendations/RestAnalyzeQueryAction.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.resthandler.recommendations;
+
+import static org.opensearch.rest.RestRequest.Method.POST;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaType;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.insights.rules.action.recommendations.AnalyzeQueryAction;
+import org.opensearch.plugin.insights.rules.action.recommendations.AnalyzeQueryRequest;
+import org.opensearch.plugin.insights.rules.action.recommendations.AnalyzeQueryResponse;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestResponse;
+import org.opensearch.rest.action.RestResponseListener;
+import org.opensearch.transport.client.node.NodeClient;
+
+/**
+ * Rest action to analyze a query and generate recommendations
+ */
+public class RestAnalyzeQueryAction extends BaseRestHandler {
+
+    private static final String RECOMMENDATIONS_BASE_URI = "/_insights/recommendations";
+    private static final String ANALYZE_URI = RECOMMENDATIONS_BASE_URI + "/analyze";
+
+    /**
+     * Constructor for RestAnalyzeQueryAction
+     */
+    public RestAnalyzeQueryAction() {}
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, ANALYZE_URI));
+    }
+
+    @Override
+    public String getName() {
+        return "query_insights_analyze_query_action";
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        // Parse request body
+        MediaType mediaType = request.getMediaType();
+        if (mediaType == null) {
+            mediaType = MediaTypeRegistry.JSON;
+        }
+
+        Map<String, Object> body = XContentHelper.convertToMap(request.content(), false, mediaType).v2();
+
+        // Extract query source
+        Object queryObj = body.get("query");
+        if (queryObj == null) {
+            throw new IllegalArgumentException("Request body must contain 'query' field");
+        }
+
+        // Convert query object to JSON string
+        String querySource;
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            builder.value(queryObj);
+            BytesReference bytes = BytesReference.bytes(builder);
+            querySource = XContentHelper.convertToJson(bytes, false, MediaTypeRegistry.JSON);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid query format: " + e.getMessage());
+        }
+
+        // Extract indices (optional)
+        List<String> indices = null;
+        Object indicesObj = body.get("indices");
+        if (indicesObj instanceof List) {
+            indices = (List<String>) indicesObj;
+        } else if (indicesObj instanceof String) {
+            indices = Arrays.asList(((String) indicesObj).split(","));
+        }
+
+        // Create request
+        final AnalyzeQueryRequest analyzeRequest = new AnalyzeQueryRequest(querySource, indices);
+
+        return channel -> client.execute(AnalyzeQueryAction.INSTANCE, analyzeRequest, analyzeQueryResponse(channel));
+    }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
+
+    private RestResponseListener<AnalyzeQueryResponse> analyzeQueryResponse(final RestChannel channel) {
+        return new RestResponseListener<>(channel) {
+            @Override
+            public RestResponse buildResponse(final AnalyzeQueryResponse response) throws Exception {
+                return new BytesRestResponse(RestStatus.OK, response.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS));
+            }
+        };
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/recommendations/TransportAnalyzeQueryAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/recommendations/TransportAnalyzeQueryAction.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.transport.recommendations;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.ParsingException;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.plugin.insights.core.service.QueryInsightsService;
+import org.opensearch.plugin.insights.core.service.recommendations.RecommendationService;
+import org.opensearch.plugin.insights.rules.action.recommendations.AnalyzeQueryAction;
+import org.opensearch.plugin.insights.rules.action.recommendations.AnalyzeQueryRequest;
+import org.opensearch.plugin.insights.rules.action.recommendations.AnalyzeQueryResponse;
+import org.opensearch.plugin.insights.rules.model.Attribute;
+import org.opensearch.plugin.insights.rules.model.Measurement;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Transport action to analyze a query and generate recommendations
+ */
+public class TransportAnalyzeQueryAction extends HandledTransportAction<AnalyzeQueryRequest, AnalyzeQueryResponse> {
+    private static final Logger log = LogManager.getLogger(TransportAnalyzeQueryAction.class);
+
+    private final RecommendationService recommendationService;
+    private final NamedXContentRegistry xContentRegistry;
+
+    /**
+     * Constructor
+     * @param transportService the transport service
+     * @param actionFilters the action filters
+     * @param queryInsightsService the query insights service
+     * @param xContentRegistry the named XContent registry
+     */
+    @Inject
+    public TransportAnalyzeQueryAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        QueryInsightsService queryInsightsService,
+        NamedXContentRegistry xContentRegistry
+    ) {
+        super(AnalyzeQueryAction.NAME, transportService, actionFilters, AnalyzeQueryRequest::new);
+        this.recommendationService = queryInsightsService.getRecommendationService();
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    @Override
+    protected void doExecute(Task task, AnalyzeQueryRequest request, ActionListener<AnalyzeQueryResponse> listener) {
+        try {
+            // Parse the query source
+            SearchSourceBuilder searchSourceBuilder = parseQuerySource(request.getQuerySource());
+
+            // Create a synthetic SearchQueryRecord for analysis
+            SearchQueryRecord record = createSyntheticRecord(searchSourceBuilder, request.getIndices());
+
+            // Generate recommendations
+            List<Recommendation> recommendations = recommendationService.generateRecommendations(record);
+
+            // Return the response
+            listener.onResponse(new AnalyzeQueryResponse(recommendations));
+        } catch (IllegalArgumentException | ParsingException e) {
+            log.debug("Invalid query in analyze request", e);
+            listener.onFailure(e);
+        } catch (Exception e) {
+            log.error("Error analyzing query", e);
+            listener.onFailure(e);
+        }
+    }
+
+    private SearchSourceBuilder parseQuerySource(String querySource) throws Exception {
+        // The querySource may be just the query part (e.g., {"term": {...}})
+        // We need to wrap it in a full SearchSourceBuilder format
+        String wrappedQuery = "{\"query\":" + querySource + "}";
+        try (
+            XContentParser parser = MediaTypeRegistry.JSON.xContent()
+                .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, wrappedQuery)
+        ) {
+            return SearchSourceBuilder.fromXContent(parser);
+        }
+    }
+
+    private SearchQueryRecord createSyntheticRecord(SearchSourceBuilder searchSourceBuilder, List<String> indices) {
+        // Create a minimal SearchQueryRecord for recommendation analysis
+        long timestamp = System.currentTimeMillis();
+        Map<MetricType, Measurement> measurements = new HashMap<>();
+        Map<Attribute, Object> attributes = new HashMap<>();
+
+        // Add indices attribute if provided
+        if (indices != null && !indices.isEmpty()) {
+            attributes.put(Attribute.INDICES, new ArrayList<>(indices));
+        }
+
+        String id = UUID.randomUUID().toString();
+
+        return new SearchQueryRecord(timestamp, measurements, attributes, searchSourceBuilder, null, id);
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -26,11 +26,13 @@ import org.opensearch.plugin.insights.core.listener.QueryInsightsListener;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.health_stats.HealthStatsAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesAction;
+import org.opensearch.plugin.insights.rules.action.recommendations.AnalyzeQueryAction;
 import org.opensearch.plugin.insights.rules.action.settings.GetQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.action.settings.UpdateQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
 import org.opensearch.plugin.insights.rules.resthandler.health_stats.RestHealthStatsAction;
 import org.opensearch.plugin.insights.rules.resthandler.live_queries.RestLiveQueriesAction;
+import org.opensearch.plugin.insights.rules.resthandler.recommendations.RestAnalyzeQueryAction;
 import org.opensearch.plugin.insights.rules.resthandler.settings.RestGetQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.resthandler.settings.RestUpdateQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.resthandler.top_queries.RestTopQueriesAction;
@@ -158,22 +160,24 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
 
     public void testGetRestHandlers() {
         List<RestHandler> components = queryInsightsPlugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null);
-        assertEquals(5, components.size());
+        assertEquals(6, components.size());
         assertTrue(components.get(0) instanceof RestTopQueriesAction);
         assertTrue(components.get(1) instanceof RestHealthStatsAction);
         assertTrue(components.get(2) instanceof RestLiveQueriesAction);
         assertTrue(components.get(3) instanceof RestGetQueryInsightsSettingsAction);
         assertTrue(components.get(4) instanceof RestUpdateQueryInsightsSettingsAction);
+        assertTrue(components.get(5) instanceof RestAnalyzeQueryAction);
     }
 
     public void testGetActions() {
         List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> components = queryInsightsPlugin.getActions();
-        assertEquals(5, components.size());
+        assertEquals(6, components.size());
         assertTrue(components.get(0).getAction() instanceof TopQueriesAction);
         assertTrue(components.get(1).getAction() instanceof HealthStatsAction);
         assertTrue(components.get(2).getAction() instanceof LiveQueriesAction);
         assertTrue(components.get(3).getAction() instanceof GetQueryInsightsSettingsAction);
         assertTrue(components.get(4).getAction() instanceof UpdateQueryInsightsSettingsAction);
+        assertTrue(components.get(5).getAction() instanceof AnalyzeQueryAction);
     }
 
     public void testLiveQueriesActionRegistration() {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/recommendations/QueryContextTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/recommendations/QueryContextTests.java
@@ -1,0 +1,268 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service.recommendations;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.plugin.insights.rules.model.Attribute;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link QueryContext}
+ */
+public class QueryContextTests extends OpenSearchTestCase {
+
+    // --- getIndices tests ---
+
+    public void testGetIndicesFromStringArray() {
+        SearchQueryRecord record = createRecordWithIndices(new String[] { "index1", "index2" });
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        List<String> indices = ctx.getIndices();
+        assertEquals(2, indices.size());
+        assertEquals("index1", indices.get(0));
+        assertEquals("index2", indices.get(1));
+    }
+
+    public void testGetIndicesFromList() {
+        SearchQueryRecord record = createRecordWithIndices(Arrays.asList("idx-a", "idx-b", "idx-c"));
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        List<String> indices = ctx.getIndices();
+        assertEquals(3, indices.size());
+        assertEquals("idx-a", indices.get(0));
+        assertEquals("idx-c", indices.get(2));
+    }
+
+    public void testGetIndicesFromObjectArray() {
+        SearchQueryRecord record = createRecordWithIndices(new Object[] { "obj-index1", "obj-index2" });
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        List<String> indices = ctx.getIndices();
+        assertEquals(2, indices.size());
+        assertEquals("obj-index1", indices.get(0));
+        assertEquals("obj-index2", indices.get(1));
+    }
+
+    public void testGetIndicesReturnsEmptyWhenNull() {
+        Map<Attribute, Object> attributes = new HashMap<>();
+        SearchQueryRecord record = new SearchQueryRecord(System.currentTimeMillis(), new HashMap<>(), attributes, "test-id");
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        List<String> indices = ctx.getIndices();
+        assertTrue(indices.isEmpty());
+    }
+
+    public void testGetIndicesReturnsEmptyForUnexpectedType() {
+        SearchQueryRecord record = createRecordWithIndices("not-an-array-or-list");
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        List<String> indices = ctx.getIndices();
+        assertTrue(indices.isEmpty());
+    }
+
+    // --- getFieldType / getFieldTypeFromProperties tests ---
+
+    public void testGetFieldTypeSimpleField() {
+        ClusterService clusterService = mockClusterWithMapping(
+            "test-index",
+            Map.of("properties", Map.of("status", Map.of("type", "keyword"), "title", Map.of("type", "text")))
+        );
+        QueryContext ctx = createContextWithIndex(clusterService, "test-index");
+
+        assertEquals("keyword", ctx.getFieldType("status"));
+        assertEquals("text", ctx.getFieldType("title"));
+    }
+
+    public void testGetFieldTypeNestedField() {
+        Map<String, Object> addressMapping = new HashMap<>();
+        addressMapping.put("properties", Map.of("city", Map.of("type", "keyword"), "zip", Map.of("type", "integer")));
+
+        ClusterService clusterService = mockClusterWithMapping("test-index", Map.of("properties", Map.of("address", addressMapping)));
+        QueryContext ctx = createContextWithIndex(clusterService, "test-index");
+
+        assertEquals("keyword", ctx.getFieldType("address.city"));
+        assertEquals("integer", ctx.getFieldType("address.zip"));
+    }
+
+    public void testGetFieldTypeMultifield() {
+        Map<String, Object> titleMapping = new HashMap<>();
+        titleMapping.put("type", "text");
+        titleMapping.put("fields", Map.of("keyword", Map.of("type", "keyword"), "raw", Map.of("type", "keyword")));
+
+        ClusterService clusterService = mockClusterWithMapping("test-index", Map.of("properties", Map.of("title", titleMapping)));
+        QueryContext ctx = createContextWithIndex(clusterService, "test-index");
+
+        assertEquals("text", ctx.getFieldType("title"));
+        assertEquals("keyword", ctx.getFieldType("title.keyword"));
+        assertEquals("keyword", ctx.getFieldType("title.raw"));
+    }
+
+    public void testGetFieldTypeReturnsNullForMissingField() {
+        ClusterService clusterService = mockClusterWithMapping(
+            "test-index",
+            Map.of("properties", Map.of("status", Map.of("type", "keyword")))
+        );
+        QueryContext ctx = createContextWithIndex(clusterService, "test-index");
+
+        assertNull(ctx.getFieldType("nonexistent"));
+    }
+
+    public void testGetFieldTypeReturnsNullWhenNoClusterService() {
+        SearchQueryRecord record = createRecordWithIndices(Arrays.asList("test-index"));
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        assertNull(ctx.getFieldType("status"));
+    }
+
+    public void testGetFieldTypeReturnsNullWhenNoIndices() {
+        ClusterService clusterService = mockClusterWithMapping(
+            "test-index",
+            Map.of("properties", Map.of("status", Map.of("type", "keyword")))
+        );
+        Map<Attribute, Object> attributes = new HashMap<>();
+        SearchQueryRecord record = new SearchQueryRecord(System.currentTimeMillis(), new HashMap<>(), attributes, "test-id");
+        QueryContext ctx = new QueryContext(record, clusterService, null);
+
+        assertNull(ctx.getFieldType("status"));
+    }
+
+    public void testGetFieldTypeReturnsNullForUnknownIndex() {
+        ClusterService clusterService = mockClusterWithMapping(
+            "existing-index",
+            Map.of("properties", Map.of("status", Map.of("type", "keyword")))
+        );
+        QueryContext ctx = createContextWithIndex(clusterService, "nonexistent-index");
+
+        assertNull(ctx.getFieldType("status"));
+    }
+
+    public void testGetFieldTypeReturnsNullWhenNoMapping() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.index("test-index")).thenReturn(indexMetadata);
+        when(indexMetadata.mapping()).thenReturn(null);
+
+        QueryContext ctx = createContextWithIndex(clusterService, "test-index");
+        assertNull(ctx.getFieldType("status"));
+    }
+
+    public void testGetFieldTypeReturnsNullWhenNoProperties() {
+        ClusterService clusterService = mockClusterWithMapping("test-index", Map.of("no_properties_key", "value"));
+        QueryContext ctx = createContextWithIndex(clusterService, "test-index");
+
+        assertNull(ctx.getFieldType("status"));
+    }
+
+    public void testGetFieldTypeDeepNestedWithMultifield() {
+        Map<String, Object> nameMapping = new HashMap<>();
+        nameMapping.put("type", "text");
+        nameMapping.put("fields", Map.of("keyword", Map.of("type", "keyword")));
+
+        Map<String, Object> authorMapping = new HashMap<>();
+        authorMapping.put("properties", Map.of("name", nameMapping));
+
+        ClusterService clusterService = mockClusterWithMapping("test-index", Map.of("properties", Map.of("author", authorMapping)));
+        QueryContext ctx = createContextWithIndex(clusterService, "test-index");
+
+        assertEquals("text", ctx.getFieldType("author.name"));
+        assertEquals("keyword", ctx.getFieldType("author.name.keyword"));
+    }
+
+    // --- extractQueries tests ---
+
+    public void testExtractQueriesFindsTermQueries() {
+        SearchSourceBuilder ssb = new SearchSourceBuilder();
+        ssb.query(new TermQueryBuilder("status", "active"));
+
+        SearchQueryRecord record = createRecordWithSource(ssb);
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        List<TermQueryBuilder> termQueries = ctx.extractQueries(TermQueryBuilder.class);
+        assertEquals(1, termQueries.size());
+        assertEquals("status", termQueries.get(0).fieldName());
+    }
+
+    public void testExtractQueriesReturnsEmptyWhenNoQuery() {
+        SearchSourceBuilder ssb = new SearchSourceBuilder();
+
+        SearchQueryRecord record = createRecordWithSource(ssb);
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        List<TermQueryBuilder> termQueries = ctx.extractQueries(TermQueryBuilder.class);
+        assertTrue(termQueries.isEmpty());
+    }
+
+    public void testExtractQueriesReturnsEmptyWhenNullSource() {
+        SearchQueryRecord record = new SearchQueryRecord(System.currentTimeMillis(), new HashMap<>(), new HashMap<>(), "test-id");
+        QueryContext ctx = new QueryContext(record, null, null);
+
+        List<TermQueryBuilder> termQueries = ctx.extractQueries(TermQueryBuilder.class);
+        assertTrue(termQueries.isEmpty());
+    }
+
+    // --- constructor validation ---
+
+    public void testConstructorRejectsNullRecord() {
+        expectThrows(NullPointerException.class, () -> new QueryContext(null, null, null));
+    }
+
+    // --- helpers ---
+
+    private SearchQueryRecord createRecordWithIndices(Object indices) {
+        Map<Attribute, Object> attributes = new HashMap<>();
+        attributes.put(Attribute.INDICES, indices);
+        return new SearchQueryRecord(System.currentTimeMillis(), new HashMap<>(), attributes, "test-id");
+    }
+
+    private SearchQueryRecord createRecordWithSource(SearchSourceBuilder ssb) {
+        Map<Attribute, Object> attributes = new HashMap<>();
+        attributes.put(Attribute.INDICES, new String[] { "test-index" });
+        return new SearchQueryRecord(System.currentTimeMillis(), new HashMap<>(), attributes, ssb, null, "test-id");
+    }
+
+    private QueryContext createContextWithIndex(ClusterService clusterService, String indexName) {
+        SearchQueryRecord record = createRecordWithIndices(new ArrayList<>(List.of(indexName)));
+        return new QueryContext(record, clusterService, null);
+    }
+
+    private ClusterService mockClusterWithMapping(String indexName, Map<String, Object> sourceAsMap) {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.index(indexName)).thenReturn(indexMetadata);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+        when(mappingMetadata.sourceAsMap()).thenReturn(sourceAsMap);
+
+        return clusterService;
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryRequestTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryRequestTests.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.recommendations;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link AnalyzeQueryRequest}
+ */
+public class AnalyzeQueryRequestTests extends OpenSearchTestCase {
+
+    public void testSerializationRoundTrip() throws IOException {
+        AnalyzeQueryRequest original = new AnalyzeQueryRequest("{\"term\":{\"status\":\"active\"}}", Arrays.asList("index1", "index2"));
+        AnalyzeQueryRequest deserialized = roundTrip(original);
+
+        assertEquals(original.getQuerySource(), deserialized.getQuerySource());
+        assertEquals(original.getIndices(), deserialized.getIndices());
+    }
+
+    public void testSerializationWithEmptyIndices() throws IOException {
+        AnalyzeQueryRequest original = new AnalyzeQueryRequest("{\"match_all\":{}}", Collections.emptyList());
+        AnalyzeQueryRequest deserialized = roundTrip(original);
+
+        assertEquals(original.getQuerySource(), deserialized.getQuerySource());
+        assertTrue(deserialized.getIndices().isEmpty());
+    }
+
+    public void testSerializationWithNullIndicesDefaultsToEmpty() throws IOException {
+        AnalyzeQueryRequest original = new AnalyzeQueryRequest("{\"match_all\":{}}", null);
+        AnalyzeQueryRequest deserialized = roundTrip(original);
+
+        assertEquals(original.getQuerySource(), deserialized.getQuerySource());
+        assertTrue(deserialized.getIndices().isEmpty());
+    }
+
+    public void testValidateReturnsNullForValidRequest() {
+        AnalyzeQueryRequest request = new AnalyzeQueryRequest("{\"term\":{\"status\":\"active\"}}", List.of("index1"));
+        assertNull(request.validate());
+    }
+
+    public void testValidateRejectsNullQuerySource() {
+        AnalyzeQueryRequest request = new AnalyzeQueryRequest(null, List.of("index1"));
+        ActionRequestValidationException exception = request.validate();
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains("query source must not be null or empty"));
+    }
+
+    public void testValidateRejectsEmptyQuerySource() {
+        AnalyzeQueryRequest request = new AnalyzeQueryRequest("", List.of("index1"));
+        ActionRequestValidationException exception = request.validate();
+        assertNotNull(exception);
+        assertTrue(exception.getMessage().contains("query source must not be null or empty"));
+    }
+
+    public void testGetters() {
+        List<String> indices = Arrays.asList("a", "b");
+        AnalyzeQueryRequest request = new AnalyzeQueryRequest("{\"match_all\":{}}", indices);
+
+        assertEquals("{\"match_all\":{}}", request.getQuerySource());
+        assertEquals(indices, request.getIndices());
+    }
+
+    private AnalyzeQueryRequest roundTrip(AnalyzeQueryRequest request) throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                return new AnalyzeQueryRequest(in);
+            }
+        }
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/recommendations/AnalyzeQueryResponseTests.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.recommendations;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
+import org.opensearch.plugin.insights.rules.model.recommendations.RecommendationType;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for {@link AnalyzeQueryResponse}
+ */
+public class AnalyzeQueryResponseTests extends OpenSearchTestCase {
+
+    public void testSerializationRoundTrip() throws IOException {
+        List<Recommendation> recs = Arrays.asList(createRecommendation("rule-1", "Title 1"), createRecommendation("rule-2", "Title 2"));
+        AnalyzeQueryResponse original = new AnalyzeQueryResponse(recs);
+        AnalyzeQueryResponse deserialized = roundTrip(original);
+
+        assertEquals(original.getRecommendations().size(), deserialized.getRecommendations().size());
+        for (int i = 0; i < original.getRecommendations().size(); i++) {
+            assertEquals(original.getRecommendations().get(i), deserialized.getRecommendations().get(i));
+        }
+    }
+
+    public void testSerializationEmpty() throws IOException {
+        AnalyzeQueryResponse original = new AnalyzeQueryResponse(Collections.emptyList());
+        AnalyzeQueryResponse deserialized = roundTrip(original);
+
+        assertTrue(deserialized.getRecommendations().isEmpty());
+    }
+
+    public void testSerializationWithNull() throws IOException {
+        List<Recommendation> nullList = null;
+        AnalyzeQueryResponse original = new AnalyzeQueryResponse(nullList);
+        AnalyzeQueryResponse deserialized = roundTrip(original);
+
+        assertTrue(deserialized.getRecommendations().isEmpty());
+    }
+
+    public void testToXContent() throws IOException {
+        List<Recommendation> recs = List.of(createRecommendation("test-rule", "Test Title"));
+        AnalyzeQueryResponse response = new AnalyzeQueryResponse(recs);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, null);
+        String json = builder.toString();
+
+        assertTrue(json.contains("\"count\":1"));
+        assertTrue(json.contains("\"recommendations\""));
+        assertTrue(json.contains("\"rule_id\":\"test-rule\""));
+        assertTrue(json.contains("\"title\":\"Test Title\""));
+    }
+
+    public void testToXContentEmpty() throws IOException {
+        AnalyzeQueryResponse response = new AnalyzeQueryResponse(Collections.emptyList());
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        response.toXContent(builder, null);
+        String json = builder.toString();
+
+        assertTrue(json.contains("\"count\":0"));
+        assertTrue(json.contains("\"recommendations\":[]"));
+    }
+
+    public void testGetRecommendations() {
+        List<Recommendation> recs = new ArrayList<>();
+        recs.add(createRecommendation("r1", "T1"));
+        AnalyzeQueryResponse response = new AnalyzeQueryResponse(recs);
+
+        assertEquals(1, response.getRecommendations().size());
+        assertEquals("r1", response.getRecommendations().get(0).getRuleId());
+    }
+
+    private Recommendation createRecommendation(String ruleId, String title) {
+        return Recommendation.builder()
+            .ruleId(ruleId)
+            .title(title)
+            .description("Test description for " + ruleId)
+            .type(RecommendationType.QUERY_REWRITE)
+            .build();
+    }
+
+    private AnalyzeQueryResponse roundTrip(AnalyzeQueryResponse response) throws IOException {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            response.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                return new AnalyzeQueryResponse(in);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Adds the POST /_insights/recommendations/analyze endpoint that accepts a query and optional indices list, evaluates it against registered recommendation rules, and returns actionable recommendations.

Changes:
- Add AnalyzeQueryAction, AnalyzeQueryRequest, AnalyzeQueryResponse
- Add RestAnalyzeQueryAction (POST /_insights/recommendations/analyze)
- Add TransportAnalyzeQueryAction (creates synthetic record, runs rules)
- Enhance QueryContext: add List handling in getIndices(), add fallback field type lookup from mapping when QueryShapeGenerator is unavailable, add KEYWORD_FIELD_TYPE/KEYWORD_SUBFIELD_SUFFIX constants
- Register AnalyzeQuery action and REST handler in QueryInsightsPlugin

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
