### PR TITLE
Add index attribute in script query metric

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizer.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.Measurement;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
@@ -82,8 +83,9 @@ public final class SearchQueryCategorizer {
     public void categorize(SearchQueryRecord record) {
         SearchSourceBuilder source = record.getSearchSourceBuilder();
         Map<MetricType, Measurement> measurements = record.getMeasurements();
+        String[] indices = (String[]) record.getAttributes().getOrDefault(Attribute.INDICES, new String[0]);
 
-        incrementQueryTypeCounters(source.query(), measurements);
+        incrementQueryTypeCounters(source.query(), measurements, indices);
         incrementQueryAggregationCounters(source.aggregations(), measurements, record.isStreaming());
         incrementQuerySortCounters(source.sorts(), measurements);
     }
@@ -113,11 +115,15 @@ public final class SearchQueryCategorizer {
         );
     }
 
-    private void incrementQueryTypeCounters(QueryBuilder topLevelQueryBuilder, Map<MetricType, Measurement> measurements) {
+    private void incrementQueryTypeCounters(
+        QueryBuilder topLevelQueryBuilder,
+        Map<MetricType, Measurement> measurements,
+        String[] indices
+    ) {
         if (topLevelQueryBuilder == null) {
             return;
         }
-        QueryBuilderVisitor searchQueryVisitor = new SearchQueryCategorizingVisitor(searchQueryCounters, measurements);
+        QueryBuilderVisitor searchQueryVisitor = new SearchQueryCategorizingVisitor(searchQueryCounters, measurements, indices);
         topLevelQueryBuilder.visit(searchQueryVisitor);
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizingVisitor.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCategorizingVisitor.java
@@ -23,22 +23,33 @@ final class SearchQueryCategorizingVisitor implements QueryBuilderVisitor {
     private final int level;
     private final SearchQueryCounters searchQueryCounters;
     private final Map<MetricType, Measurement> measurements;
+    private final String[] indices;
 
-    public SearchQueryCategorizingVisitor(SearchQueryCounters searchQueryCounters, Map<MetricType, Measurement> measurements) {
-        this(searchQueryCounters, 0, measurements);
+    public SearchQueryCategorizingVisitor(
+        SearchQueryCounters searchQueryCounters,
+        Map<MetricType, Measurement> measurements,
+        String[] indices
+    ) {
+        this(searchQueryCounters, 0, measurements, indices);
     }
 
-    private SearchQueryCategorizingVisitor(SearchQueryCounters counters, int level, Map<MetricType, Measurement> measurements) {
+    private SearchQueryCategorizingVisitor(
+        SearchQueryCounters counters,
+        int level,
+        Map<MetricType, Measurement> measurements,
+        String[] indices
+    ) {
         this.searchQueryCounters = counters;
         this.level = level;
         this.measurements = measurements;
+        this.indices = indices;
     }
 
     public void accept(QueryBuilder qb) {
-        searchQueryCounters.incrementCounter(qb, level, measurements);
+        searchQueryCounters.incrementCounter(qb, level, measurements, indices);
     }
 
     public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
-        return new SearchQueryCategorizingVisitor(searchQueryCounters, level + 1, measurements);
+        return new SearchQueryCategorizingVisitor(searchQueryCounters, level + 1, measurements, indices);
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/categorizer/SearchQueryCounters.java
@@ -104,18 +104,30 @@ public final class SearchQueryCounters {
         this.queryHandlers = new HashMap<>();
     }
 
+    private static final String INDEX_TAG = "index";
+
     /**
      * Increment counter
      * @param queryBuilder query builder
      * @param level level of query builder, 0 being highest level
      * @param measurements metrics measurements
+     * @param indices indices targeted by the query
      */
-    public void incrementCounter(QueryBuilder queryBuilder, int level, Map<MetricType, Measurement> measurements) {
+    public void incrementCounter(QueryBuilder queryBuilder, int level, Map<MetricType, Measurement> measurements, String[] indices) {
         String uniqueQueryCounterName = queryBuilder.getName();
 
         Counter counter = nameToQueryTypeCounters.computeIfAbsent(uniqueQueryCounterName, k -> createQueryCounter(k));
-        counter.add(1, Tags.create().addTag(LEVEL_TAG, level));
-        incrementAllHistograms(Tags.create().addTag(LEVEL_TAG, level).addTag(QUERY_TYPE_TAG, uniqueQueryCounterName), measurements);
+        if (indices != null && indices.length > 0) {
+            for (String index : indices) {
+                Tags tags = Tags.create().addTag(LEVEL_TAG, level).addTag(INDEX_TAG, index);
+                counter.add(1, tags);
+                incrementAllHistograms(tags.addTag(QUERY_TYPE_TAG, uniqueQueryCounterName), measurements);
+            }
+        } else {
+            Tags tags = Tags.create().addTag(LEVEL_TAG, level);
+            counter.add(1, tags);
+            incrementAllHistograms(tags.addTag(QUERY_TYPE_TAG, uniqueQueryCounterName), measurements);
+        }
     }
 
     /**


### PR DESCRIPTION
Add index attribute as a tag to query type counters and histograms in the search query categorizer. This enables per-index granularity when tracking query type metrics.

### Changes

- Extract indices from SearchQueryRecord attributes and pass them through the categorizer pipeline (SearchQueryCategorizer → SearchQueryCategorizingVisitor → SearchQueryCounters)
- Tag counters and histograms with the index dimension when indices are available
- When a query targets multiple indices, metrics are emitted per-index
- Fall back to existing behavior (no index tag) when indices are empty or null