### PR TITLE
Add recommendations parameter to Top Queries API

### DIFF
--- a/src/internalClusterTest/java/org/opensearch/plugin/insights/QueryInsightsPluginTransportIT.java
+++ b/src/internalClusterTest/java/org/opensearch/plugin/insights/QueryInsightsPluginTransportIT.java
@@ -90,7 +90,7 @@ public class QueryInsightsPluginTransportIT extends OpenSearchIntegTestCase {
         // making search requests to get top queries
         makeSearchRequests(nodes);
 
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, null);
         TopQueriesResponse response = OpenSearchIntegTestCase.client().execute(TopQueriesAction.INSTANCE, request).actionGet();
         Assert.assertEquals(0, response.failures().size());
         Assert.assertEquals(TOTAL_NUMBER_OF_NODES, response.getNodes().size());
@@ -104,7 +104,7 @@ public class QueryInsightsPluginTransportIT extends OpenSearchIntegTestCase {
         // making search requests to get top queries
         makeSearchRequests(nodes);
 
-        TopQueriesRequest request2 = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
+        TopQueriesRequest request2 = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, null);
         TopQueriesResponse response2 = OpenSearchIntegTestCase.client().execute(TopQueriesAction.INSTANCE, request2).actionGet();
         Assert.assertEquals(0, response2.failures().size());
         Assert.assertEquals(TOTAL_NUMBER_OF_NODES, response2.getNodes().size());
@@ -133,7 +133,7 @@ public class QueryInsightsPluginTransportIT extends OpenSearchIntegTestCase {
         // making search requests to get top queries
         makeSearchRequests(nodes);
 
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, null);
         TopQueriesResponse response = OpenSearchIntegTestCase.client().execute(TopQueriesAction.INSTANCE, request).actionGet();
         Assert.assertEquals(0, response.failures().size());
         Assert.assertEquals(TOTAL_NUMBER_OF_NODES, response.getNodes().size());
@@ -162,7 +162,7 @@ public class QueryInsightsPluginTransportIT extends OpenSearchIntegTestCase {
         // making search requests to get top queries
         makeSearchRequests(nodes);
 
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, null);
         TopQueriesResponse response = OpenSearchIntegTestCase.client().execute(TopQueriesAction.INSTANCE, request).actionGet();
         Assert.assertEquals(0, response.failures().size());
         Assert.assertEquals(TOTAL_NUMBER_OF_NODES, response.getNodes().size());
@@ -193,7 +193,7 @@ public class QueryInsightsPluginTransportIT extends OpenSearchIntegTestCase {
         // making search requests to get top queries
         makeSearchRequests(nodes);
 
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, null);
         TopQueriesResponse response = OpenSearchIntegTestCase.client().execute(TopQueriesAction.INSTANCE, request).actionGet();
         Assert.assertEquals(0, response.failures().size());
         Assert.assertEquals(TOTAL_NUMBER_OF_NODES, response.getNodes().size());

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueries.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueries.java
@@ -9,7 +9,11 @@
 package org.opensearch.plugin.insights.rules.action.top_queries;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.opensearch.Version;
 import org.opensearch.action.support.nodes.BaseNodeResponse;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -17,6 +21,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
 
 /**
  * Holds all top queries records by resource usage or latency on a node
@@ -26,6 +31,9 @@ public class TopQueries extends BaseNodeResponse implements ToXContentObject {
     /** The store to keep the top queries records */
     private final List<SearchQueryRecord> topQueriesRecords;
 
+    /** Pre-computed recommendations keyed by record ID */
+    private final Map<String, List<Recommendation>> recommendations;
+
     /**
      * Create the TopQueries Object from StreamInput
      * @param in A {@link StreamInput} object.
@@ -34,6 +42,21 @@ public class TopQueries extends BaseNodeResponse implements ToXContentObject {
     public TopQueries(final StreamInput in) throws IOException {
         super(in);
         topQueriesRecords = in.readList(SearchQueryRecord::new);
+        if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
+            int mapSize = in.readVInt();
+            if (mapSize > 0) {
+                recommendations = new HashMap<>(mapSize);
+                for (int i = 0; i < mapSize; i++) {
+                    String key = in.readString();
+                    List<Recommendation> recs = in.readList(Recommendation::new);
+                    recommendations.put(key, recs);
+                }
+            } else {
+                recommendations = Collections.emptyMap();
+            }
+        } else {
+            recommendations = Collections.emptyMap();
+        }
     }
 
     /**
@@ -42,8 +65,23 @@ public class TopQueries extends BaseNodeResponse implements ToXContentObject {
      * @param searchQueryRecords A list of SearchQueryRecord associated in this TopQueries.
      */
     public TopQueries(final DiscoveryNode node, final List<SearchQueryRecord> searchQueryRecords) {
+        this(node, searchQueryRecords, Collections.emptyMap());
+    }
+
+    /**
+     * Create the TopQueries Object with pre-computed recommendations
+     * @param node A node that is part of the cluster.
+     * @param searchQueryRecords A list of SearchQueryRecord associated in this TopQueries.
+     * @param recommendations Pre-computed recommendations keyed by record ID.
+     */
+    public TopQueries(
+        final DiscoveryNode node,
+        final List<SearchQueryRecord> searchQueryRecords,
+        final Map<String, List<Recommendation>> recommendations
+    ) {
         super(node);
         topQueriesRecords = searchQueryRecords;
+        this.recommendations = recommendations != null ? recommendations : Collections.emptyMap();
     }
 
     @Override
@@ -60,7 +98,13 @@ public class TopQueries extends BaseNodeResponse implements ToXContentObject {
     public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeList(topQueriesRecords);
-
+        if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
+            out.writeVInt(recommendations.size());
+            for (Map.Entry<String, List<Recommendation>> entry : recommendations.entrySet()) {
+                out.writeString(entry.getKey());
+                out.writeList(entry.getValue());
+            }
+        }
     }
 
     /**
@@ -70,5 +114,14 @@ public class TopQueries extends BaseNodeResponse implements ToXContentObject {
      */
     public List<SearchQueryRecord> getTopQueriesRecord() {
         return topQueriesRecords;
+    }
+
+    /**
+     * Get pre-computed recommendations keyed by record ID
+     *
+     * @return the recommendations map
+     */
+    public Map<String, List<Recommendation>> getRecommendations() {
+        return recommendations;
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequest.java
@@ -25,6 +25,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
     final String to;
     final String id;
     final Boolean verbose;
+    final Boolean recommendations;
 
     /**
      * Constructor for TopQueriesRequest
@@ -46,6 +47,11 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
             this.id = null;
             this.verbose = null;
         }
+        if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
+            this.recommendations = in.readOptionalBoolean();
+        } else {
+            this.recommendations = null;
+        }
     }
 
     /**
@@ -57,6 +63,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
      * @param to end timestamp
      * @param id query/group id
      * @param verbose whether to return full output
+     * @param recommendations whether to include recommendations
      * @param nodesIds the nodeIds specified in the request
      */
     public TopQueriesRequest(
@@ -65,6 +72,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
         final String to,
         final String id,
         final Boolean verbose,
+        final Boolean recommendations,
         final String... nodesIds
     ) {
         super(nodesIds);
@@ -73,6 +81,7 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
         this.to = to;
         this.verbose = verbose;
         this.id = id;
+        this.recommendations = recommendations;
     }
 
     /**
@@ -115,6 +124,14 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
         return verbose;
     }
 
+    /**
+     * Get recommendations flag
+     * @return Boolean of recommendations flag
+     */
+    public Boolean getRecommendations() {
+        return recommendations;
+    }
+
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -124,6 +141,9 @@ public class TopQueriesRequest extends BaseNodesRequest<TopQueriesRequest> {
             out.writeOptionalString(to);
             out.writeOptionalString(id);
             out.writeOptionalBoolean(verbose);
+        }
+        if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
+            out.writeOptionalBoolean(recommendations);
         }
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponse.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponse.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugin.insights.rules.action.top_queries;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -115,7 +116,11 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
         // Merge pre-computed recommendations from all node responses
         final Map<String, List<Recommendation>> mergedRecommendations = new HashMap<>();
         for (TopQueries tq : results) {
-            mergedRecommendations.putAll(tq.getRecommendations());
+            tq.getRecommendations().forEach((key, value) -> mergedRecommendations.merge(key, value, (existing, incoming) -> {
+                List<Recommendation> merged = new ArrayList<>(existing);
+                merged.addAll(incoming);
+                return merged;
+            }));
         }
 
         final List<SearchQueryRecord> all_records = results.stream()
