### PR TITLE
Add search document count metric

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -366,6 +366,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
                 null
             );
             record.setStreaming(searchRequestContext.isStreamingRequest());
+            record.setHitsLength(searchRequestContext.getHitsLength());
             queryInsightsService.addRecord(record);
         } catch (Exception e) {
             OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.DATA_INGEST_EXCEPTIONS);

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
@@ -86,6 +86,7 @@ public final class SearchQueryCategorizer {
         incrementQueryTypeCounters(source.query(), measurements);
         incrementQueryAggregationCounters(source.aggregations(), measurements, record.isStreaming());
         incrementQuerySortCounters(source.sorts(), measurements);
+        searchQueryCounters.recordSearchDocCount(record.getHitsLength());
     }
 
     private void incrementQuerySortCounters(List<SortBuilder<?>> sorts, Map<MetricType, Measurement> measurements) {

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
@@ -58,6 +58,11 @@ public final class SearchQueryCounters {
      */
     private final Histogram queryTypeMemoryHistogram;
 
+    /**
+     * Histogram for search doc count (number of hits returned per query)
+     */
+    private final Histogram searchDocCountHistogram;
+
     private final Map<Class<? extends QueryBuilder>, Counter> queryHandlers;
     /**
      * Counter name to Counter object map
@@ -100,6 +105,11 @@ public final class SearchQueryCounters {
             "search.query.type.memory.histogram",
             "Histogram for the memory per query type",
             UNIT_BYTES
+        );
+        this.searchDocCountHistogram = metricsRegistry.createHistogram(
+            "search.query.doc_count.histogram",
+            "Histogram for the number of documents returned per search query",
+            UNIT
         );
         this.queryHandlers = new HashMap<>();
     }
@@ -168,6 +178,14 @@ public final class SearchQueryCounters {
      */
     public Counter getSortCounter() {
         return sortCounter;
+    }
+
+    /**
+     * Record search doc count
+     * @param docCount number of documents returned
+     */
+    public void recordSearchDocCount(int docCount) {
+        searchDocCountHistogram.record(docCount);
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/SearchQueryRecord.java
@@ -51,6 +51,7 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
     private SearchSourceBuilder searchSourceBuilder;
     private final UserPrincipalContext userPrincipalContext; // Private field for user extraction
     private boolean streaming;
+    private int hitsLength;
 
     /**
      * Timestamp
@@ -733,6 +734,14 @@ public class SearchQueryRecord implements ToXContentObject, Writeable {
 
     public void setStreaming(boolean streaming) {
         this.streaming = streaming;
+    }
+
+    public int getHitsLength() {
+        return hitsLength;
+    }
+
+    public void setHitsLength(int hitsLength) {
+        this.hitsLength = hitsLength;
     }
 
     public boolean isCancelled() {


### PR DESCRIPTION
### Description
Add search document count metric
Metric to fetch doc count returned by search query.

Relevant Opensearch PR to update SearchRequestContext : https://github.com/opensearch-project/OpenSearch/pull/21037

metric: ImmutableMetricData{resource=Resource{schemaUrl=null, attributes={service.name="OpenSearch"}}, instrumentationScopeInfo=InstrumentationScopeInfo{name=org.opensearch.telemetry, version=null, schemaUrl=null, attributes={}}, name=search.query.doc_count.histogram, description=Histogram for the number of documents returned per search query, unit=1, type=EXPONENTIAL_HISTOGRAM, data=ImmutableExponentialHistogramData{aggregationTemporality=CUMULATIVE, points=[ImmutableExponentialHistogramPointData{getStartEpochNanos=1774810013641740000, getEpochNanos=1774810493652552000, getAttributes={}, getScale=20, getSum=12.0, getCount=4, getZeroCount=0, hasMin=true, getMin=3.0, hasMax=true, getMax=3.0, getPositiveBuckets=DoubleExponentialHistogramBuckets{scale: 20, offset: 1661953, counts: {1661953=4} }, getNegativeBuckets=EmptyExponentialHistogramBuckets{scale=20, offset=0, bucketCounts=[], totalCount=0}, getExemplars=[]}]}}