### PR TITLE
Exclude integration tests on integTestRemote

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -564,6 +564,11 @@ task integTestRemote(type: RestIntegTestTask) {
   // Set default query size limit
   systemProperty 'defaultQuerySizeLimit', '10000'
 
+  // Exclude remote repository tests - run separately in integTestRemoteRepository
+  exclude 'org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporterIT.class'
+  // Exclude RBAC tests - require security plugin, run in integTestWithSecurity
+  exclude 'org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRbacIT.class'
+
   // Only REST-based integration tests can run with remote cluster
   if (System.getProperty("tests.rest.cluster") != null) {
     filter {
@@ -571,6 +576,10 @@ task integTestRemote(type: RestIntegTestTask) {
       // Exclude tests that require multi-node cluster or internal cluster access
       excludeTestsMatching 'org.opensearch.plugin.insights.QueryInsightsClusterIT'
       excludeTestsMatching 'org.opensearch.plugin.insights.QueryInsightsPluginTransportIT'
+      // Exclude remote repository tests - run separately in integTestRemoteRepository
+      excludeTestsMatching 'org.opensearch.plugin.insights.core.exporter.RemoteRepositoryExporterIT'
+      // Exclude RBAC tests - require security plugin
+      excludeTestsMatching 'org.opensearch.plugin.insights.rules.resthandler.top_queries.TopQueriesRbacIT'
     }
   }
 


### PR DESCRIPTION
### Description
Excludes RemoteRepositoryExporterIT and TopQueriesRbacIT tests from integTestRemote. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
