### PR TITLE
Fix preexisting JDK 11 build failure on 2.19 by disabling validatePluginZipPom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,8 @@ loggerUsageCheck.enabled = false
 
 // No need to validate pom, as we do not upload to maven/sonatype
 validateNebulaPom.enabled = false
+// validatePluginZipPom pulls in a plexus-utils version compiled for a newer JDK and fails on JDK 11; skip it as we do not upload to maven/sonatype
+validatePluginZipPom.enabled = false
 
 allprojects {
   group 'org.opensearch'


### PR DESCRIPTION
### Description

The `2.19` branch CI has been red on the `Build and Test` workflow since a dependency
update around 2026-06-25, independent of any PR. All `Build and Test` matrix jobs fail at
the `:validatePluginZipPom` task with:

```
Execution failed for task ':validatePluginZipPom'.
> org/codehaus/plexus/util/xml/pull/XmlPullParserException has been compiled by a more
  recent version of the Java Runtime (class file version 61.0), this version of the Java
  Runtime only recognizes class file versions up to 55.0
```

`validatePluginZipPom` (from the `opensearch.pluginzip` plugin) transitively loads a
`plexus-utils` version that is now compiled as Java 17 bytecode (class file 61.0). The
`2.19` CI matrix still builds on JDK 11, which can only read up to class file 55.0, so the
JDK 11 `ubuntu-latest` job fails. Because the matrix uses the default fail-fast behavior,
the JDK 17/21 and macOS/Windows jobs are cancelled as a side effect — so the single root
cause shows up as every `Build and Test` job failing.

This is a preexisting failure on `2.19`; it is not caused by any open PR (e.g. #630).

### Fix

Disable the `validatePluginZipPom` task, mirroring the existing
`validateNebulaPom.enabled = false` line directly above it. We do not upload the plugin zip
to Maven/Sonatype from this branch, so POM validation is not needed, and disabling it avoids
loading the JDK-17-compiled `plexus-utils` classes under JDK 11.

### Verification

Reproduced locally on Amazon Corretto JDK 11:

- Before: `./gradlew validatePluginZipPom` → `Task :validatePluginZipPom FAILED` (class file version 61.0 error), `BUILD FAILED`.
- After: `./gradlew validatePluginZipPom` → `Task :validatePluginZipPom SKIPPED`, `BUILD SUCCESSFUL`.

### Issues Resolved

Unblocks CI on the `2.19` branch.

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
