### PR TITLE
Fix integTestRemote task spinning up unnecessary test cluster nodes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -550,7 +550,9 @@ testClusters.integTestRemoteRepository {
   }
 }
 
-task integTestRemote(type: RestIntegTestTask) {
+// Use plain Test instead of RestIntegTestTask to avoid RestTestBasePlugin
+// auto-creating a testcluster that spins up unnecessary nodes on CI.
+task integTestRemote(type: Test) {
   testClassesDirs = sourceSets.test.output.classesDirs
   classpath = sourceSets.test.runtimeClasspath
   systemProperty 'tests.security.manager', 'false'
@@ -569,8 +571,10 @@ task integTestRemote(type: RestIntegTestTask) {
   // Exclude RBAC tests - require security plugin, run in integTestWithSecurity
   exclude 'org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRbacIT.class'
 
-  // Only REST-based integration tests can run with remote cluster
+  // Remote cluster is shared; serialize tests to avoid cross-test interference.
   if (System.getProperty("tests.rest.cluster") != null) {
+    maxParallelForks = 1
+    forkEvery = 0
     filter {
       includeTestsMatching 'org.opensearch.plugin.insights.*IT'
       // Exclude tests that require multi-node cluster or internal cluster access


### PR DESCRIPTION
### Description
The integTestRemote task was declared as RestIntegTestTask, which auto-creates a Gradle test cluster. Combined with testClusters.all setting numberOfNodes=2, this caused 2 extra OpenSearch JVMs to start when running against an external cluster. On CI (opensearch-build), these extra nodes caused resource contention in the Docker container, which could leading to Connection refused on all tests.

Fix: Change task type from RestIntegTestTask to Test, which does not create a test cluster. This aligns with how cross-cluster-replication define their integTestRemote tasks. https://github.com/opensearch-project/cross-cluster-replication/blob/2af49c105ddfabe0ed62647290b073865a9930f7/build.gradle#L938,  which have 2 nodes set up.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
