### PR TITLE
Fix testNestedQueryType expectation for recursive nested query traversal

### DIFF
--- a/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/categorizer/QueryShapeGeneratorTests.java
@@ -446,7 +446,6 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
     }
 
-    // Nested query not working as expected
     public void testNestedQueryType() throws IOException {
         setUpMockMappings(
             index1,
@@ -475,7 +474,12 @@ public final class QueryShapeGeneratorTests extends OpenSearchTestCase {
 
         String shapeShowFieldsTrue = queryShapeGenerator.buildShape(sourceBuilder, true, true, successfulSearchShardIndices);
 
-        String expectedShowFieldsTrue = "nested []\n" + "  must:\n" + "    bool []\n";
+        String expectedShowFieldsTrue = "nested []\n"
+            + "  must:\n"
+            + "    bool []\n"
+            + "      should:\n"
+            + "        term [patients.smoker, boolean]\n"
+            + "        range [patients.age, integer]\n";
 
         assertEquals(expectedShowFieldsTrue, shapeShowFieldsTrue);
     }


### PR DESCRIPTION
### Description

Fixes a unit-test failure in `QueryShapeGeneratorTests.testNestedQueryType` caused by upstream snapshot drift, not by any change in this repo.

OpenSearch core PR [opensearch-project/OpenSearch#22196](https://github.com/opensearch-project/OpenSearch/pull/22196) ("Fix NestedQueryBuilder visit to recursively visit child query tree", merged 2026-06-25) changed `NestedQueryBuilder.visit()` to recurse into the inner query's subtree instead of only calling `accept()` on the immediate child. As a result, the query shape produced for a nested query now correctly includes the inner `bool` clause's children (the `should:` `term`/`range` sub-queries).

The test's hard-coded expectation pre-dated that fix and stopped at the inner `bool []`, so it began failing once `3.8.0-SNAPSHOT` core picked up the change:

```
expected:  nested []
             must:
               bool []
but was:   nested []
             must:
               bool []
                 should:
                   term [patients.smoker, boolean]
                   range [patients.age, integer]
```

This PR updates the expected shape to match core's now-correct recursive traversal and removes the stale `// Nested query not working as expected` comment.

### Issues Resolved

Fixes the `Build and Test ... JDK 25 on ubuntu-latest` failure currently red on PRs against `main` (e.g. #627), which is unrelated to those PRs' changes.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
