### PR TITLE
[Backport 3.7] Fix GitHub Actions SHA-pinning policy failures (#621)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - "*"
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch
 

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
 
-      - uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
+      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
           cache-disabled: true
           arguments: spotlessCheck
@@ -30,7 +30,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
 
-      - uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
+      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
         with:
           cache-disabled: true
           arguments: checkstyleMain checkstyleTest

--- a/.github/workflows/integ-tests-with-security.yml
+++ b/.github/workflows/integ-tests-with-security.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch
 


### PR DESCRIPTION
### Description

Backports #621 to the `3.7` branch.

The `3.7` branch has the same GitHub Actions SHA-pinning policy failures that #621 fixed on `main`. All three affected workflow files are identical on `3.7`:

1. **`code-hygiene.yml`** — `Checkstyle scan` and `Spotless scan` fail (~4s) because the deprecated `gradle/gradle-build-action` wrapper transitively references `gradle/actions/setup-gradle@v3.5.0` **by tag**. Fixed by referencing `setup-gradle` directly, SHA-pinned to `v3.5.0` (drop-in; that version still supports `arguments:`).
2. **`ci.yml` + `integ-tests-with-security.yml`** — `Get-CI-Image-Tag` uses the reusable `get-ci-image-tag.yml` pinned at a stale commit whose internal actions (`crane-installer@v1`, `actions/checkout@v6`) are tag-referenced. Pointing the ref at `@main` (where those are SHA-pinned upstream) resolves it.

> Note: on the auto version-bump PR (#619), `Get-CI-Image-Tag` currently *appears* green, but that result is stale (last ran 2026-06-10, before the policy was enforced). The `3.7` branch carries the same stale ref, so this half of the fix is needed too.

This unblocks #619 and any other PR targeting `3.7`.

### Issues Resolved

Fixes the failing `Code Hygiene` (Checkstyle/Spotless) and `Get-CI-Image-Tag` checks on the `3.7` branch.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
