### PR TITLE
fix(security): Bump httpclient5 to 5.6.1 to address CVE-2026-40542

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ configurations.all {
     eachDependency { DependencyResolveDetails details ->
       if (details.requested.group == 'org.apache.httpcomponents.client5' &&
         details.requested.name == 'httpclient5') {
-        details.useVersion '5.4.4'
+        details.useVersion '5.5.1'
       }
       if (details.requested.group == 'org.apache.httpcomponents.core5' &&
         details.requested.name == 'httpcore5-h2') {


### PR DESCRIPTION
Upgrade Apache HttpClient5 from 5.4.4 to 5.6.1 and httpcore5 from 5.3.4 to 5.3.6 to fix CVE-2026-40542 (missing critical step in SCRAM-SHA-256 mutual authentication verification).

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
