### PR TITLE
Upgrade gradle to 9.4.1 and fix health stats tests

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=16f2b95838c1ddcf7242b1c39e7bbbb43c842f1f1a1a0dc4959b6d4d68abcac3
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-all.zip
+distributionSha256Sum=708d2c6ecc97ca9a11838ef64a6c2301151b8dd10387e22dc1a12c30557cab5b
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryInsightsHealthStatsTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/healthStats/QueryInsightsHealthStatsTests.java
@@ -99,12 +99,12 @@ public class QueryInsightsHealthStatsTests extends OpenSearchTestCase {
             topQueriesHealthStats,
             fieldTypeCacheStats
         );
-        XContentBuilder builder = XContentFactory.jsonBuilder();
+        XContentBuilder builder = XContentFactory.jsonBuilder().prettyPrint();
         builder.startObject();
 
         healthStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
-        String jsonOutput = builder.prettyPrint().toString();
+        String jsonOutput = builder.toString();
         // Expected JSON output
         String expectedJson = "{\n"
             + "    \"ThreadPoolInfo\": {\n"


### PR DESCRIPTION
### Description
Upgrade gradle to 9.4.1 to match OpenSearch and fix test compatibility for opensearch 3.7 with jackson 3.x migration (#21029) with XContentBuilder.prettyPrint() throwing an error if called after generator is initialized. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 
Fixes downstream CI failures 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
