### PR TITLE
Fix grouping field_name/field_type settings overwritten to false on init

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -86,8 +86,6 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
         final ThreadPool threadPool
     ) {
         this(clusterService, queryInsightsService, threadPool, false);
-        groupingFieldNameEnabled = false;
-        groupingFieldTypeEnabled = false;
     }
 
     /**


### PR DESCRIPTION
### Description
The @Inject constructor of QueryInsightsListener was overwriting groupingFieldNameEnabled and groupingFieldTypeEnabled to false after the delegated constructor had correctly initialized them from cluster settings. Since both settings default to true, the settings update consumer would not fire when tests set them to true (no effective value change), leaving grouping without field differentiation.

This caused flaky MinMaxQueryGrouperBySimilarityIT tests — passing only when a "disabled" test ran first (explicitly setting the value to false, so the subsequent true update triggered the consumer).

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
