### PR TITLE
[Feature] Skip calling cluster state for existing indices, but just generate the indices name purely from time inputs (#351)

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -42,7 +42,7 @@ public final class LocalIndexReader implements QueryInsightsReader {
     private DateTimeFormatter indexPattern;
     private final NamedXContentRegistry namedXContentRegistry;
     private final String id;
-    private int deleteAfterDays;
+    private volatile int deleteAfterDays;
 
     /**
      * Constructor of LocalIndexReader
@@ -90,6 +90,11 @@ public final class LocalIndexReader implements QueryInsightsReader {
     public LocalIndexReader setIndexPattern(DateTimeFormatter indexPattern) {
         this.indexPattern = indexPattern;
         return this;
+    }
+
+
+    public void setDeleteAfterDays(final int deleteAfterDays) {
+        this.deleteAfterDays = deleteAfterDays;
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -42,6 +42,7 @@ public final class LocalIndexReader implements QueryInsightsReader {
     private DateTimeFormatter indexPattern;
     private final NamedXContentRegistry namedXContentRegistry;
     private final String id;
+    private int deleteAfterDays;
 
     /**
      * Constructor of LocalIndexReader
@@ -49,17 +50,21 @@ public final class LocalIndexReader implements QueryInsightsReader {
      * @param client OS client
      * @param indexPattern the pattern of index to read from
      * @param namedXContentRegistry for parsing purposes
+     * @param id reader id
+     * @param deleteAfterDays value of the delete-after retention setting
      */
     public LocalIndexReader(
         final Client client,
         final DateTimeFormatter indexPattern,
         final NamedXContentRegistry namedXContentRegistry,
-        final String id
+        final String id,
+        final int deleteAfterDays
     ) {
         this.indexPattern = indexPattern;
         this.client = client;
         this.id = id;
         this.namedXContentRegistry = namedXContentRegistry;
+        this.deleteAfterDays = deleteAfterDays;
     }
 
     @Override
@@ -134,24 +139,22 @@ public final class LocalIndexReader implements QueryInsightsReader {
         }
         final ZonedDateTime finalEnd = end;
 
-        // Discover indices in the date range
-        IndexDiscoveryHelper.discoverIndicesInDateRange(client, indexPattern, start, finalEnd, new ActionListener<List<String>>() {
-            @Override
-            public void onResponse(List<String> indexNames) {
-                if (indexNames.isEmpty()) {
-                    listener.onResponse(Collections.emptyList());
-                    return;
-                }
+        final ZonedDateTime retentionTime = now.minusDays(this.deleteAfterDays);
+        final ZonedDateTime effectiveStart = start.isBefore(retentionTime) ? retentionTime : start;
 
-                // Build and execute search request
-                executeSearchRequest(indexNames, start, finalEnd, id, verbose, metricType, username, backendRoles, listener);
-            }
+        if (effectiveStart.isAfter(finalEnd)) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
 
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
-            }
-        });
+        final List<String> indexNames = IndexDiscoveryHelper.buildIndexNamesInDateRange(indexPattern, effectiveStart, finalEnd);
+
+        if (indexNames.isEmpty()) {
+            listener.onResponse(Collections.emptyList());
+            return;
+        }
+
+        executeSearchRequest(indexNames, start, finalEnd, id, verbose, metricType, username, backendRoles, listener);
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/LocalIndexReader.java
@@ -92,7 +92,6 @@ public final class LocalIndexReader implements QueryInsightsReader {
         return this;
     }
 
-
     public void setDeleteAfterDays(final int deleteAfterDays) {
         this.deleteAfterDays = deleteAfterDays;
     }

--- a/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactory.java
@@ -42,16 +42,25 @@ public class QueryInsightsReaderFactory {
     /**
      * Create a Local Index Reader based on provided parameters
      *
+     * @param id reader id
      * @param indexPattern the index pattern if creating an index Reader
      * @param namedXContentRegistry for parsing purposes
+     * @param deleteAfterDays initial value of the
+     *                        search.insights.top_queries.exporter.delete_after_days setting
      * @return QueryInsightsReader the created Reader
      */
-    public QueryInsightsReader createLocalIndexReader(String id, String indexPattern, NamedXContentRegistry namedXContentRegistry) {
+    public QueryInsightsReader createLocalIndexReader(
+        String id,
+        String indexPattern,
+        NamedXContentRegistry namedXContentRegistry,
+        int deleteAfterDays
+    ) {
         QueryInsightsReader reader = new LocalIndexReader(
             client,
             DateTimeFormatter.ofPattern(indexPattern, Locale.ROOT),
             namedXContentRegistry,
-            id
+            id,
+            deleteAfterDays
         );
         this.readers.put(id, reader);
         return reader;

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -475,7 +475,8 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
             queryInsightsReaderFactory.createLocalIndexReader(
                 TOP_QUERIES_READER_ID,
                 DEFAULT_TOP_N_QUERIES_INDEX_PATTERN,
-                namedXContentRegistry
+                namedXContentRegistry,
+                clusterService.getClusterSettings().get(TOP_N_EXPORTER_DELETE_AFTER)
             );
         }
         // Set sink type to debug exporter

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -50,6 +50,7 @@ import org.opensearch.plugin.insights.core.exporter.RemoteRepositoryExporter;
 import org.opensearch.plugin.insights.core.exporter.SinkType;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
+import org.opensearch.plugin.insights.core.reader.LocalIndexReader;
 import org.opensearch.plugin.insights.core.reader.QueryInsightsReader;
 import org.opensearch.plugin.insights.core.reader.QueryInsightsReaderFactory;
 import org.opensearch.plugin.insights.core.service.categorizer.QueryShapeGenerator;
@@ -194,14 +195,13 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
             client,
             clusterService.getClusterSettings().get(TOP_N_EXPORTER_DELETE_AFTER)
         );
-        clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(TOP_N_EXPORTER_DELETE_AFTER, (localIndexLifecycleManager::setDeleteAfterAndDelete));
         queryInsightsExporterFactory.createRemoteRepositoryExporter(
             TOP_QUERIES_REMOTE_EXPORTER_ID,
             clusterService.getClusterSettings().get(REMOTE_EXPORTER_REPOSITORY),
             clusterService.getClusterSettings().get(REMOTE_EXPORTER_PATH),
             clusterService.getClusterSettings().get(REMOTE_EXPORTER_ENABLED)
         );
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(TOP_N_EXPORTER_DELETE_AFTER, this::onDeleteAfterDaysUpdated);
 
         // Listen for remote repository exporter setting changes - update individual settings
         clusterService.getClusterSettings().addSettingsUpdateConsumer(REMOTE_EXPORTER_ENABLED, this::updateRemoteExporterEnabled);
@@ -485,6 +485,15 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         }
 
         this.sinkType = sinkType;
+    }
+
+    private void onDeleteAfterDaysUpdated(final int deleteAfterDays) {
+        localIndexLifecycleManager.setDeleteAfterAndDelete(deleteAfterDays);
+
+        final QueryInsightsReader reader = queryInsightsReaderFactory.getReader(TOP_QUERIES_READER_ID);
+        if (reader instanceof LocalIndexReader) {
+            ((LocalIndexReader) reader).setDeleteAfterDays(deleteAfterDays);
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/core/utils/IndexDiscoveryHelper.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/utils/IndexDiscoveryHelper.java
@@ -15,16 +15,8 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
-import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.action.support.IndicesOptions;
-import org.opensearch.core.action.ActionListener;
-import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
-import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
-import org.opensearch.transport.client.Client;
 
 /**
  * Utility class for discovering and managing indices for Query Insights operations.
@@ -33,59 +25,36 @@ import org.opensearch.transport.client.Client;
  */
 public final class IndexDiscoveryHelper {
 
-    private static final Logger logger = LogManager.getLogger(IndexDiscoveryHelper.class);
-
     private IndexDiscoveryHelper() {}
 
     /**
-     * Discovers existing indices within the specified date range and executes a callback
-     * with the list of found indices.
+     * Generates the expected Query Insights local index name for every day in
+     * interval start-end inclusive, without getting the cluster state.
      *
-     * @param client OpenSearch client for cluster operations
+     * Names that do not correspond to an actual index are skipped
+     * by the search request itself.
+     *
      * @param indexPattern DateTimeFormatter pattern for index naming
      * @param start Start date for the search range
      * @param end End date for the search range
-     * @param callback Callback to execute with the discovered indices
+     * @return List of index names, one per day, in ascending date order
      */
-    public static void discoverIndicesInDateRange(
-        final Client client,
+    public static List<String> buildIndexNamesInDateRange(
         final DateTimeFormatter indexPattern,
         final ZonedDateTime start,
-        final ZonedDateTime end,
-        final ActionListener<List<String>> callback
+        final ZonedDateTime end
     ) {
-        ClusterStateRequest clusterStateRequest = createClusterStateRequest();
+        final List<String> indexNames = new ArrayList<>();
 
-        client.admin().cluster().state(clusterStateRequest, new ActionListener<ClusterStateResponse>() {
-            @Override
-            public void onResponse(ClusterStateResponse clusterStateResponse) {
-                try {
-                    Set<String> existingIndices = clusterStateResponse.getState().metadata().indices().keySet();
-                    List<String> indexNames = findIndicesInDateRange(existingIndices, indexPattern, start, end);
-                    callback.onResponse(indexNames);
-                } catch (Exception e) {
-                    logger.error("Error processing cluster state response for index discovery: ", e);
-                    OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_READER_SEARCH_EXCEPTIONS);
-                    callback.onFailure(e);
-                }
-            }
+        ZonedDateTime currentDay = start.toLocalDate().atStartOfDay(start.getZone());
+        final ZonedDateTime endDay = end.toLocalDate().atStartOfDay(end.getZone());
 
-            @Override
-            public void onFailure(Exception e) {
-                OperationalMetricsCounter.getInstance().incrementCounter(OperationalMetric.LOCAL_INDEX_READER_SEARCH_EXCEPTIONS);
-                logger.error("Failed to get cluster state for indices matching {}: ", TOP_QUERIES_INDEX_PATTERN_GLOB, e);
-                callback.onFailure(e);
-            }
-        });
-    }
+        while (!currentDay.isAfter(endDay)) {
+            indexNames.add(buildLocalIndexName(indexPattern, currentDay));
+            currentDay = currentDay.plusDays(1);
+        }
 
-    /**
-     * Creates a cluster state request configured for index discovery.
-     *
-     * @return Configured ClusterStateRequest
-     */
-    private static ClusterStateRequest createClusterStateRequest() {
-        return createClusterStateRequest(IndicesOptions.lenientExpandOpen());
+        return indexNames;
     }
 
     /**
@@ -100,39 +69,6 @@ public final class IndexDiscoveryHelper {
             .metadata(true)
             .local(true)
             .indicesOptions(indicesOptions);
-    }
-
-    /**
-     * Finds existing indices within the specified date range.
-     *
-     * @param existingIndices Set of all existing indices from cluster state
-     * @param indexPattern DateTimeFormatter pattern for index naming
-     * @param start Start date for the search range
-     * @param end End date for the search range
-     * @return List of index names that exist within the date range
-     */
-    static List<String> findIndicesInDateRange(
-        final Set<String> existingIndices,
-        final DateTimeFormatter indexPattern,
-        final ZonedDateTime start,
-        final ZonedDateTime end
-    ) {
-        List<String> indexNames = new ArrayList<>();
-
-        // Normalize dates to start of day to ensure proper day-by-day iteration
-        ZonedDateTime currentDay = start.toLocalDate().atStartOfDay(start.getZone());
-        ZonedDateTime endDay = end.toLocalDate().atStartOfDay(end.getZone());
-
-        // Iterate through each day in the range [start, end] and add only existing indices
-        while (!currentDay.isAfter(endDay)) {
-            String potentialIndexName = buildLocalIndexName(indexPattern, currentDay);
-            if (existingIndices.contains(potentialIndexName)) {
-                indexNames.add(potentialIndexName);
-            }
-            currentDay = currentDay.plusDays(1);
-        }
-
-        return indexNames;
     }
 
     /**

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
@@ -61,10 +61,11 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
     private final Client client = mock(Client.class);
     private final NamedXContentRegistry namedXContentRegistry = mock(NamedXContentRegistry.class);
     private LocalIndexReader localIndexReader;
+    private final int DELETE_AFTER = 7;
 
     @Before
     public void setup() {
-        localIndexReader = new LocalIndexReader(client, format, namedXContentRegistry, "id");
+        localIndexReader = new LocalIndexReader(client, format, namedXContentRegistry, "id", DELETE_AFTER);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
@@ -264,27 +264,25 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
             searchRequestCaptured.set(invocation.getArgument(0));
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             SearchResponse mockResponse = mock(SearchResponse.class);
-            when(mockResponse.getHits()).thenReturn(
-                new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0f)
-            );
+            when(mockResponse.getHits()).thenReturn(new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0f));
             listener.onResponse(mockResponse);
             return null;
         }).when(client).search(any(SearchRequest.class), any(ActionListener.class));
 
-        localIndexReader.read(from, to, null, true, MetricType.LATENCY, ActionListener.wrap(
-            records -> latch.countDown(),
-            e -> fail("No exception expected but got: " + e.getMessage())
-        ));
+        localIndexReader.read(
+            from,
+            to,
+            null,
+            true,
+            MetricType.LATENCY,
+            ActionListener.wrap(records -> latch.countDown(), e -> fail("No exception expected but got: " + e.getMessage()))
+        );
 
         assertTrue("Listener timed out", latch.await(1, TimeUnit.SECONDS));
         SearchRequest req = searchRequestCaptured.get();
         assertNotNull(req);
 
-        assertEquals(
-            "Expected 8 indices (today + 7-day retention), got " + req.indices().length,
-            DELETE_AFTER + 1,
-            req.indices().length
-        );
+        assertEquals("Expected 8 indices (today + 7-day retention), got " + req.indices().length, DELETE_AFTER + 1, req.indices().length);
     }
 
     /**
@@ -313,10 +311,7 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
         assertTrue("Listener timed out", latch.await(1, TimeUnit.SECONDS));
         assertNotNull(recordsRef.get());
         assertTrue("Expected empty result when range is entirely before retention", recordsRef.get().isEmpty());
-        assertFalse(
-            "client.search() must not be called when the effective range is empty",
-            searchCalled.get()
-        );
+        assertFalse("client.search() must not be called when the effective range is empty", searchCalled.get());
     }
 
     /**
@@ -338,25 +333,23 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
             captured.set(invocation.getArgument(0));
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             SearchResponse mockResponse = mock(SearchResponse.class);
-            when(mockResponse.getHits()).thenReturn(
-                new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0f)
-            );
+            when(mockResponse.getHits()).thenReturn(new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0f));
             listener.onResponse(mockResponse);
             return null;
         }).when(client).search(any(SearchRequest.class), any(ActionListener.class));
 
-        localIndexReader.read(from, to, null, true, MetricType.LATENCY, ActionListener.wrap(
-            records -> latch.countDown(),
-            e -> fail("No exception expected, got: " + e.getMessage())
-        ));
+        localIndexReader.read(
+            from,
+            to,
+            null,
+            true,
+            MetricType.LATENCY,
+            ActionListener.wrap(records -> latch.countDown(), e -> fail("No exception expected, got: " + e.getMessage()))
+        );
 
         assertTrue("Listener timed out", latch.await(1, TimeUnit.SECONDS));
         SearchRequest req = captured.get();
         assertNotNull(req);
-        assertEquals(
-            "Only today index should be targeted when deleteAfterDays=0 but got " + req.indices().length,
-            1,
-            req.indices().length
-        );
+        assertEquals("Only today index should be targeted when deleteAfterDays=0 but got " + req.indices().length, 1, req.indices().length);
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/LocalIndexReaderTests.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
@@ -243,5 +244,119 @@ public class LocalIndexReaderTests extends OpenSearchTestCase {
         final DateTimeFormatter newFormatter = DateTimeFormatter.ofPattern("YYYY-MM-dd", Locale.ROOT);
         localIndexReader.setIndexPattern(newFormatter);
         assert (localIndexReader.getIndexPattern() == newFormatter);
+    }
+
+    /**
+     * Request a 30-day-back window while the retention setting is 7 days.
+     * The SearchRequest should target 8 index names (today + 7 back)
+     */
+    @SuppressWarnings("unchecked")
+    public void testReadClipsStartToRetentionWindow() throws InterruptedException {
+        final int daysRequested = 30;
+        final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        final String from = now.minusDays(daysRequested).format(DateTimeFormatter.ISO_DATE_TIME);
+        final String to = now.format(DateTimeFormatter.ISO_DATE_TIME);
+
+        final AtomicReference<SearchRequest> searchRequestCaptured = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            searchRequestCaptured.set(invocation.getArgument(0));
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            SearchResponse mockResponse = mock(SearchResponse.class);
+            when(mockResponse.getHits()).thenReturn(
+                new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0f)
+            );
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any(ActionListener.class));
+
+        localIndexReader.read(from, to, null, true, MetricType.LATENCY, ActionListener.wrap(
+            records -> latch.countDown(),
+            e -> fail("No exception expected but got: " + e.getMessage())
+        ));
+
+        assertTrue("Listener timed out", latch.await(1, TimeUnit.SECONDS));
+        SearchRequest req = searchRequestCaptured.get();
+        assertNotNull(req);
+
+        assertEquals(
+            "Expected 8 indices (today + 7-day retention), got " + req.indices().length,
+            DELETE_AFTER + 1,
+            req.indices().length
+        );
+    }
+
+    /**
+     * When the requested [from, to] range is entirely before the retention period,
+     * the reader must return empty list without calling search.
+     */
+    @SuppressWarnings("unchecked")
+    public void testReadReturnsEmptyWhenRangeEntirelyBeforeRetention() throws InterruptedException {
+        final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        final String from = now.minusDays(30).format(DateTimeFormatter.ISO_DATE_TIME);
+        final String to = now.minusDays(20).format(DateTimeFormatter.ISO_DATE_TIME);
+
+        final AtomicBoolean searchCalled = new AtomicBoolean(false);
+        doAnswer(invocation -> {
+            searchCalled.set(true);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any(ActionListener.class));
+
+        final AtomicReference<List<SearchQueryRecord>> recordsRef = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        localIndexReader.read(from, to, null, true, MetricType.LATENCY, ActionListener.wrap(records -> {
+            recordsRef.set(records);
+            latch.countDown();
+        }, e -> fail("No exception expected but got: " + e.getMessage())));
+
+        assertTrue("Listener timed out", latch.await(1, TimeUnit.SECONDS));
+        assertNotNull(recordsRef.get());
+        assertTrue("Expected empty result when range is entirely before retention", recordsRef.get().isEmpty());
+        assertFalse(
+            "client.search() must not be called when the effective range is empty",
+            searchCalled.get()
+        );
+    }
+
+    /**
+     * With deleteAfterDays = 0 the retention floor becomes `now`, so any window
+     * that reaches back into the past should be tripped down to today index
+     */
+    @SuppressWarnings("unchecked")
+    public void testReadWithDeleteAfterZeroTargetsOnlyTodayIndex() throws InterruptedException {
+        localIndexReader.setDeleteAfterDays(0);
+
+        final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        final String from = now.minusDays(1).format(DateTimeFormatter.ISO_DATE_TIME);
+        final String to = now.plusMinutes(1).format(DateTimeFormatter.ISO_DATE_TIME);
+
+        final AtomicReference<SearchRequest> captured = new AtomicReference<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            captured.set(invocation.getArgument(0));
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            SearchResponse mockResponse = mock(SearchResponse.class);
+            when(mockResponse.getHits()).thenReturn(
+                new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0f)
+            );
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any(ActionListener.class));
+
+        localIndexReader.read(from, to, null, true, MetricType.LATENCY, ActionListener.wrap(
+            records -> latch.countDown(),
+            e -> fail("No exception expected, got: " + e.getMessage())
+        ));
+
+        assertTrue("Listener timed out", latch.await(1, TimeUnit.SECONDS));
+        SearchRequest req = captured.get();
+        assertNotNull(req);
+        assertEquals(
+            "Only today index should be targeted when deleteAfterDays=0 but got " + req.indices().length,
+            1,
+            req.indices().length
+        );
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/MultiIndexDateRangeIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/MultiIndexDateRangeIT.java
@@ -33,20 +33,24 @@ import org.opensearch.plugin.insights.core.utils.IndexDiscoveryHelper;
 public class MultiIndexDateRangeIT extends QueryInsightsRestTestCase {
     private static final DateTimeFormatter indexPattern = DateTimeFormatter.ofPattern(INDEX_DATE_FORMAT_PATTERN, Locale.ROOT);
 
+    private static ZonedDateTime getDaysAgo(int daysAgo) {
+        return ZonedDateTime.now(ZoneOffset.UTC).toLocalDate().atStartOfDay(ZoneOffset.UTC).minusDays(daysAgo);
+    }
+
     void createLocalIndices() throws IOException, ParseException, InterruptedException {
         // Explicitly enable local_index exporter to ensure the reader is initialized,
         // regardless of the default exporter type (which may be NONE in some builds).
         defaultExporterSettings();
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(INDEX_DATE_FORMAT_PATTERN, Locale.ROOT);
+        // Use dates within the default retention window (delete_after_days = 7) so
+        // LocalIndexReader's retention clamp does not exclude them. Five indices are
+        // created on today-5 … today-1; the tests below query today-4 forward so that
+        // the today-5 index is the "one outside the range" and 4 records are returned.
+        List<ZonedDateTime> dates = List.of(getDaysAgo(5), getDaysAgo(4), getDaysAgo(3), getDaysAgo(2), getDaysAgo(1));
 
-        List<String> inputDates = List.of("2022.06.21", "2020.10.04", "2023.02.15", "2021.12.29", "2024.03.08");
-
-        for (String dateStr : inputDates) {
-            LocalDate localDate = LocalDate.parse(dateStr, formatter);
-            ZonedDateTime zdt = localDate.atStartOfDay(ZoneOffset.UTC);
-            long timestamp = zdt.toInstant().toEpochMilli();
-            String indexName = buildLocalIndexName(zdt);
+        for (ZonedDateTime date : dates) {
+            long timestamp = date.toInstant().toEpochMilli();
+            String indexName = buildLocalIndexName(date);
             createTopQueriesIndex(indexName, timestamp);
         }
 
@@ -56,7 +60,10 @@ public class MultiIndexDateRangeIT extends QueryInsightsRestTestCase {
     public void testMultiIndexDateRangeRetrieval() throws IOException, ParseException, InterruptedException {
         createLocalIndices();
 
-        Request request = new Request("GET", "/_insights/top_queries?from=2021-04-01T00:00:00Z&to=2025-04-02T00:00:00Z");
+        // Query range [today-4, today]: excludes the today-5 index to 4 of the 5 records match.
+        String from = getDaysAgo(4).format(DateTimeFormatter.ISO_INSTANT);
+        String to = getDaysAgo(0).format(DateTimeFormatter.ISO_INSTANT);
+        Request request = new Request("GET", "/_insights/top_queries?from=" + from + "&to=" + to);
 
         Response response = client().performRequest(request);
         String responseBody = EntityUtils.toString(response.getEntity());
@@ -84,8 +91,12 @@ public class MultiIndexDateRangeIT extends QueryInsightsRestTestCase {
     public void testReaderTopNLabels() throws IOException, ParseException, InterruptedException {
         createLocalIndices();
 
+        // Query range [today-4, today] so 4 of the 5 records match.
+        String from = getDaysAgo(4).format(DateTimeFormatter.ISO_INSTANT);
+        String to = getDaysAgo(0).format(DateTimeFormatter.ISO_INSTANT);
+
         // type=cpu, 4 top queries
-        Request request = new Request("GET", "/_insights/top_queries?from=2021-04-01T00:00:00Z&to=2025-04-02T00:00:00Z&type=cpu");
+        Request request = new Request("GET", "/_insights/top_queries?from=" + from + "&to=" + to + "&type=cpu");
 
         Response response = client().performRequest(request);
         String responseBody = EntityUtils.toString(response.getEntity());
@@ -109,7 +120,7 @@ public class MultiIndexDateRangeIT extends QueryInsightsRestTestCase {
         }
 
         // type=memory, 0 top queries
-        request = new Request("GET", "/_insights/top_queries?from=2021-04-01T00:00:00Z&to=2025-04-02T00:00:00Z&type=memory");
+        request = new Request("GET", "/_insights/top_queries?from=" + from + "&to=" + to + "&type=memory");
 
         response = client().performRequest(request);
         responseBody = EntityUtils.toString(response.getEntity());

--- a/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/reader/QueryInsightsReaderFactoryTests.java
@@ -33,6 +33,7 @@ public class QueryInsightsReaderFactoryTests extends OpenSearchTestCase {
     private final NamedXContentRegistry namedXContentRegistry = mock(NamedXContentRegistry.class);
     private QueryInsightsReaderFactory queryInsightsReaderFactory;
     private MetricsRegistry metricsRegistry;
+    private final int DELETE_AFTER = 7;
 
     @Before
     public void setup() {
@@ -45,7 +46,7 @@ public class QueryInsightsReaderFactoryTests extends OpenSearchTestCase {
     }
 
     public void testCreateAndCloseReader() {
-        QueryInsightsReader reader1 = queryInsightsReaderFactory.createLocalIndexReader("id", format, namedXContentRegistry);
+        QueryInsightsReader reader1 = queryInsightsReaderFactory.createLocalIndexReader("id", format, namedXContentRegistry, DELETE_AFTER);
         assertTrue(reader1 instanceof LocalIndexReader);
         try {
             queryInsightsReaderFactory.closeReader(reader1);
@@ -60,7 +61,8 @@ public class QueryInsightsReaderFactoryTests extends OpenSearchTestCase {
             client,
             DateTimeFormatter.ofPattern(format, Locale.ROOT),
             namedXContentRegistry,
-            "id"
+            "id",
+            7
         );
         queryInsightsReaderFactory.updateReader(reader, "yyyy-MM-dd-HH");
         assertEquals(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH", Locale.ROOT).toString(), reader.getIndexPattern().toString());

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -10,6 +10,7 @@ package org.opensearch.plugin.insights.core.service;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -537,7 +538,8 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         verify(queryInsightsReaderFactory, times(2)).createLocalIndexReader(
             eq(TopQueriesService.TOP_QUERIES_READER_ID),
             anyString(),
-            eq(namedXContentRegistry)
+            eq(namedXContentRegistry),
+            anyInt()
         );
         // Verify local indices are not deleted
         verify(mockLocalIndexLifecycleManagerSpy, times(0)).deleteSingleIndex(any(), any());
@@ -583,7 +585,8 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         verify(queryInsightsReaderFactory, times(2)).createLocalIndexReader(
             eq(TopQueriesService.TOP_QUERIES_READER_ID),
             anyString(),
-            eq(namedXContentRegistry)
+            eq(namedXContentRegistry),
+            anyInt()
         );
         // Verify local indices are not deleted
         verify(mockLocalIndexLifecycleManagerSpy, times(0)).deleteSingleIndex(any(), any());

--- a/src/test/java/org/opensearch/plugin/insights/core/utils/IndexDiscoveryHelperTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/utils/IndexDiscoveryHelperTests.java
@@ -16,7 +16,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.test.OpenSearchTestCase;
@@ -173,8 +172,7 @@ public class IndexDiscoveryHelperTests extends OpenSearchTestCase {
         String expectedIndex2 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start.plusDays(1));
         String expectedIndex3 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start.plusDays(2));
 
-        Set<String> existingIndices = Set.of(expectedIndex1, expectedIndex2, expectedIndex3);
-        List<String> result = IndexDiscoveryHelper.findIndicesInDateRange(existingIndices, indexPattern, start, end);
+        List<String> result = IndexDiscoveryHelper.buildIndexNamesInDateRange(indexPattern, start, end);
 
         // Should include all 3 days: 2023-06-15, 2023-06-16, 2023-06-17
         assertEquals(3, result.size());
@@ -188,46 +186,23 @@ public class IndexDiscoveryHelperTests extends OpenSearchTestCase {
         ZonedDateTime end = ZonedDateTime.of(2023, 6, 15, 23, 59, 59, 0, ZoneOffset.UTC);
 
         String expectedIndex = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start);
-        Set<String> existingIndices = Set.of(expectedIndex);
-        List<String> result = IndexDiscoveryHelper.findIndicesInDateRange(existingIndices, indexPattern, start, end);
+
+        List<String> result = IndexDiscoveryHelper.buildIndexNamesInDateRange(indexPattern, start, end);
 
         // Should include exactly 1 day
         assertEquals(1, result.size());
         assertTrue(result.contains(expectedIndex));
     }
 
-    public void testDiscoverIndicesInDateRangeWithMissingIndices() {
-        // Test range where some indices don't exist
-        ZonedDateTime start = ZonedDateTime.of(2023, 6, 15, 0, 0, 0, 0, ZoneOffset.UTC);
-        ZonedDateTime end = ZonedDateTime.of(2023, 6, 17, 12, 0, 0, 0, ZoneOffset.UTC);
-
-        String expectedIndex1 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start);
-        String expectedIndex3 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start.plusDays(2));
-
-        // Only indices for day 1 and day 3 exist, day 2 is missing
-        Set<String> existingIndices = Set.of(expectedIndex1, expectedIndex3);
-
-        List<String> result = IndexDiscoveryHelper.findIndicesInDateRange(existingIndices, indexPattern, start, end);
-
-        // Should include only the 2 existing indices
-        assertEquals(2, result.size());
-        assertTrue(result.contains(expectedIndex1));
-        assertTrue(result.contains(expectedIndex3));
-    }
-
     public void testDiscoverIndicesInDateRangeWithTimeComponentsInEndDate() {
         ZonedDateTime start = ZonedDateTime.of(2023, 6, 15, 0, 0, 0, 0, ZoneOffset.UTC);
         ZonedDateTime end = ZonedDateTime.of(2023, 6, 17, 23, 59, 59, 999_000_000, ZoneOffset.UTC); // End of day
 
-        // Create expected index names for all 3 days
         String expectedIndex1 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start);
         String expectedIndex2 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start.plusDays(1));
         String expectedIndex3 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start.plusDays(2));
 
-        // All indices exist
-        Set<String> existingIndices = Set.of(expectedIndex1, expectedIndex2, expectedIndex3);
-
-        List<String> result = IndexDiscoveryHelper.findIndicesInDateRange(existingIndices, indexPattern, start, end);
+        List<String> result = IndexDiscoveryHelper.buildIndexNamesInDateRange(indexPattern, start, end);
 
         // the last day is NOT missed even when end date has time components
         assertEquals(3, result.size());
@@ -243,9 +218,7 @@ public class IndexDiscoveryHelperTests extends OpenSearchTestCase {
         String expectedIndex1 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start);
         String expectedIndex2 = IndexDiscoveryHelper.buildLocalIndexName(indexPattern, start.plusDays(1));
 
-        Set<String> existingIndices = Set.of(expectedIndex1, expectedIndex2);
-
-        List<String> result = IndexDiscoveryHelper.findIndicesInDateRange(existingIndices, indexPattern, start, end);
+        List<String> result = IndexDiscoveryHelper.buildIndexNamesInDateRange(indexPattern, start, end);
 
         assertEquals(2, result.size());
         assertTrue(result.contains(expectedIndex1));


### PR DESCRIPTION
### Description
Stop calling cluster state. Generate the index-name list locally from the date range

### Issues Resolved
Implement #351 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