@@ -127,7 +132,7 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
         builder.startArray(CLUSTER_LEVEL_RESULTS_KEY);
         for (SearchQueryRecord record : all_records) {
             List<Recommendation> recs = mergedRecommendations.get(record.getId());
-            if (recs != null && !recs.isEmpty()) {
+            if (recs != null) {
                 record.toXContentWithRecommendations(builder, params, recs);
             } else {
                 record.toXContent(builder, params);

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponse.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponse.java
@@ -10,7 +10,9 @@ package org.opensearch.plugin.insights.rules.action.top_queries;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.nodes.BaseNodesResponse;
@@ -22,6 +24,7 @@ import org.opensearch.core.xcontent.ToXContentFragment;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
 
 /**
  * Transport response for cluster/node level top queries information.
@@ -109,6 +112,12 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
      */
     private void toClusterLevelResult(final XContentBuilder builder, final Params params, final List<TopQueries> results)
         throws IOException {
+        // Merge pre-computed recommendations from all node responses
+        final Map<String, List<Recommendation>> mergedRecommendations = new HashMap<>();
+        for (TopQueries tq : results) {
+            mergedRecommendations.putAll(tq.getRecommendations());
+        }
+
         final List<SearchQueryRecord> all_records = results.stream()
             .map(TopQueries::getTopQueriesRecord)
             .flatMap(Collection::stream)
@@ -117,7 +126,12 @@ public class TopQueriesResponse extends BaseNodesResponse<TopQueries> implements
             .collect(Collectors.toList());
         builder.startArray(CLUSTER_LEVEL_RESULTS_KEY);
         for (SearchQueryRecord record : all_records) {
-            record.toXContent(builder, params);
+            List<Recommendation> recs = mergedRecommendations.get(record.getId());
+            if (recs != null && !recs.isEmpty()) {
+                record.toXContentWithRecommendations(builder, params, recs);
+            } else {
+                record.toXContent(builder, params);
+            }
         }
         builder.endArray();
     }

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -34,6 +34,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
 import org.opensearch.plugin.insights.core.auth.UserPrincipalContext;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
 import reactor.util.annotation.NonNull;
@@ -580,23 +581,56 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
      */
     @Override
     public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        toXContentInner(builder, params);
+        return builder.endObject();
+    }
+
+    /**
+     * Serializes this object into an {@link XContentBuilder} with recommendations appended.
+     *
+     * @param builder The {@link XContentBuilder} to serialize into.
+     * @param params  Optional serialization parameters.
+     * @param recommendations The list of recommendations to include.
+     * @return The updated {@link XContentBuilder} with this object's content and recommendations.
+     * @throws IOException if an I/O error occurs during serialization.
+     */
+    public XContentBuilder toXContentWithRecommendations(
+        final XContentBuilder builder,
+        final Params params,
+        final List<Recommendation> recommendations
+    ) throws IOException {
+        toXContentInner(builder, params);
+        if (recommendations != null && !recommendations.isEmpty()) {
+            builder.startArray("recommendations");
+            for (Recommendation recommendation : recommendations) {
+                recommendation.toXContent(builder, params);
+            }
+            builder.endArray();
+        }
+        return builder.endObject();
+    }
+
+    /**
+     * Shared serialization of core fields (timestamp, id, attributes, measurements).
+     * Caller is responsible for calling {@code builder.endObject()} after adding any extra fields.
+     */
+    private XContentBuilder toXContentInner(final XContentBuilder builder, final Params params) throws IOException {
         builder.startObject();
         builder.field("timestamp", timestamp);
         builder.field("id", id);
-
         for (Map.Entry<Attribute, Object> entry : attributes.entrySet()) {
-            if (entry.getKey() == Attribute.TOP_N_QUERY) { // Always skip TOP_N_QUERY attribute
+            if (entry.getKey() == Attribute.TOP_N_QUERY) {
                 continue;
             }
             builder.field(entry.getKey().toString(), entry.getValue());
         }
         builder.startObject(MEASUREMENTS);
         for (Map.Entry<MetricType, Measurement> entry : measurements.entrySet()) {
-            builder.field(entry.getKey().toString());  // MetricType as field name
-            entry.getValue().toXContent(builder, params);  // Serialize Measurement object
+            builder.field(entry.getKey().toString());
+            entry.getValue().toXContent(builder, params);
         }
         builder.endObject();
-        return builder.endObject();
+        return builder;
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -600,7 +600,7 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
         final List<Recommendation> recommendations
     ) throws IOException {
         toXContentInner(builder, params);
-        if (recommendations != null && !recommendations.isEmpty()) {
+        if (recommendations != null) {
             builder.startArray("recommendations");
             for (Recommendation recommendation : recommendations) {
                 recommendation.toXContent(builder, params);

--- a/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesAction.java
@@ -81,6 +81,7 @@ public class RestTopQueriesAction extends BaseRestHandler {
         final String to = request.param("to", null);
         final String id = request.param("id", null);
         final boolean verbose = request.paramAsBoolean("verbose", true);
+        final boolean recommendations = request.paramAsBoolean("recommendations", false);
         if (!ALLOWED_METRICS.contains(metricType)) {
             throw new IllegalArgumentException(
                 String.format(Locale.ROOT, "request [%s] contains invalid metric type [%s]", request.path(), metricType)
@@ -91,7 +92,7 @@ public class RestTopQueriesAction extends BaseRestHandler {
             validateTimeRange(request, from, to);
         }
 
-        return new TopQueriesRequest(MetricType.fromString(metricType), from, to, id, verbose, nodesIds);
+        return new TopQueriesRequest(MetricType.fromString(metricType), from, to, id, verbose, recommendations, nodesIds);
     }
 
     private static void validateTimeRange(RestRequest request, String from, String to) {

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -11,8 +11,10 @@ package org.opensearch.plugin.insights.rules.transport.top_queries;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -30,12 +32,14 @@ import org.opensearch.plugin.insights.core.auth.TopQueriesRbacFilter;
 import org.opensearch.plugin.insights.core.auth.UserPrincipalContext;
 import org.opensearch.plugin.insights.core.auth.UserPrincipalContext.UserPrincipalInfo;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
+import org.opensearch.plugin.insights.core.service.recommendations.RecommendationService;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueries;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesRequest;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesResponse;
 import org.opensearch.plugin.insights.rules.model.FilterByMode;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportRequest;
@@ -118,7 +122,9 @@ public class TransportTopQueriesAction extends TransportNodesAction<
         if (from != null && to != null) {
             fetchHistoricalData(request, filterByMode, userInfo, inMemoryTopQueries, inMemoryDataFailures, finalListener);
         } else {
-            finalListener.onResponse(inMemoryQueriesResponse);
+            finalListener.onResponse(
+                new TopQueriesResponse(clusterService.getClusterName(), inMemoryTopQueries, inMemoryDataFailures, request.getMetricType())
+            );
         }
     }
 
@@ -190,7 +196,21 @@ public class TransportTopQueriesAction extends TransportNodesAction<
             // Remove duplicates between in-memory and historical records
             List<SearchQueryRecord> deduplicatedHistoricalRecords = removeDuplicates(inMemoryTopQueries, historicalRecords);
             if (!deduplicatedHistoricalRecords.isEmpty()) {
-                combinedTopQueriesList.add(new TopQueries(clusterService.localNode(), deduplicatedHistoricalRecords));
+                // Pre-compute recommendations for historical records (in-memory records already have them from nodeOperation)
+                Map<String, List<Recommendation>> historicalRecs = Collections.emptyMap();
+                if (Boolean.TRUE.equals(request.getRecommendations())) {
+                    RecommendationService recommendationService = queryInsightsService.getRecommendationService();
+                    if (recommendationService != null) {
+                        historicalRecs = new HashMap<>();
+                        for (SearchQueryRecord record : deduplicatedHistoricalRecords) {
+                            List<Recommendation> recs = recommendationService.generateRecommendations(record);
+                            if (recs != null && !recs.isEmpty()) {
+                                historicalRecs.put(record.getId(), recs);
+                            }
+                        }
+                    }
+                }
+                combinedTopQueriesList.add(new TopQueries(clusterService.localNode(), deduplicatedHistoricalRecords, historicalRecs));
             }
         }
         finalListener.onResponse(
@@ -290,7 +310,7 @@ public class TransportTopQueriesAction extends TransportNodesAction<
                 try {
                     List<TopQueries> filteredNodes = response.getNodes().stream().map(topQueries -> {
                         List<SearchQueryRecord> filtered = TopQueriesRbacFilter.filterRecords(topQueries.getTopQueriesRecord(), mode, info);
-                        return new TopQueries(topQueries.getNode(), filtered);
+                        return new TopQueries(topQueries.getNode(), filtered, topQueries.getRecommendations());
                     }).collect(Collectors.toList());
                     delegate.onResponse(
                         new TopQueriesResponse(response.getClusterName(), filteredNodes, response.failures(), response.getMetricType())
@@ -329,11 +349,23 @@ public class TransportTopQueriesAction extends TransportNodesAction<
     @Override
     protected TopQueries nodeOperation(final NodeRequest nodeRequest) {
         final TopQueriesRequest request = nodeRequest.request;
-        return new TopQueries(
-            clusterService.localNode(),
-            queryInsightsService.getTopQueriesService(request.getMetricType())
-                .getTopQueriesRecords(true, request.getFrom(), request.getTo(), request.getId(), request.getVerbose())
-        );
+        List<SearchQueryRecord> records = queryInsightsService.getTopQueriesService(request.getMetricType())
+            .getTopQueriesRecords(true, request.getFrom(), request.getTo(), request.getId(), request.getVerbose());
+
+        if (Boolean.TRUE.equals(request.getRecommendations())) {
+            RecommendationService recommendationService = queryInsightsService.getRecommendationService();
+            if (recommendationService != null) {
+                Map<String, List<Recommendation>> recommendationsMap = new HashMap<>();
+                for (SearchQueryRecord record : records) {
+                    List<Recommendation> recs = recommendationService.generateRecommendations(record);
+                    if (recs != null && !recs.isEmpty()) {
+                        recommendationsMap.put(record.getId(), recs);
+                    }
+                }
+                return new TopQueries(clusterService.localNode(), records, recommendationsMap);
+            }
+        }
+        return new TopQueries(clusterService.localNode(), records);
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesAction.java
@@ -199,15 +199,13 @@ public class TransportTopQueriesAction extends TransportNodesAction<
                 // Pre-compute recommendations for historical records (in-memory records already have them from nodeOperation)
                 Map<String, List<Recommendation>> historicalRecs = Collections.emptyMap();
                 if (Boolean.TRUE.equals(request.getRecommendations())) {
+                    historicalRecs = new HashMap<>();
                     RecommendationService recommendationService = queryInsightsService.getRecommendationService();
-                    if (recommendationService != null) {
-                        historicalRecs = new HashMap<>();
-                        for (SearchQueryRecord record : deduplicatedHistoricalRecords) {
-                            List<Recommendation> recs = recommendationService.generateRecommendations(record);
-                            if (recs != null && !recs.isEmpty()) {
-                                historicalRecs.put(record.getId(), recs);
-                            }
-                        }
+                    for (SearchQueryRecord record : deduplicatedHistoricalRecords) {
+                        List<Recommendation> recs = (recommendationService != null)
+                            ? recommendationService.generateRecommendations(record)
+                            : null;
+                        historicalRecs.put(record.getId(), recs != null ? recs : Collections.emptyList());
                     }
                 }
                 combinedTopQueriesList.add(new TopQueries(clusterService.localNode(), deduplicatedHistoricalRecords, historicalRecs));
@@ -310,7 +308,13 @@ public class TransportTopQueriesAction extends TransportNodesAction<
                 try {
                     List<TopQueries> filteredNodes = response.getNodes().stream().map(topQueries -> {
                         List<SearchQueryRecord> filtered = TopQueriesRbacFilter.filterRecords(topQueries.getTopQueriesRecord(), mode, info);
-                        return new TopQueries(topQueries.getNode(), filtered, topQueries.getRecommendations());
+                        Set<String> filteredIds = filtered.stream().map(SearchQueryRecord::getId).collect(Collectors.toSet());
+                        Map<String, List<Recommendation>> filteredRecs = topQueries.getRecommendations()
+                            .entrySet()
+                            .stream()
+                            .filter(e -> filteredIds.contains(e.getKey()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                        return new TopQueries(topQueries.getNode(), filtered, filteredRecs);
                     }).collect(Collectors.toList());
                     delegate.onResponse(
                         new TopQueriesResponse(response.getClusterName(), filteredNodes, response.failures(), response.getMetricType())
@@ -353,17 +357,13 @@ public class TransportTopQueriesAction extends TransportNodesAction<
             .getTopQueriesRecords(true, request.getFrom(), request.getTo(), request.getId(), request.getVerbose());
 
         if (Boolean.TRUE.equals(request.getRecommendations())) {
+            Map<String, List<Recommendation>> recommendationsMap = new HashMap<>();
             RecommendationService recommendationService = queryInsightsService.getRecommendationService();
-            if (recommendationService != null) {
-                Map<String, List<Recommendation>> recommendationsMap = new HashMap<>();
-                for (SearchQueryRecord record : records) {
-                    List<Recommendation> recs = recommendationService.generateRecommendations(record);
-                    if (recs != null && !recs.isEmpty()) {
-                        recommendationsMap.put(record.getId(), recs);
-                    }
-                }
-                return new TopQueries(clusterService.localNode(), records, recommendationsMap);
+            for (SearchQueryRecord record : records) {
+                List<Recommendation> recs = (recommendationService != null) ? recommendationService.generateRecommendations(record) : null;
+                recommendationsMap.put(record.getId(), recs != null ? recs : Collections.emptyList());
             }
+            return new TopQueries(clusterService.localNode(), records, recommendationsMap);
         }
         return new TopQueries(clusterService.localNode(), records);
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequestTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesRequestTests.java
@@ -22,9 +22,27 @@ public class TopQueriesRequestTests extends OpenSearchTestCase {
      * Check that we can set the metric type
      */
     public void testSetMetricType() throws Exception {
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, randomAlphaOfLength(5), null);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, randomAlphaOfLength(5), null, null);
         TopQueriesRequest deserializedRequest = roundTripRequest(request);
         assertEquals(request.getMetricType(), deserializedRequest.getMetricType());
+    }
+
+    public void testRecommendationsTrueRoundTrip() throws Exception {
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, true);
+        TopQueriesRequest deserialized = roundTripRequest(request);
+        assertEquals(true, deserialized.getRecommendations());
+    }
+
+    public void testRecommendationsFalseRoundTrip() throws Exception {
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, false);
+        TopQueriesRequest deserialized = roundTripRequest(request);
+        assertEquals(false, deserialized.getRecommendations());
+    }
+
+    public void testRecommendationsNullRoundTrip() throws Exception {
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, null);
+        TopQueriesRequest deserialized = roundTripRequest(request);
+        assertNull(deserialized.getRecommendations());
     }
 
     /**

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
@@ -8,11 +8,17 @@
 
 package org.opensearch.plugin.insights.rules.action.top_queries;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -20,8 +26,15 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
+import org.opensearch.plugin.insights.rules.model.AggregationType;
+import org.opensearch.plugin.insights.rules.model.Attribute;
+import org.opensearch.plugin.insights.rules.model.Measurement;
 import org.opensearch.plugin.insights.rules.model.MetricType;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
+import org.opensearch.plugin.insights.rules.model.recommendations.RecommendationType;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.VersionUtils;
 
 /**
  * Granular tests for the {@link TopQueriesResponse} class.
@@ -99,6 +112,117 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
         Arrays.sort(xContent);
 
         assertEquals(Arrays.hashCode(expectedXContent), Arrays.hashCode(xContent));
+    }
+
+    public void testToXContentWithRecommendations() throws IOException {
+        DiscoveryNode node = new DiscoveryNode(
+            "test_node",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+        String recordId = "rec_record_id";
+        SearchQueryRecord record = new SearchQueryRecord(
+            1706574180000L,
+            Map.of(MetricType.LATENCY, new Measurement(1L)),
+            Map.of(Attribute.NODE_ID, node.getId()),
+            recordId
+        );
+        Recommendation rec = Recommendation.builder()
+            .ruleId("test-rule")
+            .title("Test Recommendation")
+            .description("Test Description")
+            .type(RecommendationType.QUERY_REWRITE)
+            .confidence(0.95)
+            .build();
+
+        Map<String, List<Recommendation>> recsMap = new HashMap<>();
+        recsMap.put(recordId, List.of(rec));
+        TopQueries topQueries = new TopQueries(node, List.of(record), recsMap);
+
+        ClusterName clusterName = new ClusterName("test-cluster");
+        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(topQueries), new ArrayList<>(), MetricType.LATENCY);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        String json = BytesReference.bytes(response.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString();
+
+        assertTrue(json.contains("\"recommendations\""));
+        assertTrue(json.contains("\"rule_id\":\"test-rule\""));
+        assertTrue(json.contains("\"title\":\"Test Recommendation\""));
+        assertTrue(json.contains("\"confidence\":0.95"));
+    }
+
+    public void testToXContentWithoutRecommendations() throws IOException {
+        String id = "no_rec_id";
+        TopQueries topQueries = QueryInsightsTestUtils.createFixedTopQueries(id);
+        ClusterName clusterName = new ClusterName("test-cluster");
+        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(topQueries), new ArrayList<>(), MetricType.LATENCY);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        String json = BytesReference.bytes(response.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString();
+
+        assertFalse(json.contains("\"recommendations\""));
+    }
+
+    public void testToXContentMergesRecommendationsFromMultipleNodes() throws IOException {
+        DiscoveryNode node1 = new DiscoveryNode(
+            "node1",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "node2",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+
+        SearchQueryRecord record1 = new SearchQueryRecord(
+            2L,
+            Map.of(MetricType.LATENCY, new Measurement(10.0D, AggregationType.AVERAGE)),
+            Map.of(Attribute.NODE_ID, node1.getId()),
+            "id_node1"
+        );
+        SearchQueryRecord record2 = new SearchQueryRecord(
+            1L,
+            Map.of(MetricType.LATENCY, new Measurement(5.0D, AggregationType.AVERAGE)),
+            Map.of(Attribute.NODE_ID, node2.getId()),
+            "id_node2"
+        );
+
+        Recommendation rec1 = Recommendation.builder()
+            .ruleId("rule-a")
+            .title("Rec A")
+            .description("From node1")
+            .type(RecommendationType.QUERY_REWRITE)
+            .confidence(0.8)
+            .build();
+        Recommendation rec2 = Recommendation.builder()
+            .ruleId("rule-b")
+            .title("Rec B")
+            .description("From node2")
+            .type(RecommendationType.INDEX_CONFIG)
+            .confidence(0.7)
+            .build();
+
+        Map<String, List<Recommendation>> recsMap1 = Map.of("id_node1", List.of(rec1));
+        Map<String, List<Recommendation>> recsMap2 = Map.of("id_node2", List.of(rec2));
+
+        TopQueries tq1 = new TopQueries(node1, List.of(record1), recsMap1);
+        TopQueries tq2 = new TopQueries(node2, List.of(record2), recsMap2);
+
+        ClusterName clusterName = new ClusterName("test-cluster");
+        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(tq1, tq2), new ArrayList<>(), MetricType.LATENCY);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        String json = BytesReference.bytes(response.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString();
+
+        assertTrue(json.contains("\"rule_id\":\"rule-a\""));
+        assertTrue(json.contains("\"rule_id\":\"rule-b\""));
     }
 
     /**

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesResponseTests.java
@@ -165,6 +165,39 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
         assertFalse(json.contains("\"recommendations\""));
     }
 
+    public void testToXContentWithEmptyRecommendationsArray() throws IOException {
+        DiscoveryNode node = new DiscoveryNode(
+            "test_node",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+        String recordId = "empty_rec_record_id";
+        SearchQueryRecord record = new SearchQueryRecord(
+            1706574180000L,
+            Map.of(MetricType.LATENCY, new Measurement(1L)),
+            Map.of(Attribute.NODE_ID, node.getId()),
+            recordId
+        );
+
+        // Recommendations requested but no rules matched — empty list in map
+        Map<String, List<Recommendation>> recsMap = new HashMap<>();
+        recsMap.put(recordId, List.of());
+        TopQueries topQueries = new TopQueries(node, List.of(record), recsMap);
+
+        ClusterName clusterName = new ClusterName("test-cluster");
+        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(topQueries), new ArrayList<>(), MetricType.LATENCY);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        String json = BytesReference.bytes(response.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString();
+
+        assertTrue(
+            "Should contain empty recommendations array when requested but no rules matched",
+            json.contains("\"recommendations\":[]")
+        );
+    }
+
     public void testToXContentMergesRecommendationsFromMultipleNodes() throws IOException {
         DiscoveryNode node1 = new DiscoveryNode(
             "node1",
@@ -221,6 +254,66 @@ public class TopQueriesResponseTests extends OpenSearchTestCase {
         XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
         String json = BytesReference.bytes(response.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString();
 
+        assertTrue(json.contains("\"rule_id\":\"rule-a\""));
+        assertTrue(json.contains("\"rule_id\":\"rule-b\""));
+    }
+
+    public void testToXContentMergesRecommendationsForDuplicateRecordId() throws IOException {
+        DiscoveryNode node1 = new DiscoveryNode(
+            "node1",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+        DiscoveryNode node2 = new DiscoveryNode(
+            "node2",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+
+        // Same record ID on both nodes (e.g. grouped query)
+        String sharedId = "shared_id";
+        SearchQueryRecord record1 = new SearchQueryRecord(
+            1L,
+            Map.of(MetricType.LATENCY, new Measurement(10.0D, AggregationType.AVERAGE)),
+            Map.of(Attribute.NODE_ID, node1.getId()),
+            sharedId
+        );
+        SearchQueryRecord record2 = new SearchQueryRecord(
+            1L,
+            Map.of(MetricType.LATENCY, new Measurement(10.0D, AggregationType.AVERAGE)),
+            Map.of(Attribute.NODE_ID, node2.getId()),
+            sharedId
+        );
+
+        Recommendation recA = Recommendation.builder()
+            .ruleId("rule-a")
+            .title("Rec A")
+            .description("From node1")
+            .type(RecommendationType.QUERY_REWRITE)
+            .confidence(0.8)
+            .build();
+        Recommendation recB = Recommendation.builder()
+            .ruleId("rule-b")
+            .title("Rec B")
+            .description("From node2")
+            .type(RecommendationType.INDEX_CONFIG)
+            .confidence(0.7)
+            .build();
+
+        TopQueries tq1 = new TopQueries(node1, List.of(record1), Map.of(sharedId, List.of(recA)));
+        TopQueries tq2 = new TopQueries(node2, List.of(record2), Map.of(sharedId, List.of(recB)));
+
+        ClusterName clusterName = new ClusterName("test-cluster");
+        TopQueriesResponse response = new TopQueriesResponse(clusterName, List.of(tq1, tq2), new ArrayList<>(), MetricType.LATENCY);
+
+        XContentBuilder builder = MediaTypeRegistry.contentBuilder(MediaTypeRegistry.JSON);
+        String json = BytesReference.bytes(response.toXContent(builder, ToXContent.EMPTY_PARAMS)).utf8ToString();
+
+        // Both recommendations should be present (merged, not dropped)
         assertTrue(json.contains("\"rule_id\":\"rule-a\""));
         assertTrue(json.contains("\"rule_id\":\"rule-b\""));
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/top_queries/TopQueriesTests.java
@@ -8,11 +8,27 @@
 
 package org.opensearch.plugin.insights.rules.action.top_queries;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
+import org.opensearch.plugin.insights.rules.model.AggregationType;
+import org.opensearch.plugin.insights.rules.model.Attribute;
+import org.opensearch.plugin.insights.rules.model.Measurement;
+import org.opensearch.plugin.insights.rules.model.MetricType;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
+import org.opensearch.plugin.insights.rules.model.recommendations.RecommendationType;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.VersionUtils;
 
 /**
  * Tests for {@link TopQueries}.
@@ -30,5 +46,86 @@ public class TopQueriesTests extends OpenSearchTestCase {
                 );
             }
         }
+    }
+
+    public void testTopQueriesWithRecommendationsRoundTrip() throws IOException {
+        DiscoveryNode node = new DiscoveryNode(
+            "test_node",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+        SearchQueryRecord record = new SearchQueryRecord(
+            1L,
+            Map.of(MetricType.LATENCY, new Measurement(5.0D, AggregationType.AVERAGE)),
+            Map.of(Attribute.NODE_ID, node.getId()),
+            "rec_test_id"
+        );
+        Recommendation rec = Recommendation.builder()
+            .ruleId("test-rule")
+            .title("Test Title")
+            .description("Test Description")
+            .type(RecommendationType.QUERY_REWRITE)
+            .confidence(0.9)
+            .build();
+
+        Map<String, List<Recommendation>> recsMap = new HashMap<>();
+        recsMap.put(record.getId(), List.of(rec));
+
+        TopQueries topQueries = new TopQueries(node, List.of(record), recsMap);
+        assertEquals(1, topQueries.getRecommendations().size());
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            topQueries.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                TopQueries deserialized = new TopQueries(in);
+                assertTrue(QueryInsightsTestUtils.checkRecordsEquals(topQueries.getTopQueriesRecord(), deserialized.getTopQueriesRecord()));
+                assertEquals(1, deserialized.getRecommendations().size());
+                List<Recommendation> deserializedRecs = deserialized.getRecommendations().get("rec_test_id");
+                assertNotNull(deserializedRecs);
+                assertEquals(1, deserializedRecs.size());
+                assertEquals(rec, deserializedRecs.get(0));
+            }
+        }
+    }
+
+    public void testTopQueriesWithEmptyRecommendationsRoundTrip() throws IOException {
+        DiscoveryNode node = new DiscoveryNode(
+            "test_node",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+        SearchQueryRecord record = new SearchQueryRecord(
+            1L,
+            Map.of(MetricType.LATENCY, new Measurement(5.0D, AggregationType.AVERAGE)),
+            Map.of(Attribute.NODE_ID, node.getId()),
+            "test_id"
+        );
+        TopQueries topQueries = new TopQueries(node, List.of(record));
+        assertTrue(topQueries.getRecommendations().isEmpty());
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            topQueries.writeTo(out);
+            try (StreamInput in = out.bytes().streamInput()) {
+                TopQueries deserialized = new TopQueries(in);
+                assertTrue(deserialized.getRecommendations().isEmpty());
+            }
+        }
+    }
+
+    public void testTopQueriesNullRecommendationsDefaultsToEmpty() {
+        DiscoveryNode node = new DiscoveryNode(
+            "test_node",
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            emptySet(),
+            VersionUtils.randomVersion(random())
+        );
+        TopQueries topQueries = new TopQueries(node, Collections.emptyList(), null);
+        assertNotNull(topQueries.getRecommendations());
+        assertTrue(topQueries.getRecommendations().isEmpty());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
@@ -367,7 +367,18 @@ public class SearchQueryRecordTests extends OpenSearchTestCase {
         builder.flush();
 
         String json = builder.toString();
-        assertFalse("Empty recommendations list should not produce recommendations field", json.contains("\"recommendations\""));
+        assertTrue("Empty recommendations list should produce empty recommendations array", json.contains("\"recommendations\":[]"));
+    }
+
+    public void testToXContentWithNullRecommendations() throws IOException {
+        SearchQueryRecord record = QueryInsightsTestUtils.createFixedSearchQueryRecord("test_id");
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        record.toXContentWithRecommendations(builder, ToXContent.EMPTY_PARAMS, null);
+        builder.flush();
+
+        String json = builder.toString();
+        assertFalse("Null recommendations should not produce recommendations field", json.contains("\"recommendations\""));
     }
 
     /**

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecordTests.java
@@ -23,10 +23,13 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
 import org.opensearch.plugin.insights.core.auth.UserPrincipalContext;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
+import org.opensearch.plugin.insights.rules.model.recommendations.RecommendationType;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -328,6 +331,43 @@ public class SearchQueryRecordTests extends OpenSearchTestCase {
             "The following SearchPhaseName enum values are missing from phase_latency_map: " + missingPhases,
             missingPhases.isEmpty()
         );
+    }
+
+    public void testToXContentWithRecommendations() throws IOException {
+        SearchQueryRecord record = QueryInsightsTestUtils.createFixedSearchQueryRecord("test_rec_id");
+
+        Recommendation rec = Recommendation.builder()
+            .ruleId("test-rule")
+            .title("Test Title")
+            .description("Test Description")
+            .type(RecommendationType.QUERY_REWRITE)
+            .confidence(0.85)
+            .build();
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        record.toXContentWithRecommendations(builder, ToXContent.EMPTY_PARAMS, List.of(rec));
+        builder.flush();
+
+        String json = builder.toString();
+        assertTrue(json.contains("\"recommendations\""));
+        assertTrue(json.contains("\"rule_id\":\"test-rule\""));
+        assertTrue(json.contains("\"title\":\"Test Title\""));
+        assertTrue(json.contains("\"description\":\"Test Description\""));
+        assertTrue(json.contains("\"type\":\"query_rewrite\""));
+        assertTrue(json.contains("\"confidence\":0.85"));
+        assertTrue(json.contains("\"timestamp\":1706574180000"));
+        assertTrue(json.contains("\"id\":\"test_rec_id\""));
+    }
+
+    public void testToXContentWithEmptyRecommendations() throws IOException {
+        SearchQueryRecord record = QueryInsightsTestUtils.createFixedSearchQueryRecord("test_id");
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        record.toXContentWithRecommendations(builder, ToXContent.EMPTY_PARAMS, List.of());
+        builder.flush();
+
+        String json = builder.toString();
+        assertFalse("Empty recommendations list should not produce recommendations field", json.contains("\"recommendations\""));
     }
 
     /**

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/RestTopQueriesActionTests.java
@@ -130,6 +130,32 @@ public class RestTopQueriesActionTests extends OpenSearchTestCase {
         );
     }
 
+    public void testRecommendationsParamTrue() {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "latency");
+        params.put("recommendations", "true");
+        RestRequest restRequest = buildRestRequest(params);
+        TopQueriesRequest actual = RestTopQueriesAction.prepareRequest(restRequest);
+        assertEquals(true, actual.getRecommendations());
+    }
+
+    public void testRecommendationsParamFalse() {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "latency");
+        params.put("recommendations", "false");
+        RestRequest restRequest = buildRestRequest(params);
+        TopQueriesRequest actual = RestTopQueriesAction.prepareRequest(restRequest);
+        assertEquals(false, actual.getRecommendations());
+    }
+
+    public void testRecommendationsParamDefaultsFalse() {
+        Map<String, String> params = new HashMap<>();
+        params.put("type", "latency");
+        RestRequest restRequest = buildRestRequest(params);
+        TopQueriesRequest actual = RestTopQueriesAction.prepareRequest(restRequest);
+        assertEquals(false, actual.getRecommendations());
+    }
+
     public void testGetRoutes() {
         RestTopQueriesAction action = new RestTopQueriesAction();
         List<RestHandler.Route> routes = action.routes();

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/health_stats/TransportHealthStatsActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/health_stats/TransportHealthStatsActionTests.java
@@ -69,7 +69,7 @@ public class TransportHealthStatsActionTests extends OpenSearchTestCase {
         }
 
         public TopQueriesResponse createNewResponse() {
-            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
+            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, null);
             return newResponse(request, List.of(), List.of());
         }
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
@@ -514,6 +514,80 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
     }
 
     @SuppressWarnings("unchecked")
+    public void testWrapWithRbacFilter_filtersOrphanedRecommendations() {
+        ActionListener<TopQueriesResponse> finalListener = mock(ActionListener.class);
+        UserPrincipalInfo userInfo = new UserPrincipalInfo("user1", List.of("team_a"), List.of("role1"));
+
+        ActionListener<TopQueriesResponse> wrapped = actionToTest.wrapWithRbacFilter(finalListener, FilterByMode.BACKEND_ROLES, userInfo);
+
+        Map<Attribute, Object> attrs1 = new HashMap<>();
+        attrs1.put(Attribute.BACKEND_ROLES, new String[] { "team_a" });
+        attrs1.put(Attribute.NODE_ID, node1.getId());
+        SearchQueryRecord record1 = new SearchQueryRecord(
+            1L,
+            Map.of(MetricType.LATENCY, new Measurement(1.0D, AggregationType.AVERAGE)),
+            attrs1,
+            "kept_rec"
+        );
+
+        Map<Attribute, Object> attrs2 = new HashMap<>();
+        attrs2.put(Attribute.BACKEND_ROLES, new String[] { "team_c" });
+        attrs2.put(Attribute.NODE_ID, node1.getId());
+        SearchQueryRecord record2 = new SearchQueryRecord(
+            2L,
+            Map.of(MetricType.LATENCY, new Measurement(2.0D, AggregationType.AVERAGE)),
+            attrs2,
+            "filtered_out_rec"
+        );
+
+        Recommendation rec1 = Recommendation.builder()
+            .ruleId("rule-kept")
+            .title("Kept")
+            .description("Should survive")
+            .type(RecommendationType.QUERY_REWRITE)
+            .confidence(0.9)
+            .build();
+        Recommendation rec2 = Recommendation.builder()
+            .ruleId("rule-orphan")
+            .title("Orphan")
+            .description("Should be removed")
+            .type(RecommendationType.INDEX_CONFIG)
+            .confidence(0.8)
+            .build();
+
+        Map<String, List<Recommendation>> recsMap = new HashMap<>();
+        recsMap.put("kept_rec", List.of(rec1));
+        recsMap.put("filtered_out_rec", List.of(rec2));
+
+        List<SearchQueryRecord> records = new ArrayList<>();
+        records.add(record1);
+        records.add(record2);
+        TopQueries topQueries = new TopQueries(node1, records, recsMap);
+        TopQueriesResponse response = new TopQueriesResponse(
+            clusterService.getClusterName(),
+            Collections.singletonList(topQueries),
+            Collections.emptyList(),
+            MetricType.LATENCY
+        );
+
+        wrapped.onResponse(response);
+
+        ArgumentCaptor<TopQueriesResponse> responseCaptor = ArgumentCaptor.forClass(TopQueriesResponse.class);
+        verify(finalListener).onResponse(responseCaptor.capture());
+
+        TopQueriesResponse filteredResponse = responseCaptor.getValue();
+        assertEquals(1, filteredResponse.getNodes().size());
+        TopQueries filteredTq = filteredResponse.getNodes().get(0);
+        // Only record1 survives RBAC filtering
+        assertEquals(1, filteredTq.getTopQueriesRecord().size());
+        assertEquals("kept_rec", filteredTq.getTopQueriesRecord().get(0).getId());
+        // Recommendations map should only contain the surviving record's entry
+        assertEquals(1, filteredTq.getRecommendations().size());
+        assertNotNull(filteredTq.getRecommendations().get("kept_rec"));
+        assertNull(filteredTq.getRecommendations().get("filtered_out_rec"));
+    }
+
+    @SuppressWarnings("unchecked")
     public void testHandleInMemoryDataResponse_withRecommendationsTrue_passesThrough() {
         TopQueriesRequest request = new TopQueriesRequest(MetricType.CPU, null, null, null, false, true);
 
@@ -627,6 +701,77 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
         assertEquals(2, response.getNodes().size());
         TopQueries historicalNode = response.getNodes().get(1);
         assertTrue(historicalNode.getRecommendations().isEmpty());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testOnHistoricalDataResponse_withRecommendationsTrue_noRulesMatch_emptyArray() {
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, "from", "to", "id", true, true);
+
+        RecommendationService mockRecService = mock(RecommendationService.class);
+        when(queryInsightsService.getRecommendationService()).thenReturn(mockRecService);
+        // Service returns empty list — no rules matched
+        when(mockRecService.generateRecommendations(any(SearchQueryRecord.class))).thenReturn(Collections.emptyList());
+
+        List<TopQueries> inMemoryTopQueries = Collections.singletonList(new TopQueries(node1, Collections.emptyList()));
+        List<FailedNodeException> failures = Collections.emptyList();
+        List<SearchQueryRecord> histRecords = Collections.singletonList(
+            new SearchQueryRecord(
+                2L,
+                Map.of(MetricType.LATENCY, new Measurement(10.0D, AggregationType.AVERAGE)),
+                Map.of(Attribute.NODE_ID, node1.getId()),
+                null,
+                null,
+                "hist_entry"
+            )
+        );
+        ActionListener<TopQueriesResponse> finalListener = mock(ActionListener.class);
+
+        actionToTest.onHistoricalDataResponse(request, inMemoryTopQueries, failures, histRecords, finalListener);
+
+        ArgumentCaptor<TopQueriesResponse> responseCaptor = ArgumentCaptor.forClass(TopQueriesResponse.class);
+        verify(finalListener).onResponse(responseCaptor.capture());
+
+        TopQueriesResponse response = responseCaptor.getValue();
+        assertEquals(2, response.getNodes().size());
+        TopQueries historicalNode = response.getNodes().get(1);
+        // Key should be present with empty list (not absent)
+        assertEquals(1, historicalNode.getRecommendations().size());
+        assertNotNull(historicalNode.getRecommendations().get("hist_entry"));
+        assertTrue(historicalNode.getRecommendations().get("hist_entry").isEmpty());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testOnHistoricalDataResponse_withRecommendationsTrue_nullService_emptyArray() {
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, "from", "to", "id", true, true);
+
+        when(queryInsightsService.getRecommendationService()).thenReturn(null);
+
+        List<TopQueries> inMemoryTopQueries = Collections.singletonList(new TopQueries(node1, Collections.emptyList()));
+        List<FailedNodeException> failures = Collections.emptyList();
+        List<SearchQueryRecord> histRecords = Collections.singletonList(
+            new SearchQueryRecord(
+                2L,
+                Map.of(MetricType.LATENCY, new Measurement(10.0D, AggregationType.AVERAGE)),
+                Map.of(Attribute.NODE_ID, node1.getId()),
+                null,
+                null,
+                "hist_entry"
+            )
+        );
+        ActionListener<TopQueriesResponse> finalListener = mock(ActionListener.class);
+
+        actionToTest.onHistoricalDataResponse(request, inMemoryTopQueries, failures, histRecords, finalListener);
+
+        ArgumentCaptor<TopQueriesResponse> responseCaptor = ArgumentCaptor.forClass(TopQueriesResponse.class);
+        verify(finalListener).onResponse(responseCaptor.capture());
+
+        TopQueriesResponse response = responseCaptor.getValue();
+        assertEquals(2, response.getNodes().size());
+        TopQueries historicalNode = response.getNodes().get(1);
+        // Key should be present with empty list even when service is null
+        assertEquals(1, historicalNode.getRecommendations().size());
+        assertNotNull(historicalNode.getRecommendations().get("hist_entry"));
+        assertTrue(historicalNode.getRecommendations().get("hist_entry").isEmpty());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/top_queries/TransportTopQueriesActionTests.java
@@ -40,6 +40,7 @@ import org.opensearch.plugin.insights.core.auth.UserPrincipalContext;
 import org.opensearch.plugin.insights.core.auth.UserPrincipalContext.UserPrincipalInfo;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.core.service.TopQueriesService;
+import org.opensearch.plugin.insights.core.service.recommendations.RecommendationService;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueries;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesRequest;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesResponse;
@@ -49,6 +50,8 @@ import org.opensearch.plugin.insights.rules.model.FilterByMode;
 import org.opensearch.plugin.insights.rules.model.Measurement;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.rules.model.recommendations.Recommendation;
+import org.opensearch.plugin.insights.rules.model.recommendations.RecommendationType;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.Task;
@@ -91,7 +94,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
 
         @SuppressWarnings("unchecked")
         public TopQueriesResponse createNewResponse() {
-            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null);
+            TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, null, null, null, null, null);
             return newResponse(request, Collections.emptyList(), Collections.emptyList());
         }
     }
@@ -152,7 +155,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
 
     @SuppressWarnings("unchecked")
     public void testHandleInMemoryDataResponse_noHistoricalData() {
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.CPU, null, null, null, false);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.CPU, null, null, null, false, null);
         List<SearchQueryRecord> inMemoryRecords = Collections.singletonList(
             new SearchQueryRecord(
                 1L,
@@ -174,12 +177,16 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
 
         actionToTest.handleInMemoryDataResponse(request, FilterByMode.NONE, null, inMemoryResponse, finalListener);
 
-        verify(finalListener).onResponse(inMemoryResponse);
+        ArgumentCaptor<TopQueriesResponse> captor = ArgumentCaptor.forClass(TopQueriesResponse.class);
+        verify(finalListener).onResponse(captor.capture());
+        TopQueriesResponse capturedResponse = captor.getValue();
+        assertEquals(request.getMetricType(), capturedResponse.getMetricType());
+        assertEquals(1, capturedResponse.getNodes().size());
     }
 
     @SuppressWarnings("unchecked")
     public void testHandleInMemoryDataResponse_withHistoricalData_invokesFetch() {
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.CPU, "from", "to", "id", false);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.CPU, "from", "to", "id", false, null);
         List<TopQueries> inMemoryTopQueries = Collections.singletonList(new TopQueries(node1, Collections.emptyList()));
         List<FailedNodeException> failures = Collections.emptyList();
         ActionListener<TopQueriesResponse> finalListener = mock(ActionListener.class);
@@ -207,7 +214,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
 
     @SuppressWarnings("unchecked")
     public void testOnHistoricalDataResponse_combinesDataCorrectly() {
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, "from", "to", "id", true);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, "from", "to", "id", true, null);
         List<SearchQueryRecord> inMemoryRecords = Collections.singletonList(
             new SearchQueryRecord(
                 1L,
@@ -246,7 +253,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
 
     @SuppressWarnings("unchecked")
     public void testOnHistoricalDataFailure_usesInMemoryData() {
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.CPU, "from", "to", "id", false);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.CPU, "from", "to", "id", false, null);
         List<SearchQueryRecord> inMemoryRecords = Collections.singletonList(
             new SearchQueryRecord(
                 3L,
@@ -276,7 +283,7 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
 
     @SuppressWarnings("unchecked")
     public void testOnHistoricalDataResponse_removesDuplicates() {
-        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, "from", "to", "id", true);
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, "from", "to", "id", true, null);
 
         // in-memory record that's unique
         SearchQueryRecord uniqueInMemoryRecord = new SearchQueryRecord(
@@ -504,6 +511,122 @@ public class TransportTopQueriesActionTests extends OpenSearchTestCase {
         assertEquals(1, filteredResponse.getNodes().size());
         assertEquals(1, filteredResponse.getNodes().get(0).getTopQueriesRecord().size());
         assertEquals("rec1", filteredResponse.getNodes().get(0).getTopQueriesRecord().get(0).getId());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testHandleInMemoryDataResponse_withRecommendationsTrue_passesThrough() {
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.CPU, null, null, null, false, true);
+
+        Recommendation rec = Recommendation.builder()
+            .ruleId("rule-1")
+            .title("Title")
+            .description("Desc")
+            .type(RecommendationType.QUERY_REWRITE)
+            .confidence(0.9)
+            .build();
+        Map<String, List<Recommendation>> recsMap = Map.of("rec_id", List.of(rec));
+
+        List<SearchQueryRecord> inMemoryRecords = Collections.singletonList(
+            new SearchQueryRecord(
+                1L,
+                Map.of(MetricType.CPU, new Measurement(1.0D, AggregationType.SUM)),
+                Map.of(Attribute.NODE_ID, node1.getId()),
+                new SearchSourceBuilder(),
+                new UserPrincipalContext(threadPool),
+                "rec_id"
+            )
+        );
+        TopQueries inMemoryTq = new TopQueries(node1, inMemoryRecords, recsMap);
+        TopQueriesResponse inMemoryResponse = new TopQueriesResponse(
+            clusterService.getClusterName(),
+            Collections.singletonList(inMemoryTq),
+            Collections.emptyList(),
+            request.getMetricType()
+        );
+        ActionListener<TopQueriesResponse> finalListener = mock(ActionListener.class);
+
+        actionToTest.handleInMemoryDataResponse(request, FilterByMode.NONE, null, inMemoryResponse, finalListener);
+
+        ArgumentCaptor<TopQueriesResponse> captor = ArgumentCaptor.forClass(TopQueriesResponse.class);
+        verify(finalListener).onResponse(captor.capture());
+        TopQueriesResponse capturedResponse = captor.getValue();
+        // Recommendations from nodeOperation should be preserved in the TopQueries nodes
+        assertEquals(1, capturedResponse.getNodes().size());
+        assertEquals(1, capturedResponse.getNodes().get(0).getRecommendations().size());
+        assertNotNull(capturedResponse.getNodes().get(0).getRecommendations().get("rec_id"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testOnHistoricalDataResponse_withRecommendationsTrue_generatesForHistorical() {
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, "from", "to", "id", true, true);
+
+        RecommendationService mockRecService = mock(RecommendationService.class);
+        when(queryInsightsService.getRecommendationService()).thenReturn(mockRecService);
+
+        Recommendation rec = Recommendation.builder()
+            .ruleId("hist-rule")
+            .title("Historical Rec")
+            .description("For historical record")
+            .type(RecommendationType.INDEX_CONFIG)
+            .confidence(0.75)
+            .build();
+        when(mockRecService.generateRecommendations(any(SearchQueryRecord.class))).thenReturn(List.of(rec));
+
+        List<TopQueries> inMemoryTopQueries = Collections.singletonList(new TopQueries(node1, Collections.emptyList()));
+        List<FailedNodeException> failures = Collections.emptyList();
+        List<SearchQueryRecord> histRecords = Collections.singletonList(
+            new SearchQueryRecord(
+                2L,
+                Map.of(MetricType.LATENCY, new Measurement(10.0D, AggregationType.AVERAGE)),
+                Map.of(Attribute.NODE_ID, node1.getId()),
+                null,
+                null,
+                "hist_entry"
+            )
+        );
+        ActionListener<TopQueriesResponse> finalListener = mock(ActionListener.class);
+
+        actionToTest.onHistoricalDataResponse(request, inMemoryTopQueries, failures, histRecords, finalListener);
+
+        ArgumentCaptor<TopQueriesResponse> responseCaptor = ArgumentCaptor.forClass(TopQueriesResponse.class);
+        verify(finalListener).onResponse(responseCaptor.capture());
+
+        TopQueriesResponse response = responseCaptor.getValue();
+        // Node 0 = in-memory (empty), Node 1 = historical with recommendations
+        assertEquals(2, response.getNodes().size());
+        TopQueries historicalNode = response.getNodes().get(1);
+        assertEquals(1, historicalNode.getRecommendations().size());
+        assertNotNull(historicalNode.getRecommendations().get("hist_entry"));
+        assertEquals(rec, historicalNode.getRecommendations().get("hist_entry").get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testOnHistoricalDataResponse_withRecommendationsFalse_noRecommendations() {
+        TopQueriesRequest request = new TopQueriesRequest(MetricType.LATENCY, "from", "to", "id", true, false);
+
+        List<TopQueries> inMemoryTopQueries = Collections.singletonList(new TopQueries(node1, Collections.emptyList()));
+        List<FailedNodeException> failures = Collections.emptyList();
+        List<SearchQueryRecord> histRecords = Collections.singletonList(
+            new SearchQueryRecord(
+                2L,
+                Map.of(MetricType.LATENCY, new Measurement(10.0D, AggregationType.AVERAGE)),
+                Map.of(Attribute.NODE_ID, node1.getId()),
+                null,
+                null,
+                "hist_entry"
+            )
+        );
+        ActionListener<TopQueriesResponse> finalListener = mock(ActionListener.class);
+
+        actionToTest.onHistoricalDataResponse(request, inMemoryTopQueries, failures, histRecords, finalListener);
+
+        ArgumentCaptor<TopQueriesResponse> responseCaptor = ArgumentCaptor.forClass(TopQueriesResponse.class);
+        verify(finalListener).onResponse(responseCaptor.capture());
+
+        TopQueriesResponse response = responseCaptor.getValue();
+        assertEquals(2, response.getNodes().size());
+        TopQueries historicalNode = response.getNodes().get(1);
+        assertTrue(historicalNode.getRecommendations().isEmpty());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
### Description
Adds ?recommendations=true query parameter to the top_queries endpoint that enriches each query record with inline recommendations generated by the recommendation service.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
