### PR TITLE
Fix flaky grouper ITs by waiting for settings propagation before searching

### DIFF
--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsClusterIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsClusterIT.java
@@ -324,19 +324,18 @@ public class QueryInsightsClusterIT extends QueryInsightsRestTestCase {
     /**
      * Test cluster health impact of query insights
      */
-    public void testClusterHealthImpactOfQueryInsights() throws IOException, InterruptedException {
+    public void testClusterHealthImpactOfQueryInsights() throws Exception {
         // Monitor cluster health before enabling query insights
         verifyClusterHealth();
 
         // Clear any existing queries
         updateClusterSettings(this::disableTopQueriesSettings);
+        waitForSettingsDisabled("latency");
         waitForEmptyTopQueriesResponse();
 
         // Enable query insights
         updateClusterSettings(this::defaultTopQueriesSettings);
-
-        // Allow settings to propagate
-        Thread.sleep(1000);
+        waitForSettingsPropagation("latency");
 
         // Perform searches
         doSearch(15);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperByNoneIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperByNoneIT.java
@@ -7,7 +7,6 @@
  */
 package org.opensearch.plugin.insights.core.service.grouper;
 
-import java.io.IOException;
 import org.opensearch.plugin.insights.QueryInsightsRestTestCase;
 
 /**
@@ -17,13 +16,15 @@ public class MinMaxQueryGrouperByNoneIT extends QueryInsightsRestTestCase {
 
     /**
      * Grouping by none should not group queries
-     * @throws IOException
-     * @throws InterruptedException
+     * @throws Exception
      */
-    public void testGroupingByNone() throws IOException, InterruptedException {
+    public void testGroupingByNone() throws Exception {
 
         updateClusterSettings(this::disableTopQueriesSettings);
+        waitForSettingsDisabled("latency");
+
         updateClusterSettings(this::groupByNoneSettings);
+        waitForSettingsPropagation("latency");
 
         waitForEmptyTopQueriesResponse();
 

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperBySimilarityIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperBySimilarityIT.java
@@ -29,16 +29,15 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
      *
      * @throws IOException IOException
      */
-    public void testGroupingBySimilarity() throws IOException, InterruptedException {
+    public void testGroupingBySimilarity() throws Exception {
         // Disable first to clear any previous state
         updateClusterSettings(this::disableTopQueriesSettings);
+        waitForSettingsDisabled("latency");
         waitForEmptyTopQueriesResponse();
 
         // Enable grouping settings
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
-
-        // Allow time for settings to propagate to all nodes
-        Thread.sleep(2000);
+        waitForSettingsPropagation("latency");
 
         waitForEmptyTopQueriesResponse();
 
@@ -55,16 +54,15 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
      *
      * @throws IOException IOException
      */
-    public void testGroupingWithFieldName() throws IOException, InterruptedException {
+    public void testGroupingWithFieldName() throws Exception {
         // Disable first to clear any previous state
         updateClusterSettings(this::disableTopQueriesSettings);
+        waitForSettingsDisabled("latency");
         waitForEmptyTopQueriesResponse();
 
         // Enable grouping settings
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
-
-        // Allow time for settings to propagate to all nodes
-        Thread.sleep(2000);
+        waitForSettingsPropagation("latency");
 
         // Wait for any residual queries to clear after settings change
         waitForEmptyTopQueriesResponse();
@@ -81,19 +79,20 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
      *
      * @throws IOException IOException
      */
-    public void testGroupingWithFieldNameDisabled() throws IOException, InterruptedException {
+    public void testGroupingWithFieldNameDisabled() throws Exception {
         // Disable first to clear any previous state
         updateClusterSettings(this::disableTopQueriesSettings);
+        waitForSettingsDisabled("latency");
         waitForEmptyTopQueriesResponse();
 
         // Enable grouping settings
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
-        Thread.sleep(2000);
+        waitForSettingsPropagation("latency");
         waitForEmptyTopQueriesResponse();
 
         // Now disable field_name
         updateClusterSettings(this::disableFieldNameSettings);
-        Thread.sleep(2000);
+        waitForNonCollectionSettingsPropagation();
         waitForEmptyTopQueriesResponse();
 
         // With field_name disabled, match queries on different fields should group together
@@ -108,16 +107,15 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
      *
      * @throws IOException IOException
      */
-    public void testGroupingWithFieldType() throws IOException, InterruptedException {
+    public void testGroupingWithFieldType() throws Exception {
         // Disable first to clear any previous state
         updateClusterSettings(this::disableTopQueriesSettings);
+        waitForSettingsDisabled("latency");
         waitForEmptyTopQueriesResponse();
 
         // Enable grouping settings
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
-
-        // Allow time for settings to propagate to all nodes (especially important in multi-node security cluster)
-        Thread.sleep(2000);
+        waitForSettingsPropagation("latency");
 
         // Wait for any residual queries to clear after settings change
         waitForEmptyTopQueriesResponse();
@@ -134,24 +132,25 @@ public class MinMaxQueryGrouperBySimilarityIT extends QueryInsightsRestTestCase 
      *
      * @throws IOException IOException
      */
-    public void testGroupingWithFieldTypeDisabled() throws IOException, InterruptedException {
+    public void testGroupingWithFieldTypeDisabled() throws Exception {
         // Disable first to clear any previous state
         updateClusterSettings(this::disableTopQueriesSettings);
+        waitForSettingsDisabled("latency");
         waitForEmptyTopQueriesResponse();
 
         // Enable grouping settings
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
-        Thread.sleep(2000);
+        waitForSettingsPropagation("latency");
         waitForEmptyTopQueriesResponse();
 
         // First disable field_name so field names don't interfere
         updateClusterSettings(this::disableFieldNameSettings);
-        Thread.sleep(2000);
+        waitForNonCollectionSettingsPropagation();
         waitForEmptyTopQueriesResponse();
 
         // Now disable field_type
         updateClusterSettings(this::disableFieldTypeSettings);
-        Thread.sleep(2000);
+        waitForNonCollectionSettingsPropagation();
         waitForEmptyTopQueriesResponse();
 
         // With both field_name and field_type disabled, match queries should group together

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperIT.java
@@ -7,20 +7,19 @@
  */
 package org.opensearch.plugin.insights.core.service.grouper;
 
-import java.io.IOException;
 import org.opensearch.plugin.insights.QueryInsightsRestTestCase;
 
 public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
     /**
      * Grouping by none should not group queries
-     * @throws IOException
-     * @throws InterruptedException
+     * @throws Exception
      */
-    public void testNoneToSimilarityGroupingTransition() throws IOException, InterruptedException {
+    public void testNoneToSimilarityGroupingTransition() throws Exception {
 
         waitForEmptyTopQueriesResponse();
 
         updateClusterSettings(this::defaultTopQueriesSettings);
+        waitForSettingsPropagation("latency");
 
         // Search
         doSearch("range", 1);
@@ -43,11 +42,12 @@ public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
         assertTopQueriesCount(3, "latency");
     }
 
-    public void testSimilarityToNoneGroupingTransition() throws IOException, InterruptedException {
+    public void testSimilarityToNoneGroupingTransition() throws Exception {
 
         waitForEmptyTopQueriesResponse();
 
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
+        waitForSettingsPropagation("latency");
 
         // Search
         doSearch("range", 1);
@@ -69,11 +69,12 @@ public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
         assertTopQueriesCount(6, "latency");
     }
 
-    public void testSimilarityMaxGroupsChanged() throws IOException, InterruptedException {
+    public void testSimilarityMaxGroupsChanged() throws Exception {
 
         waitForEmptyTopQueriesResponse();
 
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
+        waitForSettingsPropagation("latency");
 
         // Search
         doSearch("range", 1);


### PR DESCRIPTION
### Description
`MinMaxQueryGrouperByNoneIT.testGroupingByNone` failed in the 3.8.0 release integ-test (#642 / #643) with `Top N queries count [0] is not equal to expected [6]`.

Root cause is a settings-propagation race in the test: it enables latency collection via a cluster-settings PUT (whose helper only checks for HTTP 200, not that the setting applied) and then immediately runs searches. If the target node hasn't yet applied the setting, `QueryInsightsListener` isn't attached to those searches, so the records are dropped at capture time and never recorded — the count stays 0 through the entire 30s retry loop.

The fix uses the existing `waitForSettingsDisabled(...)` / `waitForSettingsPropagation(...)` helpers (added in #513 for the same failure mode in `TopQueriesRestIT`) to verify the setting has taken effect before searching. The same latent gap is fixed across the other grouper ITs and one cluster IT that share the enable-then-search pattern (replacing fixed `Thread.sleep` guesses with the verified helpers).

### Related Issues
Resolves #642, #643

### Check List
- [x] All tests pass
- [x] New functionality has been documented (n/a — test-only change)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
