### PR TITLE
Add ci.opensearch.org maven2 mirror to avoid throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
   }
@@ -194,6 +195,7 @@ allprojects {
 repositories {
     mavenLocal()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,12 @@
  * in the user manual at https://docs.gradle.org/6.5.1/userguide/multi_project_builds.html
  */
 
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'query-insights'


### PR DESCRIPTION
### Description
Add ci.opensearch.org maven2 mirror to avoid maven central throttling

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6062

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).