### PR TITLE
Fix GitHub Actions SHA-pinning policy failures (code-hygiene gradle action + opensearch-build ref)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - "*"
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch
 

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
 
-      - uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
+      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
           cache-disabled: true
           arguments: spotlessCheck
@@ -30,7 +30,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
 
-      - uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
+      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
           cache-disabled: true
           arguments: checkstyleMain checkstyleTest

--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch
 


### PR DESCRIPTION
### Description

Fixes all GitHub Actions failures caused by the org policy requiring every action to be pinned to a full-length commit SHA (including transitively-referenced actions). Two independent spots violated it:

**1. `code-hygiene.yml` — Checkstyle & Spotless (failed in ~3–5s)**

```
The action gradle/actions/setup-gradle@v3.5.0 is not allowed ... because all actions must be pinned to a full-length commit SHA.
```

These jobs used the deprecated `gradle/gradle-build-action` wrapper. Even SHA-pinned (#613), its internal `action.yml` references `gradle/actions/setup-gradle@v3.5.0` **by tag**, which the policy rejects. Fixed by referencing `gradle/actions/setup-gradle` directly, SHA-pinned. Staying on `v3.5.0` keeps it a drop-in (that version still supports the `arguments:` input; v4+ removed it). Mirrors how `opensearch-project/security` fixed the same failure.

**2. `ci.yml` + `integ-tests-with-security.yml` — Get-CI-Image-Tag (failed in ~2s)**

```
The actions iarekylew00t/crane-installer@v1 and actions/checkout@v6 are not allowed ... because all actions must be pinned to a full-length commit SHA.
```

The reusable `get-ci-image-tag.yml` was pinned at a stale commit whose internal actions are tag-referenced (`@v1`, `@v6`). Pointing the ref at `@main` (where those internal actions are already SHA-pinned upstream) resolves it. This also unblocks the required `Build and Test ... ubuntu-latest` check, which is skipped whenever `Get-CI-Image-Tag` fails (it declares `needs: Get-CI-Image-Tag`).

> Supersedes #620 (which made only the `@main` ref change). This PR includes that change plus the gradle-action fix, so it goes green on its own.

### Issues Resolved

Fixes the failing `Code Hygiene` (Checkstyle/Spotless) and `Get-CI-Image-Tag` checks that currently break on every PR.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
