### PR TITLE
fix(ci): Pin LocalStack version and increase health check timeout

### DIFF
--- a/.github/workflows/remote_repository_exporter.yml
+++ b/.github/workflows/remote_repository_exporter.yml
@@ -35,18 +35,28 @@ jobs:
 
       - name: Pull LocalStack Docker image
         run: |
-          docker pull localstack/localstack:latest
+          docker pull localstack/localstack:4.4
 
       - name: Run LocalStack
         run: |
-          docker run --rm -d --name localstack-query-insights -p 4566:4566 localstack/localstack:latest
+          docker run --rm -d --name localstack-query-insights -p 4566:4566 localstack/localstack:4.4
 
       - name: Verify LocalStack is ready
         run: |
-          if ! timeout 30 bash -c 'until curl --silent --fail http://localhost:4566/_localstack/health; do sleep 1; done'; then
-            echo "LocalStack health check failed after 30 seconds"
-            exit 1
-          fi
+          echo "Waiting for LocalStack to be ready..."
+          for i in $(seq 1 60); do
+            if curl --silent --fail http://localhost:4566/_localstack/health > /dev/null 2>&1; then
+              echo "LocalStack is ready after ${i}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "LocalStack health check failed after 120 seconds"
+          echo "--- Container logs ---"
+          docker logs localstack-query-insights 2>&1 | tail -50
+          echo "--- Docker ps ---"
+          docker ps -a
+          exit 1
 
       - name: Create S3 Bucket in LocalStack
         run: |


### PR DESCRIPTION
### Description

Pin localstack/localstack to v4.4 instead of :latest to avoid breakage from upstream releases. Increase health check timeout from 30s to 120s with 2s polling interval to handle slow CI runners. Add container log output on failure for debugging.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
