### PR TITLE
[FIX] IS_STREAMING_TAG not propagated in incrementAggCounter and update eclipse formatter config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ spotless {
     }
     removeUnusedImports()
     importOrder()
-    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('config/formatterConfig.xml')
+    eclipse().configFile rootProject.file('config/formatterConfig.xml')
     trimTrailingWhitespace()
     endWithNewline()
   }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
@@ -126,7 +126,7 @@ public final class SearchQueryCounters {
      * @param isStreaming whether the query is a streaming request
      */
     public void incrementAggCounter(double value, Tags tags, Map<MetricType, Measurement> measurements, boolean isStreaming) {
-        tags.addTag(IS_STREAMING_TAG, String.valueOf(isStreaming));
+        tags = tags.addTag(IS_STREAMING_TAG, String.valueOf(isStreaming));
         aggCounter.add(value, tags);
         incrementAllHistograms(tags, measurements);
     }


### PR DESCRIPTION
### Description

Fixes `testAggregationsQuery` test failure introduced in #551.

issue:

`Tags` is immutable — `addTag` returns a new `Tags` instance with the added tag, leaving the original unchanged. In `incrementAggCounter`, the return value of `addTag` was being discarded:

```
// before
tags.addTag(IS_STREAMING_TAG, String.valueOf(isStreaming));
```
This meant is_streaming tag was never present in the Tags object passed to aggCounter.add(...), causing testAggregationsQuery to fail with:

```
java.lang.AssertionError: expected:<true> but was:<null>
    at SearchQueryCategorizerTests.testAggregationsQuery(SearchQueryCategorizerTests.java:124)
```

Fix
Reassign tags to the new instance returned by addTag:

```
// after
tags = tags.addTag(IS_STREAMING_TAG, String.valueOf(isStreaming));
```

### Changes
`SearchQueryCounters.java`— assign return value of addTag in incrementAggCounter

Testing
Existing test SearchQueryCategorizerTests.testAggregationsQuery covers this fix.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
