### PR TITLE
[feat] Capture user identity (username, roles, backend roles) in query insights records Live Queries

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
+++ b/src/main/java/org/opensearch/plugin/insights/QueryInsightsPlugin.java
@@ -35,6 +35,7 @@ import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.health_stats.HealthStatsAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.FinishedQueriesAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesAction;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoAction;
 import org.opensearch.plugin.insights.rules.action.settings.GetQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.action.settings.UpdateQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
@@ -46,6 +47,7 @@ import org.opensearch.plugin.insights.rules.resthandler.top_queries.RestTopQueri
 import org.opensearch.plugin.insights.rules.transport.health_stats.TransportHealthStatsAction;
 import org.opensearch.plugin.insights.rules.transport.live_queries.TransportFinishedQueriesAction;
 import org.opensearch.plugin.insights.rules.transport.live_queries.TransportLiveQueriesAction;
+import org.opensearch.plugin.insights.rules.transport.live_queries.TransportLiveQueriesUserInfoAction;
 import org.opensearch.plugin.insights.rules.transport.settings.TransportGetQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.transport.settings.TransportUpdateQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.transport.top_queries.TransportTopQueriesAction;
@@ -145,6 +147,7 @@ public class QueryInsightsPlugin extends Plugin implements ActionPlugin, Telemet
             new ActionPlugin.ActionHandler<>(HealthStatsAction.INSTANCE, TransportHealthStatsAction.class),
             new ActionPlugin.ActionHandler<>(LiveQueriesAction.INSTANCE, TransportLiveQueriesAction.class),
             new ActionPlugin.ActionHandler<>(FinishedQueriesAction.INSTANCE, TransportFinishedQueriesAction.class),
+            new ActionPlugin.ActionHandler<>(LiveQueriesUserInfoAction.INSTANCE, TransportLiveQueriesUserInfoAction.class),
             new ActionPlugin.ActionHandler<>(GetQueryInsightsSettingsAction.INSTANCE, TransportGetQueryInsightsSettingsAction.class),
             new ActionPlugin.ActionHandler<>(UpdateQueryInsightsSettingsAction.INSTANCE, TransportUpdateQueryInsightsSettingsAction.class)
         );

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -225,11 +225,15 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
 
     @Override
     public void onPhaseStart(SearchPhaseContext context) {
+        // Issue 6: Skip user capture when listener is disabled
+        if (!isEnabled()) {
+            return;
+        }
         // Capture user identity at search phase start for live queries
         try {
             if (context.getTask() != null) {
                 String taskId = QueryInsightsService.buildLiveQueryTaskKey(clusterService.localNode().getId(), context.getTask().getId());
-                // Only capture once per task
+                // Issue 4: Only capture once per request — skip if already captured for this task
                 if (queryInsightsService.getLiveQueryUserInfo(taskId) == null) {
                     UserPrincipalContext ctx = new UserPrincipalContext(threadPool);
                     UserPrincipalContext.UserPrincipalInfo userInfo = ctx.extractUserInfo();
@@ -268,6 +272,15 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     }
 
     private void addToFinishedCache(SearchPhaseContext context, SearchQueryRecord record) {
+        // Issue 5: Guard null record early before any other work
+        if (record == null) {
+            // Still clean up the live query user info entry even when record is null
+            if (context.getTask() != null) {
+                String taskKey = QueryInsightsService.buildLiveQueryTaskKey(clusterService.localNode().getId(), context.getTask().getId());
+                queryInsightsService.removeLiveQueryUserInfo(taskKey);
+            }
+            return;
+        }
         try {
             UserPrincipalContext.UserPrincipalInfo cachedUser = null;
             // Clean up live query user map and retrieve cached user info
@@ -277,7 +290,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
                 queryInsightsService.removeLiveQueryUserInfo(taskKey);
             }
             // Populate user info on record (prefer cached identity captured at phase start)
-            if (cachedUser != null && record != null) {
+            if (cachedUser != null) {
                 if (cachedUser.getUserName() != null) {
                     record.addAttribute(Attribute.USERNAME, cachedUser.getUserName());
                 }
@@ -292,7 +305,7 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
                 TopQueriesService.setUserInfo(record);
             }
             FinishedQueriesCache cache = queryInsightsService.getFinishedQueriesCache();
-            if (cache == null || record == null || context.getTask() == null) return;
+            if (cache == null || context.getTask() == null) return;
             cache.capture(record, context.getTask().getId());
         } catch (Exception e) {
             log.debug("Failed to capture finished query into cache", e);

--- a/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/listener/QueryInsightsListener.java
@@ -47,6 +47,7 @@ import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.core.service.FinishedQueriesCache;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
+import org.opensearch.plugin.insights.core.service.TopQueriesService;
 import org.opensearch.plugin.insights.core.service.categorizer.QueryShapeGenerator;
 import org.opensearch.plugin.insights.rules.model.Attribute;
 import org.opensearch.plugin.insights.rules.model.Measurement;
@@ -223,7 +224,25 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
     }
 
     @Override
-    public void onPhaseStart(SearchPhaseContext context) {}
+    public void onPhaseStart(SearchPhaseContext context) {
+        // Capture user identity at search phase start for live queries
+        try {
+            if (context.getTask() != null) {
+                String taskId = QueryInsightsService.buildLiveQueryTaskKey(clusterService.localNode().getId(), context.getTask().getId());
+                // Only capture once per task
+                if (queryInsightsService.getLiveQueryUserInfo(taskId) == null) {
+                    UserPrincipalContext ctx = new UserPrincipalContext(threadPool);
+                    UserPrincipalContext.UserPrincipalInfo userInfo = ctx.extractUserInfo();
+                    if (userInfo != null) {
+                        log.debug("Captured user for task {}: {}", taskId, userInfo.getUserName());
+                        queryInsightsService.putLiveQueryUserInfo(taskId, userInfo);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Failed to capture user info in onPhaseStart", e);
+        }
+    }
 
     @Override
     public void onPhaseEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {}
@@ -250,8 +269,30 @@ public final class QueryInsightsListener extends SearchRequestOperationsListener
 
     private void addToFinishedCache(SearchPhaseContext context, SearchQueryRecord record) {
         try {
+            UserPrincipalContext.UserPrincipalInfo cachedUser = null;
+            // Clean up live query user map and retrieve cached user info
+            if (context.getTask() != null) {
+                String taskKey = QueryInsightsService.buildLiveQueryTaskKey(clusterService.localNode().getId(), context.getTask().getId());
+                cachedUser = queryInsightsService.getLiveQueryUserInfo(taskKey);
+                queryInsightsService.removeLiveQueryUserInfo(taskKey);
+            }
+            // Populate user info on record (prefer cached identity captured at phase start)
+            if (cachedUser != null && record != null) {
+                if (cachedUser.getUserName() != null) {
+                    record.addAttribute(Attribute.USERNAME, cachedUser.getUserName());
+                }
+                if (cachedUser.getRoles() != null && !cachedUser.getRoles().isEmpty()) {
+                    record.addAttribute(Attribute.USER_ROLES, cachedUser.getRoles().toArray(new String[0]));
+                }
+                if (cachedUser.getBackendRoles() != null && !cachedUser.getBackendRoles().isEmpty()) {
+                    record.addAttribute(Attribute.BACKEND_ROLES, cachedUser.getBackendRoles().toArray(new String[0]));
+                }
+            } else {
+                // Fallback: extract from thread context (may be stale on failure paths)
+                TopQueriesService.setUserInfo(record);
+            }
             FinishedQueriesCache cache = queryInsightsService.getFinishedQueriesCache();
-            if (cache == null || record == null) return;
+            if (cache == null || record == null || context.getTask() == null) return;
             cache.capture(record, context.getTask().getId());
         } catch (Exception e) {
             log.debug("Failed to capture finished query into cache", e);

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -66,6 +66,7 @@ import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.plugin.insights.rules.model.healthStats.QueryInsightsHealthStats;
 import org.opensearch.plugin.insights.rules.model.healthStats.TopQueriesHealthStats;
 import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
+import org.opensearch.tasks.TaskManager;
 import org.opensearch.telemetry.metrics.MetricsRegistry;
 import org.opensearch.threadpool.Scheduler;
 import org.opensearch.threadpool.ThreadPool;
@@ -149,6 +150,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     private final FinishedQueriesCache finishedQueriesCache;
     private final ConcurrentHashMap<String, TimestampedUserInfo> liveQueryUserMap = new ConcurrentHashMap<>();
     private final AtomicBoolean evictionInProgress = new AtomicBoolean(false);
+    private volatile TaskManager taskManager;
 
     private static final int USER_INFO_MAX_SIZE = 1000;
 
@@ -696,6 +698,16 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         return finishedQueriesCache;
     }
 
+    /**
+     * Sets the TaskManager used for liveness checks during eviction of orphaned entries
+     * from the live query user info map.
+     *
+     * @param taskManager the cluster TaskManager
+     */
+    public void setTaskManager(TaskManager taskManager) {
+        this.taskManager = taskManager;
+    }
+
     public void putLiveQueryUserInfo(String taskId, UserPrincipalContext.UserPrincipalInfo userInfo) {
         if (userInfo == null) {
             return;
@@ -705,16 +717,31 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
                 // Remove entries whose tasks are no longer running (orphaned entries).
                 // Keys are "nodeId:taskId" — we rely on remove-on-finish for normal cleanup,
                 // but orphans may remain if onRequestEnd was never called (e.g., node disconnect).
-                // Since TaskManager is not available here, remove oldest entries as fallback.
-                int overflow = liveQueryUserMap.size() - USER_INFO_MAX_SIZE + 1;
-                if (overflow > 0) {
-                    liveQueryUserMap.entrySet()
-                        .stream()
-                        .sorted(Comparator.comparingLong(e -> e.getValue().timestamp))
-                        .limit(overflow)
-                        .map(Map.Entry::getKey)
-                        .collect(Collectors.toList())
-                        .forEach(liveQueryUserMap::remove);
+                TaskManager tm = this.taskManager;
+                if (tm != null) {
+                    // Liveness sweep: drop keys where the task is gone
+                    liveQueryUserMap.keySet().removeIf(key -> {
+                        int sep = key.indexOf(':');
+                        if (sep <= 0) return false;
+                        try {
+                            long parsedTaskId = Long.parseLong(key.substring(sep + 1));
+                            return tm.getTask(parsedTaskId) == null;
+                        } catch (NumberFormatException e) {
+                            return false;
+                        }
+                    });
+                } else {
+                    // Fallback: TaskManager not yet available, remove oldest entries
+                    int overflow = liveQueryUserMap.size() - USER_INFO_MAX_SIZE + 1;
+                    if (overflow > 0) {
+                        liveQueryUserMap.entrySet()
+                            .stream()
+                            .sorted(Comparator.comparingLong(e -> e.getValue().timestamp))
+                            .limit(overflow)
+                            .map(Map.Entry::getKey)
+                            .collect(Collectors.toList())
+                            .forEach(liveQueryUserMap::remove);
+                    }
                 }
             } finally {
                 evictionInProgress.set(false);
@@ -724,7 +751,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         if (liveQueryUserMap.size() >= USER_INFO_MAX_SIZE) {
             logger.warn(
                 "Live query user info map at capacity ({}). Skipping capture for task [{}]. "
-                    + "Consider increasing concurrency capacity if this persists.",
+                    + "Consider increasing USER_INFO_MAX_SIZE if this persists.",
                 USER_INFO_MAX_SIZE,
                 taskId
             );

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -32,9 +32,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,6 +46,7 @@ import org.opensearch.common.lifecycle.AbstractLifecycleComponent;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.FutureUtils;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.plugin.insights.core.auth.UserPrincipalContext;
 import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporter;
 import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporterFactory;
 import org.opensearch.plugin.insights.core.exporter.RemoteRepositoryExporter;
@@ -143,6 +146,25 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     private LocalIndexLifecycleManager localIndexLifecycleManager;
 
     private final FinishedQueriesCache finishedQueriesCache;
+    private final ConcurrentHashMap<String, TimestampedUserInfo> liveQueryUserMap = new ConcurrentHashMap<>();
+
+    private static final long USER_INFO_TTL_MS = 30 * 60 * 1000; // 30 minutes (covers long-running queries)
+    private static final int USER_INFO_MAX_SIZE = 10000;
+
+    /**
+     * Time source for live query user info TTL/eviction. Overridable in tests to advance time deterministically.
+     */
+    private LongSupplier clock = System::currentTimeMillis;
+
+    private class TimestampedUserInfo {
+        final UserPrincipalContext.UserPrincipalInfo info;
+        final long timestamp;
+
+        TimestampedUserInfo(UserPrincipalContext.UserPrincipalInfo info) {
+            this.info = info;
+            this.timestamp = clock.getAsLong();
+        }
+    }
 
     SinkType sinkType;
 
@@ -671,6 +693,94 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      */
     public FinishedQueriesCache getFinishedQueriesCache() {
         return finishedQueriesCache;
+    }
+
+    public void putLiveQueryUserInfo(String taskId, UserPrincipalContext.UserPrincipalInfo userInfo) {
+        // Evict stale entries if map is too large
+        if (liveQueryUserMap.size() > USER_INFO_MAX_SIZE) {
+            long now = clock.getAsLong();
+            liveQueryUserMap.entrySet().removeIf(e -> now - e.getValue().timestamp > USER_INFO_TTL_MS);
+        }
+        // Fallback: if still over capacity, batch-remove oldest entries in a single sorted pass (O(n log n))
+        int overflow = liveQueryUserMap.size() - USER_INFO_MAX_SIZE;
+        if (overflow > 0) {
+            liveQueryUserMap.entrySet()
+                .stream()
+                .sorted(Comparator.comparingLong(e -> e.getValue().timestamp))
+                .limit(overflow)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList())
+                .forEach(liveQueryUserMap::remove);
+        }
+        liveQueryUserMap.put(taskId, new TimestampedUserInfo(userInfo));
+    }
+
+    /**
+     * Resolve user info for a set of task keys from this node's local map.
+     * Only keys present (and not expired) in the local map are returned.
+     *
+     * @param taskKeys the task keys to resolve
+     * @return a map of task key to its captured user info
+     */
+    public Map<String, UserPrincipalContext.UserPrincipalInfo> getLiveQueryUserInfoForKeys(java.util.Collection<String> taskKeys) {
+        Map<String, UserPrincipalContext.UserPrincipalInfo> resolved = new HashMap<>();
+        if (taskKeys == null) {
+            return resolved;
+        }
+        for (String key : taskKeys) {
+            UserPrincipalContext.UserPrincipalInfo info = getLiveQueryUserInfo(key);
+            if (info != null) {
+                resolved.put(key, info);
+            }
+        }
+        return resolved;
+    }
+
+    public UserPrincipalContext.UserPrincipalInfo getLiveQueryUserInfo(String taskId) {
+        TimestampedUserInfo entry = liveQueryUserMap.get(taskId);
+        if (entry == null) return null;
+        // Check TTL
+        if (clock.getAsLong() - entry.timestamp > USER_INFO_TTL_MS) {
+            liveQueryUserMap.remove(taskId);
+            return null;
+        }
+        return entry.info;
+    }
+
+    /**
+     * Build a consistent task key for live query user info map lookups.
+     * @param nodeId the node ID
+     * @param taskId the task ID number
+     * @return the composite key
+     */
+    public static String buildLiveQueryTaskKey(String nodeId, long taskId) {
+        return nodeId + ":" + taskId;
+    }
+
+    public void removeLiveQueryUserInfo(String taskId) {
+        liveQueryUserMap.remove(taskId);
+    }
+
+    /**
+     * Overrides the time source used for live query user info TTL/eviction.
+     * <p>
+     * <strong>Note:</strong> This method is intended for testing purposes only.
+     *
+     * @param clock the time source supplying the current epoch millis
+     */
+    void setLiveQueryUserInfoClock(final LongSupplier clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Returns the current number of entries in the live query user info map.
+     * <p>
+     * <strong>Note:</strong> This method is intended for testing purposes only.
+     *
+     * @return the map size
+     */
+    int getLiveQueryUserInfoMapSize() {
+        return liveQueryUserMap.size();
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -147,22 +148,22 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
 
     private final FinishedQueriesCache finishedQueriesCache;
     private final ConcurrentHashMap<String, TimestampedUserInfo> liveQueryUserMap = new ConcurrentHashMap<>();
+    private final AtomicBoolean evictionInProgress = new AtomicBoolean(false);
 
-    private static final long USER_INFO_TTL_MS = 30 * 60 * 1000; // 30 minutes (covers long-running queries)
-    private static final int USER_INFO_MAX_SIZE = 10000;
+    private static final int USER_INFO_MAX_SIZE = 1000;
 
     /**
      * Time source for live query user info TTL/eviction. Overridable in tests to advance time deterministically.
      */
     private LongSupplier clock = System::currentTimeMillis;
 
-    private class TimestampedUserInfo {
+    private static class TimestampedUserInfo {
         final UserPrincipalContext.UserPrincipalInfo info;
         final long timestamp;
 
-        TimestampedUserInfo(UserPrincipalContext.UserPrincipalInfo info) {
+        TimestampedUserInfo(UserPrincipalContext.UserPrincipalInfo info, long timestamp) {
             this.info = info;
-            this.timestamp = clock.getAsLong();
+            this.timestamp = timestamp;
         }
     }
 
@@ -696,23 +697,40 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     }
 
     public void putLiveQueryUserInfo(String taskId, UserPrincipalContext.UserPrincipalInfo userInfo) {
-        // Evict stale entries if map is too large
-        if (liveQueryUserMap.size() > USER_INFO_MAX_SIZE) {
-            long now = clock.getAsLong();
-            liveQueryUserMap.entrySet().removeIf(e -> now - e.getValue().timestamp > USER_INFO_TTL_MS);
+        if (userInfo == null) {
+            return;
         }
-        // Fallback: if still over capacity, batch-remove oldest entries in a single sorted pass (O(n log n))
-        int overflow = liveQueryUserMap.size() - USER_INFO_MAX_SIZE;
-        if (overflow > 0) {
-            liveQueryUserMap.entrySet()
-                .stream()
-                .sorted(Comparator.comparingLong(e -> e.getValue().timestamp))
-                .limit(overflow)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList())
-                .forEach(liveQueryUserMap::remove);
+        if (liveQueryUserMap.size() >= USER_INFO_MAX_SIZE && evictionInProgress.compareAndSet(false, true)) {
+            try {
+                // Remove entries whose tasks are no longer running (orphaned entries).
+                // Keys are "nodeId:taskId" — we rely on remove-on-finish for normal cleanup,
+                // but orphans may remain if onRequestEnd was never called (e.g., node disconnect).
+                // Since TaskManager is not available here, remove oldest entries as fallback.
+                int overflow = liveQueryUserMap.size() - USER_INFO_MAX_SIZE + 1;
+                if (overflow > 0) {
+                    liveQueryUserMap.entrySet()
+                        .stream()
+                        .sorted(Comparator.comparingLong(e -> e.getValue().timestamp))
+                        .limit(overflow)
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toList())
+                        .forEach(liveQueryUserMap::remove);
+                }
+            } finally {
+                evictionInProgress.set(false);
+            }
         }
-        liveQueryUserMap.put(taskId, new TimestampedUserInfo(userInfo));
+        // If still at capacity after eviction, skip this insert rather than evicting a live entry
+        if (liveQueryUserMap.size() >= USER_INFO_MAX_SIZE) {
+            logger.warn(
+                "Live query user info map at capacity ({}). Skipping capture for task [{}]. "
+                    + "Consider increasing concurrency capacity if this persists.",
+                USER_INFO_MAX_SIZE,
+                taskId
+            );
+            return;
+        }
+        liveQueryUserMap.put(taskId, new TimestampedUserInfo(userInfo, clock.getAsLong()));
     }
 
     /**
@@ -739,11 +757,6 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
     public UserPrincipalContext.UserPrincipalInfo getLiveQueryUserInfo(String taskId) {
         TimestampedUserInfo entry = liveQueryUserMap.get(taskId);
         if (entry == null) return null;
-        // Check TTL
-        if (clock.getAsLong() - entry.timestamp > USER_INFO_TTL_MS) {
-            liveQueryUserMap.remove(taskId);
-            return null;
-        }
         return entry.info;
     }
 

--- a/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/service/QueryInsightsService.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -597,6 +598,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
         }
 
         finishedQueriesCache.stop();
+        liveQueryUserMap.clear();
 
         FutureUtils.cancel(deleteIndicesScheduledFuture);
     }
@@ -767,7 +769,7 @@ public class QueryInsightsService extends AbstractLifecycleComponent {
      * @param taskKeys the task keys to resolve
      * @return a map of task key to its captured user info
      */
-    public Map<String, UserPrincipalContext.UserPrincipalInfo> getLiveQueryUserInfoForKeys(java.util.Collection<String> taskKeys) {
+    public Map<String, UserPrincipalContext.UserPrincipalInfo> getLiveQueryUserInfoForKeys(Collection<String> taskKeys) {
         Map<String, UserPrincipalContext.UserPrincipalInfo> resolved = new HashMap<>();
         if (taskKeys == null) {
             return resolved;

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesUserInfoAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesUserInfoAction.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.live_queries;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * Transport action to resolve live query user info from each node's local map.
+ */
+public class LiveQueriesUserInfoAction extends ActionType<LiveQueriesUserInfoResponse> {
+
+    public static final LiveQueriesUserInfoAction INSTANCE = new LiveQueriesUserInfoAction();
+    public static final String NAME = "cluster:admin/opensearch/insights/live_queries_user_info";
+
+    private LiveQueriesUserInfoAction() {
+        super(NAME, LiveQueriesUserInfoResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesUserInfoNodeResponse.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesUserInfoNodeResponse.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.live_queries;
+
+import java.io.IOException;
+import java.util.Map;
+import org.opensearch.Version;
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+/**
+ * Per-node response carrying resolved live query user info (task key to identity) from one node.
+ */
+public class LiveQueriesUserInfoNodeResponse extends BaseNodeResponse {
+
+    private final Map<String, LiveQueryUserInfoDTO> userInfoByTaskKey;
+
+    public LiveQueriesUserInfoNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        this.userInfoByTaskKey = in.getVersion().onOrAfter(Version.V_3_8_0)
+            ? in.readMap(StreamInput::readString, LiveQueryUserInfoDTO::new)
+            : Map.of();
+    }
+
+    public LiveQueriesUserInfoNodeResponse(DiscoveryNode node, Map<String, LiveQueryUserInfoDTO> userInfoByTaskKey) {
+        super(node);
+        this.userInfoByTaskKey = userInfoByTaskKey != null ? userInfoByTaskKey : Map.of();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeMap(userInfoByTaskKey, StreamOutput::writeString, (o, v) -> v.writeTo(o));
+        }
+    }
+
+    public Map<String, LiveQueryUserInfoDTO> getUserInfoByTaskKey() {
+        return userInfoByTaskKey;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesUserInfoRequest.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesUserInfoRequest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.live_queries;
+
+import java.io.IOException;
+import java.util.List;
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+/**
+ * Request to resolve user info for a set of live query task keys from all (or specific) nodes.
+ * Each node resolves the keys it owns from its local map.
+ */
+public class LiveQueriesUserInfoRequest extends BaseNodesRequest<LiveQueriesUserInfoRequest> {
+
+    private final List<String> taskKeys;
+
+    public LiveQueriesUserInfoRequest(StreamInput in) throws IOException {
+        super(in);
+        this.taskKeys = in.readStringList();
+    }
+
+    public LiveQueriesUserInfoRequest(List<String> taskKeys, String... nodeIds) {
+        super(nodeIds);
+        this.taskKeys = taskKeys != null ? taskKeys : List.of();
+    }
+
+    public List<String> getTaskKeys() {
+        return taskKeys;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeStringCollection(taskKeys);
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesUserInfoResponse.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesUserInfoResponse.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.live_queries;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+/**
+ * Aggregated response carrying resolved live query user info from all nodes.
+ */
+public class LiveQueriesUserInfoResponse extends BaseNodesResponse<LiveQueriesUserInfoNodeResponse> {
+
+    public LiveQueriesUserInfoResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public LiveQueriesUserInfoResponse(
+        ClusterName clusterName,
+        List<LiveQueriesUserInfoNodeResponse> nodes,
+        List<FailedNodeException> failures
+    ) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<LiveQueriesUserInfoNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(LiveQueriesUserInfoNodeResponse::new);
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<LiveQueriesUserInfoNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    /**
+     * Merge all per-node maps into a single task-key to user-info map.
+     * Each task key is owned by exactly one node, so there are no cross-node collisions.
+     *
+     * @return the merged map of task key to user info
+     */
+    public Map<String, LiveQueryUserInfoDTO> getAllUserInfo() {
+        Map<String, LiveQueryUserInfoDTO> merged = new HashMap<>();
+        for (LiveQueriesUserInfoNodeResponse nodeResponse : getNodes()) {
+            merged.putAll(nodeResponse.getUserInfoByTaskKey());
+        }
+        return merged;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueryUserInfoDTO.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueryUserInfoDTO.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.action.live_queries;
+
+import java.io.IOException;
+import java.util.List;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.plugin.insights.core.auth.UserPrincipalContext;
+
+/**
+ * Serializable holder for a captured user identity (username, roles, backend roles),
+ * used to carry live query user info across nodes during fan-out.
+ */
+public class LiveQueryUserInfoDTO implements Writeable {
+
+    private final String username;
+    private final List<String> roles;
+    private final List<String> backendRoles;
+
+    public LiveQueryUserInfoDTO(String username, List<String> roles, List<String> backendRoles) {
+        this.username = username;
+        this.roles = roles != null ? roles : List.of();
+        this.backendRoles = backendRoles != null ? backendRoles : List.of();
+    }
+
+    public LiveQueryUserInfoDTO(UserPrincipalContext.UserPrincipalInfo info) {
+        this(info == null ? null : info.getUserName(), info == null ? null : info.getRoles(), info == null ? null : info.getBackendRoles());
+    }
+
+    public LiveQueryUserInfoDTO(StreamInput in) throws IOException {
+        this.username = in.readOptionalString();
+        List<String> readRoles = in.readOptionalStringList();
+        this.roles = readRoles != null ? readRoles : List.of();
+        List<String> readBackendRoles = in.readOptionalStringList();
+        this.backendRoles = readBackendRoles != null ? readBackendRoles : List.of();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(username);
+        out.writeOptionalStringCollection(roles.isEmpty() ? null : roles);
+        out.writeOptionalStringCollection(backendRoles.isEmpty() ? null : backendRoles);
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public List<String> getRoles() {
+        return roles;
+    }
+
+    public List<String> getBackendRoles() {
+        return backendRoles;
+    }
+}

--- a/src/main/java/org/opensearch/plugin/insights/rules/model/LiveQueryRecord.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/LiveQueryRecord.java
@@ -11,6 +11,7 @@ package org.opensearch.plugin.insights.rules.model;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -31,6 +32,9 @@ public class LiveQueryRecord implements Writeable, ToXContentObject {
     private final long totalMemory;
     private final TaskDetails coordinatorTask;
     private final List<TaskDetails> shardTasks;
+    private final String username;
+    private final List<String> userRoles;
+    private final List<String> backendRoles;
 
     public LiveQueryRecord(
         String liveQueryRecordId,
@@ -41,7 +45,10 @@ public class LiveQueryRecord implements Writeable, ToXContentObject {
         long totalCpu,
         long totalMemory,
         TaskDetails coordinatorTask,
-        List<TaskDetails> shardTasks
+        List<TaskDetails> shardTasks,
+        String username,
+        List<String> userRoles,
+        List<String> backendRoles
     ) {
         this.liveQueryRecordId = liveQueryRecordId;
         this.status = status;
@@ -52,6 +59,9 @@ public class LiveQueryRecord implements Writeable, ToXContentObject {
         this.totalMemory = totalMemory;
         this.coordinatorTask = coordinatorTask;
         this.shardTasks = shardTasks != null ? shardTasks : new ArrayList<>();
+        this.username = username;
+        this.userRoles = userRoles != null ? userRoles : List.of();
+        this.backendRoles = backendRoles != null ? backendRoles : List.of();
     }
 
     public LiveQueryRecord(StreamInput in) throws IOException {
@@ -64,6 +74,18 @@ public class LiveQueryRecord implements Writeable, ToXContentObject {
         this.totalMemory = in.readLong();
         this.coordinatorTask = in.readOptionalWriteable(TaskDetails::new);
         this.shardTasks = in.readList(TaskDetails::new);
+        if (in.getVersion().onOrAfter(Version.V_3_8_0)) {
+            this.username = in.readOptionalString();
+            List<String> readRoles = in.readOptionalStringList();
+            this.userRoles = readRoles != null ? readRoles : List.of();
+            List<String> readBackendRoles = in.readOptionalStringList();
+            this.backendRoles = readBackendRoles != null ? readBackendRoles : List.of();
+        } else {
+            this.username = null;
+            this.userRoles = List.of();
+            this.backendRoles = List.of();
+        }
+
     }
 
     @Override
@@ -77,6 +99,12 @@ public class LiveQueryRecord implements Writeable, ToXContentObject {
         out.writeLong(totalMemory);
         out.writeOptionalWriteable(coordinatorTask);
         out.writeList(shardTasks);
+        if (out.getVersion().onOrAfter(Version.V_3_8_0)) {
+            out.writeOptionalString(username);
+            out.writeOptionalStringCollection(userRoles.isEmpty() ? null : userRoles);
+            out.writeOptionalStringCollection(backendRoles.isEmpty() ? null : backendRoles);
+        }
+
     }
 
     @Override
@@ -100,6 +128,15 @@ public class LiveQueryRecord implements Writeable, ToXContentObject {
             task.toXContent(builder, params);
         }
         builder.endArray();
+        if (username != null) {
+            builder.field("username", username);
+        }
+        if (!userRoles.isEmpty()) {
+            builder.array("user_roles", userRoles.toArray(new String[0]));
+        }
+        if (!backendRoles.isEmpty()) {
+            builder.array("backend_roles", backendRoles.toArray(new String[0]));
+        }
         builder.endObject();
         return builder;
     }
@@ -138,5 +175,17 @@ public class LiveQueryRecord implements Writeable, ToXContentObject {
 
     public List<TaskDetails> getShardTasks() {
         return shardTasks;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public List<String> getUserRoles() {
+        return userRoles;
+    }
+
+    public List<String> getBackendRoles() {
+        return backendRoles;
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -43,6 +43,7 @@ import org.opensearch.plugin.insights.rules.model.FilterByMode;
 import org.opensearch.plugin.insights.rules.model.FinishedQueryRecord;
 import org.opensearch.plugin.insights.rules.model.LiveQueryRecord;
 import org.opensearch.plugin.insights.rules.model.Measurement;
+import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
 import org.opensearch.plugin.insights.rules.model.TaskDetails;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskInfo;
@@ -299,15 +300,14 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
             client.execute(
                 FinishedQueriesAction.INSTANCE,
                 new FinishedQueriesRequest(request.nodesIds()),
-                ActionListener.wrap(
-                    finishedResponse -> listener.onResponse(
-                        new LiveQueriesResponse(finalRecords, sortAndLimit(finishedResponse.getAllFinishedQueries(), request), true)
-                    ),
-                    ex -> {
-                        logger.error("Failed to retrieve finished queries from nodes", ex);
-                        listener.onFailure(ex);
-                    }
-                )
+                ActionListener.wrap(finishedResponse -> {
+                    List<FinishedQueryRecord> finishedRecords = sortAndLimit(finishedResponse.getAllFinishedQueries(), request);
+                    finishedRecords = filterFinishedRecordsByMode(finishedRecords);
+                    listener.onResponse(new LiveQueriesResponse(finalRecords, finishedRecords, true));
+                }, ex -> {
+                    logger.error("Failed to retrieve finished queries from nodes", ex);
+                    listener.onFailure(ex);
+                })
             );
         } else {
             listener.onResponse(new LiveQueriesResponse(finalRecords, List.of(), false));
@@ -331,6 +331,37 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
             if (mb == null) return -1;
             return Double.compare(mb.getMeasurement().doubleValue(), ma.getMeasurement().doubleValue());
         }).limit(request.getSize() < 0 ? Long.MAX_VALUE : request.getSize()).toList();
+    }
+
+    /**
+     * Applies RBAC filtering to finished query records based on filter_by_mode.
+     * Finished records carry username/roles (stamped in addToFinishedCache), so the same
+     * access control must apply as for live records.
+     */
+    @SuppressWarnings("unchecked")
+    private List<FinishedQueryRecord> filterFinishedRecordsByMode(List<FinishedQueryRecord> records) {
+        FilterByMode mode = queryInsightsService.getFilterByMode();
+        if (mode == null || mode == FilterByMode.NONE) {
+            return records;
+        }
+        UserPrincipalInfo requestingUser;
+        try {
+            requestingUser = new UserPrincipalContext(transportService.getThreadPool()).extractUserInfo();
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+        if (requestingUser == null) {
+            return Collections.emptyList();
+        }
+        if (TopQueriesRbacFilter.isAdmin(requestingUser)) {
+            return records;
+        }
+        List<SearchQueryRecord> filtered = TopQueriesRbacFilter.filterRecords(
+            (List<SearchQueryRecord>) (List<?>) records,
+            mode,
+            requestingUser
+        );
+        return (List<FinishedQueryRecord>) (List<?>) filtered;
     }
 
     /**

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -219,8 +219,10 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
         // A task key is "nodeId:taskId"; user info for a task lives only on the node that
         // coordinated it. Target the fan-out at just those owning nodes instead of the whole
         // cluster (the identity was captured there, so other nodes have nothing to contribute).
+        // Issue 3: Use indexOf(':') since taskId is always numeric (the first ':' separates
+        // nodeId from taskId), matching the format produced by buildLiveQueryTaskKey().
         String[] targetNodeIds = taskKeys.stream().map(key -> {
-            int sep = key.lastIndexOf(':');
+            int sep = key.indexOf(':');
             return sep > 0 ? key.substring(0, sep) : key;
         }).distinct().toArray(String[]::new);
 

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -9,9 +9,13 @@
 package org.opensearch.plugin.insights.rules.transport.live_queries;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
@@ -23,6 +27,9 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceStats;
 import org.opensearch.core.tasks.resourcetracker.TaskResourceUsage;
+import org.opensearch.plugin.insights.core.auth.TopQueriesRbacFilter;
+import org.opensearch.plugin.insights.core.auth.UserPrincipalContext;
+import org.opensearch.plugin.insights.core.auth.UserPrincipalContext.UserPrincipalInfo;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.live_queries.FinishedQueriesAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.FinishedQueriesRequest;
@@ -32,6 +39,7 @@ import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesRespo
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoRequest;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO;
+import org.opensearch.plugin.insights.rules.model.FilterByMode;
 import org.opensearch.plugin.insights.rules.model.FinishedQueryRecord;
 import org.opensearch.plugin.insights.rules.model.LiveQueryRecord;
 import org.opensearch.plugin.insights.rules.model.Measurement;
@@ -65,6 +73,7 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
         this.transportService = transportService;
         this.client = client;
         this.queryInsightsService = queryInsightsService;
+        queryInsightsService.setTaskManager(transportService.getTaskManager());
     }
 
     @Override
@@ -231,11 +240,13 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
             new LiveQueriesUserInfoRequest(taskKeys, targetNodeIds),
             ActionListener.wrap(userInfoResponse -> {
                 List<LiveQueryRecord> enrichedRecords = enrichWithUserInfo(records, userInfoResponse.getAllUserInfo());
-                respondWithFinishedQueries(enrichedRecords, request, listener);
+                List<LiveQueryRecord> filteredRecords = filterLiveRecordsByMode(enrichedRecords);
+                respondWithFinishedQueries(filteredRecords, request, listener);
             }, ex -> {
                 // User info is best-effort — on failure, fall back to records without identity
                 logger.error("Failed to resolve live query user info from nodes", ex);
-                respondWithFinishedQueries(records, request, listener);
+                List<LiveQueryRecord> filteredRecords = filterLiveRecordsByMode(records);
+                respondWithFinishedQueries(filteredRecords, request, listener);
             })
         );
     }
@@ -320,5 +331,50 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
             if (mb == null) return -1;
             return Double.compare(mb.getMeasurement().doubleValue(), ma.getMeasurement().doubleValue());
         }).limit(request.getSize() < 0 ? Long.MAX_VALUE : request.getSize()).toList();
+    }
+
+    /**
+     * Applies RBAC filtering to live query records based on the configured filter_by_mode,
+     * mirroring the same access control that top queries enforces.
+     */
+    private List<LiveQueryRecord> filterLiveRecordsByMode(List<LiveQueryRecord> records) {
+        FilterByMode mode = queryInsightsService.getFilterByMode();
+        if (mode == null || mode == FilterByMode.NONE) {
+            return records;
+        }
+
+        UserPrincipalInfo requestingUser;
+        try {
+            requestingUser = new UserPrincipalContext(transportService.getThreadPool()).extractUserInfo();
+        } catch (Exception e) {
+            logger.warn("Failed to extract user info for live queries RBAC filtering", e);
+            return Collections.emptyList();
+        }
+
+        if (requestingUser == null) {
+            return Collections.emptyList();
+        }
+
+        if (TopQueriesRbacFilter.isAdmin(requestingUser)) {
+            return records;
+        }
+
+        switch (mode) {
+            case USERNAME:
+                if (requestingUser.getUserName() == null) {
+                    return Collections.emptyList();
+                }
+                return records.stream().filter(r -> requestingUser.getUserName().equals(r.getUsername())).collect(Collectors.toList());
+            case BACKEND_ROLES:
+                if (requestingUser.getBackendRoles() == null || requestingUser.getBackendRoles().isEmpty()) {
+                    return Collections.emptyList();
+                }
+                Set<String> myRoles = new HashSet<>(requestingUser.getBackendRoles());
+                return records.stream()
+                    .filter(r -> r.getBackendRoles() != null && !Collections.disjoint(myRoles, new HashSet<>(r.getBackendRoles())))
+                    .collect(Collectors.toList());
+            default:
+                return records;
+        }
     }
 }

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesAction.java
@@ -29,6 +29,9 @@ import org.opensearch.plugin.insights.rules.action.live_queries.FinishedQueriesR
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesRequest;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesResponse;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoAction;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoRequest;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO;
 import org.opensearch.plugin.insights.rules.model.FinishedQueryRecord;
 import org.opensearch.plugin.insights.rules.model.LiveQueryRecord;
 import org.opensearch.plugin.insights.rules.model.Measurement;
@@ -89,7 +92,13 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                             continue;
                         }
 
-                        String queryId = coordinatorInfo.getTaskId().toString();
+                        // Build the query id with the shared key helper so it matches the key the
+                        // listener stores user info under (nodeId:taskId) and can't drift from
+                        // TaskId.toString()'s internal format.
+                        String queryId = QueryInsightsService.buildLiveQueryTaskKey(
+                            coordinatorInfo.getTaskId().getNodeId(),
+                            coordinatorInfo.getTaskId().getId()
+                        );
 
                         // Get WLM group ID
                         String wlmGroupId = null;
@@ -141,6 +150,8 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                         // Determine status based on coordinator cancellation
                         String queryStatus = coordinatorInfo.isCancelled() ? "cancelled" : "running";
 
+                        // User info is resolved after the fan-out below; build the record with the
+                        // task key so it can be enriched once per-node identity comes back.
                         LiveQueryRecord record = new LiveQueryRecord(
                             queryId,
                             queryStatus,
@@ -150,13 +161,16 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                             totalCpu,
                             totalMem,
                             new TaskDetails(coordinatorInfo, queryStatus),
-                            shardTasks
+                            shardTasks,
+                            null,
+                            List.of(),
+                            List.of()
                         );
 
                         allRecords.add(record);
                     }
 
-                    List<LiveQueryRecord> finalRecords = allRecords.stream().sorted((a, b) -> {
+                    List<LiveQueryRecord> sortedRecords = allRecords.stream().sorted((a, b) -> {
                         switch (request.getSortBy()) {
                             case CPU:
                                 return Long.compare(b.getTotalCpu(), a.getTotalCpu());
@@ -167,32 +181,9 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                         }
                     }).limit(request.getSize() < 0 ? Long.MAX_VALUE : request.getSize()).toList();
 
-                    if (request.isUseFinishedCache()) {
-                        // Touch the local cache on the coordinating node to schedule the idle-check
-                        // timer and update lastAccessTime. Fan-out nodes use getFinishedQueriesIfActive()
-                        // to avoid activating caches cluster-wide.
-                        queryInsightsService.getFinishedQueriesCache().getFinishedQueries();
-
-                        client.execute(
-                            FinishedQueriesAction.INSTANCE,
-                            new FinishedQueriesRequest(request.nodesIds()),
-                            ActionListener.wrap(
-                                finishedResponse -> listener.onResponse(
-                                    new LiveQueriesResponse(
-                                        finalRecords,
-                                        sortAndLimit(finishedResponse.getAllFinishedQueries(), request),
-                                        true
-                                    )
-                                ),
-                                ex -> {
-                                    logger.error("Failed to retrieve finished queries from nodes", ex);
-                                    listener.onFailure(ex);
-                                }
-                            )
-                        );
-                    } else {
-                        listener.onResponse(new LiveQueriesResponse(finalRecords, List.of(), false));
-                    }
+                    // Fan out to all nodes to resolve user identity captured on the coordinating node of
+                    // each search, then continue with finished-queries handling (if requested).
+                    resolveUserInfoAndRespond(sortedRecords, request, listener);
                 } catch (Exception ex) {
                     logger.error("Failed to process live queries response", ex);
                     listener.onFailure(ex);
@@ -205,6 +196,109 @@ public class TransportLiveQueriesAction extends HandledTransportAction<LiveQueri
                 listener.onFailure(e);
             }
         });
+    }
+
+    /**
+     * Fans out to all nodes to resolve user identity for the given live query records (each record's
+     * id is the {@code nodeId:taskId} key used by the listener), enriches the records, and then
+     * completes the response — appending finished queries if the request asked for them.
+     */
+    private void resolveUserInfoAndRespond(
+        final List<LiveQueryRecord> records,
+        final LiveQueriesRequest request,
+        final ActionListener<LiveQueriesResponse> listener
+    ) {
+        // No live queries — skip the cluster-wide user info fan-out entirely.
+        if (records.isEmpty()) {
+            respondWithFinishedQueries(records, request, listener);
+            return;
+        }
+
+        List<String> taskKeys = records.stream().map(LiveQueryRecord::getQueryId).toList();
+
+        // A task key is "nodeId:taskId"; user info for a task lives only on the node that
+        // coordinated it. Target the fan-out at just those owning nodes instead of the whole
+        // cluster (the identity was captured there, so other nodes have nothing to contribute).
+        String[] targetNodeIds = taskKeys.stream().map(key -> {
+            int sep = key.lastIndexOf(':');
+            return sep > 0 ? key.substring(0, sep) : key;
+        }).distinct().toArray(String[]::new);
+
+        client.execute(
+            LiveQueriesUserInfoAction.INSTANCE,
+            new LiveQueriesUserInfoRequest(taskKeys, targetNodeIds),
+            ActionListener.wrap(userInfoResponse -> {
+                List<LiveQueryRecord> enrichedRecords = enrichWithUserInfo(records, userInfoResponse.getAllUserInfo());
+                respondWithFinishedQueries(enrichedRecords, request, listener);
+            }, ex -> {
+                // User info is best-effort — on failure, fall back to records without identity
+                logger.error("Failed to resolve live query user info from nodes", ex);
+                respondWithFinishedQueries(records, request, listener);
+            })
+        );
+    }
+
+    private List<LiveQueryRecord> enrichWithUserInfo(
+        final List<LiveQueryRecord> records,
+        final Map<String, LiveQueryUserInfoDTO> userInfoByTaskKey
+    ) {
+        if (userInfoByTaskKey.isEmpty()) {
+            return records;
+        }
+        List<LiveQueryRecord> enriched = new ArrayList<>(records.size());
+        for (LiveQueryRecord record : records) {
+            LiveQueryUserInfoDTO userInfo = userInfoByTaskKey.get(record.getQueryId());
+            if (userInfo == null) {
+                enriched.add(record);
+                continue;
+            }
+            enriched.add(
+                new LiveQueryRecord(
+                    record.getQueryId(),
+                    record.getStatus(),
+                    record.getStartTime(),
+                    record.getWlmGroupId(),
+                    record.getTotalLatency(),
+                    record.getTotalCpu(),
+                    record.getTotalMemory(),
+                    record.getCoordinatorTask(),
+                    record.getShardTasks(),
+                    userInfo.getUsername(),
+                    userInfo.getRoles(),
+                    userInfo.getBackendRoles()
+                )
+            );
+        }
+        return enriched;
+    }
+
+    private void respondWithFinishedQueries(
+        final List<LiveQueryRecord> finalRecords,
+        final LiveQueriesRequest request,
+        final ActionListener<LiveQueriesResponse> listener
+    ) {
+        if (request.isUseFinishedCache()) {
+            // Touch the local cache on the coordinating node to schedule the idle-check
+            // timer and update lastAccessTime. Fan-out nodes use getFinishedQueriesIfActive()
+            // to avoid activating caches cluster-wide.
+            queryInsightsService.getFinishedQueriesCache().getFinishedQueries();
+
+            client.execute(
+                FinishedQueriesAction.INSTANCE,
+                new FinishedQueriesRequest(request.nodesIds()),
+                ActionListener.wrap(
+                    finishedResponse -> listener.onResponse(
+                        new LiveQueriesResponse(finalRecords, sortAndLimit(finishedResponse.getAllFinishedQueries(), request), true)
+                    ),
+                    ex -> {
+                        logger.error("Failed to retrieve finished queries from nodes", ex);
+                        listener.onFailure(ex);
+                    }
+                )
+            );
+        } else {
+            listener.onResponse(new LiveQueriesResponse(finalRecords, List.of(), false));
+        }
     }
 
     private void collectChildTasks(TaskGroup group, List<TaskDetails> result) {

--- a/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesUserInfoAction.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesUserInfoAction.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.rules.transport.live_queries;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.plugin.insights.core.auth.UserPrincipalContext;
+import org.opensearch.plugin.insights.core.service.QueryInsightsService;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoAction;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoNodeResponse;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoRequest;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoResponse;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportRequest;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Fans out to all nodes to resolve live query user info from each node's local map.
+ * <p>
+ * The listener captures user identity on the node that coordinates a search, keyed by
+ * {@code nodeId:taskId}. Since the live queries API can be served by any node, this fan-out
+ * lets each node resolve the task keys it owns so identity is populated regardless of which
+ * node handles the API request.
+ */
+public class TransportLiveQueriesUserInfoAction extends TransportNodesAction<
+    LiveQueriesUserInfoRequest,
+    LiveQueriesUserInfoResponse,
+    TransportLiveQueriesUserInfoAction.NodeRequest,
+    LiveQueriesUserInfoNodeResponse> {
+
+    private final QueryInsightsService queryInsightsService;
+
+    @Inject
+    public TransportLiveQueriesUserInfoAction(
+        final ThreadPool threadPool,
+        final ClusterService clusterService,
+        final TransportService transportService,
+        final QueryInsightsService queryInsightsService,
+        final ActionFilters actionFilters
+    ) {
+        super(
+            LiveQueriesUserInfoAction.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            LiveQueriesUserInfoRequest::new,
+            NodeRequest::new,
+            ThreadPool.Names.GENERIC,
+            LiveQueriesUserInfoNodeResponse.class
+        );
+        this.queryInsightsService = queryInsightsService;
+    }
+
+    @Override
+    protected LiveQueriesUserInfoResponse newResponse(
+        LiveQueriesUserInfoRequest request,
+        List<LiveQueriesUserInfoNodeResponse> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new LiveQueriesUserInfoResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected NodeRequest newNodeRequest(LiveQueriesUserInfoRequest request) {
+        return new NodeRequest(request);
+    }
+
+    @Override
+    protected LiveQueriesUserInfoNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new LiveQueriesUserInfoNodeResponse(in);
+    }
+
+    @Override
+    protected LiveQueriesUserInfoNodeResponse nodeOperation(NodeRequest nodeRequest) {
+        Map<String, UserPrincipalContext.UserPrincipalInfo> resolved = queryInsightsService.getLiveQueryUserInfoForKeys(
+            nodeRequest.request.getTaskKeys()
+        );
+        Map<String, LiveQueryUserInfoDTO> dtos = new HashMap<>();
+        for (Map.Entry<String, UserPrincipalContext.UserPrincipalInfo> entry : resolved.entrySet()) {
+            dtos.put(entry.getKey(), new LiveQueryUserInfoDTO(entry.getValue()));
+        }
+        return new LiveQueriesUserInfoNodeResponse(clusterService.localNode(), dtos);
+    }
+
+    /**
+     * Inner per-node request.
+     */
+    public static class NodeRequest extends TransportRequest {
+
+        final LiveQueriesUserInfoRequest request;
+
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            request = new LiveQueriesUserInfoRequest(in);
+        }
+
+        public NodeRequest(LiveQueriesUserInfoRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            request.writeTo(out);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsPluginTests.java
@@ -27,6 +27,7 @@ import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.health_stats.HealthStatsAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.FinishedQueriesAction;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesAction;
+import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoAction;
 import org.opensearch.plugin.insights.rules.action.settings.GetQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.action.settings.UpdateQueryInsightsSettingsAction;
 import org.opensearch.plugin.insights.rules.action.top_queries.TopQueriesAction;
@@ -170,13 +171,14 @@ public class QueryInsightsPluginTests extends OpenSearchTestCase {
 
     public void testGetActions() {
         List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> components = queryInsightsPlugin.getActions();
-        assertEquals(6, components.size());
+        assertEquals(7, components.size());
         assertTrue(components.get(0).getAction() instanceof TopQueriesAction);
         assertTrue(components.get(1).getAction() instanceof HealthStatsAction);
         assertTrue(components.get(2).getAction() instanceof LiveQueriesAction);
         assertTrue(components.get(3).getAction() instanceof FinishedQueriesAction);
-        assertTrue(components.get(4).getAction() instanceof GetQueryInsightsSettingsAction);
-        assertTrue(components.get(5).getAction() instanceof UpdateQueryInsightsSettingsAction);
+        assertTrue(components.get(4).getAction() instanceof LiveQueriesUserInfoAction);
+        assertTrue(components.get(5).getAction() instanceof GetQueryInsightsSettingsAction);
+        assertTrue(components.get(6).getAction() instanceof UpdateQueryInsightsSettingsAction);
     }
 
     public void testLiveQueriesActionRegistration() {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/LiveQueryUserInfoTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/LiveQueryUserInfoTests.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.plugin.insights.core.service;
+
+import java.util.List;
+import org.opensearch.plugin.insights.core.auth.UserPrincipalContext.UserPrincipalInfo;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Unit tests for live query user info map operations in {@link QueryInsightsService}
+ */
+public class LiveQueryUserInfoTests extends OpenSearchTestCase {
+
+    public void testBuildLiveQueryTaskKey() {
+        String key = QueryInsightsService.buildLiveQueryTaskKey("nodeA", 42);
+        assertEquals("nodeA:42", key);
+    }
+
+    public void testBuildLiveQueryTaskKeyWithLongId() {
+        String key = QueryInsightsService.buildLiveQueryTaskKey("H1xZaeAmQk6kjw2KSA7swQ", 99999);
+        assertEquals("H1xZaeAmQk6kjw2KSA7swQ:99999", key);
+    }
+
+    public void testUserPrincipalInfoBasic() {
+        UserPrincipalInfo info = new UserPrincipalInfo("admin", List.of("backend1"), List.of("role1", "role2"));
+        assertEquals("admin", info.getUserName());
+        assertEquals(List.of("role1", "role2"), info.getRoles());
+        assertEquals(List.of("backend1"), info.getBackendRoles());
+    }
+
+    public void testUserPrincipalInfoWithNullUsername() {
+        UserPrincipalInfo info = new UserPrincipalInfo(null, List.of("backend1"), List.of("role1"));
+        assertNull(info.getUserName());
+        assertEquals(List.of("role1"), info.getRoles());
+        assertEquals(List.of("backend1"), info.getBackendRoles());
+    }
+
+    public void testUserPrincipalInfoWithEmptyRoles() {
+        UserPrincipalInfo info = new UserPrincipalInfo("user1", List.of(), List.of());
+        assertEquals("user1", info.getUserName());
+        assertTrue(info.getRoles().isEmpty());
+        assertTrue(info.getBackendRoles().isEmpty());
+    }
+
+    public void testUserPrincipalInfoWithMultipleRoles() {
+        UserPrincipalInfo info = new UserPrincipalInfo(
+            "analyst",
+            List.of("readall", "devteam"),
+            List.of("all_access", "readall", "kibana_user")
+        );
+        assertEquals("analyst", info.getUserName());
+        assertEquals(3, info.getRoles().size());
+        assertEquals(2, info.getBackendRoles().size());
+        assertTrue(info.getRoles().contains("all_access"));
+        assertTrue(info.getBackendRoles().contains("devteam"));
+    }
+}

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -46,6 +46,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Before;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
@@ -65,6 +66,7 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.plugin.insights.QueryInsightsTestUtils;
+import org.opensearch.plugin.insights.core.auth.UserPrincipalContext.UserPrincipalInfo;
 import org.opensearch.plugin.insights.core.exporter.DebugExporter;
 import org.opensearch.plugin.insights.core.exporter.LocalIndexExporter;
 import org.opensearch.plugin.insights.core.exporter.QueryInsightsExporterFactory;
@@ -860,5 +862,55 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         } catch (NullPointerException e) {
             fail("Should not throw NPE when exporter is null");
         }
+    }
+
+    public void testLiveQueryUserInfoPutGetRemove() {
+        String key = QueryInsightsService.buildLiveQueryTaskKey("nodeA", 1);
+        UserPrincipalInfo info = new UserPrincipalInfo("alice", List.of("backend1"), List.of("role1"));
+
+        assertNull(queryInsightsService.getLiveQueryUserInfo(key));
+
+        queryInsightsService.putLiveQueryUserInfo(key, info);
+        UserPrincipalInfo retrieved = queryInsightsService.getLiveQueryUserInfo(key);
+        assertNotNull(retrieved);
+        assertEquals("alice", retrieved.getUserName());
+        assertEquals(List.of("role1"), retrieved.getRoles());
+        assertEquals(List.of("backend1"), retrieved.getBackendRoles());
+
+        queryInsightsService.removeLiveQueryUserInfo(key);
+        assertNull(queryInsightsService.getLiveQueryUserInfo(key));
+    }
+
+    public void testLiveQueryUserInfoTtlExpiry() {
+        AtomicLong now = new AtomicLong(0L);
+        queryInsightsService.setLiveQueryUserInfoClock(now::get);
+
+        String key = QueryInsightsService.buildLiveQueryTaskKey("nodeA", 2);
+        queryInsightsService.putLiveQueryUserInfo(key, new UserPrincipalInfo("bob", List.of(), List.of()));
+
+        // Within TTL — still present
+        now.set(29 * 60 * 1000L);
+        assertNotNull(queryInsightsService.getLiveQueryUserInfo(key));
+
+        // Past the 30-minute TTL — expired and lazily removed
+        now.set(31 * 60 * 1000L);
+        assertNull(queryInsightsService.getLiveQueryUserInfo(key));
+        assertEquals(0, queryInsightsService.getLiveQueryUserInfoMapSize());
+    }
+
+    public void testLiveQueryUserInfoForKeysResolvesOnlyPresentKeys() {
+        String present = QueryInsightsService.buildLiveQueryTaskKey("nodeA", 3);
+        String absent = QueryInsightsService.buildLiveQueryTaskKey("nodeB", 4);
+        queryInsightsService.putLiveQueryUserInfo(present, new UserPrincipalInfo("carol", List.of(), List.of("r")));
+
+        Map<String, UserPrincipalInfo> resolved = queryInsightsService.getLiveQueryUserInfoForKeys(List.of(present, absent));
+        assertEquals(1, resolved.size());
+        assertTrue(resolved.containsKey(present));
+        assertFalse(resolved.containsKey(absent));
+        assertEquals("carol", resolved.get(present).getUserName());
+    }
+
+    public void testLiveQueryUserInfoForKeysWithNullReturnsEmpty() {
+        assertTrue(queryInsightsService.getLiveQueryUserInfoForKeys(null).isEmpty());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -881,19 +881,19 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         assertNull(queryInsightsService.getLiveQueryUserInfo(key));
     }
 
-    public void testLiveQueryUserInfoTtlExpiry() {
+    public void testLiveQueryUserInfoPersistsUntilExplicitRemoval() {
         AtomicLong now = new AtomicLong(0L);
         queryInsightsService.setLiveQueryUserInfoClock(now::get);
 
         String key = QueryInsightsService.buildLiveQueryTaskKey("nodeA", 2);
         queryInsightsService.putLiveQueryUserInfo(key, new UserPrincipalInfo("bob", List.of(), List.of()));
 
-        // Within TTL — still present
-        now.set(29 * 60 * 1000L);
+        // Entry persists regardless of time elapsed (no TTL-on-read)
+        now.set(60 * 60 * 1000L); // 1 hour later
         assertNotNull(queryInsightsService.getLiveQueryUserInfo(key));
 
-        // Past the 30-minute TTL — expired and lazily removed
-        now.set(31 * 60 * 1000L);
+        // Only removed by explicit call (simulates onRequestEnd cleanup)
+        queryInsightsService.removeLiveQueryUserInfo(key);
         assertNull(queryInsightsService.getLiveQueryUserInfo(key));
         assertEquals(0, queryInsightsService.getLiveQueryUserInfoMapSize());
     }

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseFinishedTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseFinishedTests.java
@@ -29,7 +29,20 @@ import org.opensearch.test.OpenSearchTestCase;
 public class LiveQueriesResponseFinishedTests extends OpenSearchTestCase {
 
     private LiveQueryRecord createLiveRecord(String id, long latency) {
-        return new LiveQueryRecord(id, "running", System.currentTimeMillis(), null, latency, 200L, 300L, null, new ArrayList<>());
+        return new LiveQueryRecord(
+            id,
+            "running",
+            System.currentTimeMillis(),
+            null,
+            latency,
+            200L,
+            300L,
+            null,
+            new ArrayList<>(),
+            null,
+            List.of(),
+            List.of()
+        );
     }
 
     private FinishedQueryRecord createFinishedRecord(String id, long latency) {

--- a/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/action/live_queries/LiveQueriesResponseTests.java
@@ -58,7 +58,10 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
                 randomLongBetween(10, 1000),
                 randomLongBetween(1024, 10240),
                 new TaskDetails(coordinator, "running"),
-                new ArrayList<>()
+                new ArrayList<>(),
+                null,
+                List.of(),
+                List.of()
             );
         }).collect(Collectors.toList());
     }
@@ -126,7 +129,10 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
             20L,
             30L,
             new TaskDetails(coordinator1, "running"),
-            new ArrayList<>()
+            new ArrayList<>(),
+            null,
+            List.of(),
+            List.of()
         );
         LiveQueryRecord rec2 = new LiveQueryRecord(
             "id2",
@@ -137,7 +143,10 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
             20L,
             30L,
             new TaskDetails(coordinator2, "running"),
-            new ArrayList<>()
+            new ArrayList<>(),
+            null,
+            List.of(),
+            List.of()
         );
         LiveQueryRecord rec3 = new LiveQueryRecord(
             "id3",
@@ -148,7 +157,10 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
             20L,
             30L,
             new TaskDetails(coordinator3, "running"),
-            new ArrayList<>()
+            new ArrayList<>(),
+            null,
+            List.of(),
+            List.of()
         );
         List<LiveQueryRecord> records = List.of(rec2, rec1, rec3);
         LiveQueriesResponse response = new LiveQueriesResponse(records);
@@ -234,7 +246,10 @@ public class LiveQueriesResponseTests extends OpenSearchTestCase {
             totalCpu,
             totalMem,
             new TaskDetails(coordinator, "running"),
-            List.of(new TaskDetails(shard1, "running"), new TaskDetails(shard2, "running"))
+            List.of(new TaskDetails(shard1, "running"), new TaskDetails(shard2, "running")),
+            null,
+            List.of(),
+            List.of()
         );
 
         assertEquals(1800L, record.getTotalCpu());

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/LiveQueryRecordTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/LiveQueryRecordTests.java
@@ -20,7 +20,20 @@ import org.opensearch.test.OpenSearchTestCase;
 public class LiveQueryRecordTests extends OpenSearchTestCase {
 
     public void testSerialization() throws IOException {
-        LiveQueryRecord record = new LiveQueryRecord("query1", "running", 123L, "wlm1", 456L, 789L, 1024L, null, List.of());
+        LiveQueryRecord record = new LiveQueryRecord(
+            "query1",
+            "running",
+            123L,
+            "wlm1",
+            456L,
+            789L,
+            1024L,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of()
+        );
 
         BytesStreamOutput out = new BytesStreamOutput();
         record.writeTo(out);
@@ -37,7 +50,20 @@ public class LiveQueryRecordTests extends OpenSearchTestCase {
     }
 
     public void testToXContent() throws IOException {
-        LiveQueryRecord record = new LiveQueryRecord("query1", "running", 123L, null, 456L, 789L, 1024L, null, List.of());
+        LiveQueryRecord record = new LiveQueryRecord(
+            "query1",
+            "running",
+            123L,
+            null,
+            456L,
+            789L,
+            1024L,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of()
+        );
 
         XContentBuilder builder = XContentFactory.jsonBuilder();
         record.toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -50,5 +76,133 @@ public class LiveQueryRecordTests extends OpenSearchTestCase {
         assertTrue(json.contains("\"total_cpu_nanos\":789"));
         assertTrue(json.contains("\"total_memory_bytes\":1024"));
         assertFalse(json.contains("wlm_group_id"));
+    }
+
+    public void testSerializationWithUserInfo() throws IOException {
+        LiveQueryRecord record = new LiveQueryRecord(
+            "query2",
+            "running",
+            1000L,
+            "wlm-group-1",
+            500L,
+            300L,
+            2048L,
+            null,
+            List.of(),
+            "testuser",
+            List.of("all_access", "readall"),
+            List.of("admin", "devteam")
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        record.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        LiveQueryRecord deserialized = new LiveQueryRecord(in);
+
+        assertEquals("testuser", deserialized.getUsername());
+        assertEquals(List.of("all_access", "readall"), deserialized.getUserRoles());
+        assertEquals(List.of("admin", "devteam"), deserialized.getBackendRoles());
+    }
+
+    public void testSerializationWithNullUserInfo() throws IOException {
+        LiveQueryRecord record = new LiveQueryRecord(
+            "query3",
+            "completed",
+            2000L,
+            null,
+            100L,
+            50L,
+            512L,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of()
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        record.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        LiveQueryRecord deserialized = new LiveQueryRecord(in);
+
+        assertNull(deserialized.getUsername());
+        assertEquals(List.of(), deserialized.getUserRoles());
+        assertEquals(List.of(), deserialized.getBackendRoles());
+    }
+
+    public void testToXContentWithUserInfo() throws IOException {
+        LiveQueryRecord record = new LiveQueryRecord(
+            "query4",
+            "running",
+            3000L,
+            "wlm1",
+            700L,
+            400L,
+            4096L,
+            null,
+            List.of(),
+            "analyst_user",
+            List.of("all_access", "readall"),
+            List.of("backend_role1")
+        );
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        record.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = builder.toString();
+
+        assertTrue(json.contains("\"username\":\"analyst_user\""));
+        assertTrue(json.contains("\"user_roles\":[\"all_access\",\"readall\"]"));
+        assertTrue(json.contains("\"backend_roles\":[\"backend_role1\"]"));
+    }
+
+    public void testToXContentWithoutUserInfo() throws IOException {
+        LiveQueryRecord record = new LiveQueryRecord(
+            "query5",
+            "running",
+            4000L,
+            null,
+            200L,
+            100L,
+            1024L,
+            null,
+            List.of(),
+            null,
+            List.of(),
+            List.of()
+        );
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        record.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        String json = builder.toString();
+
+        assertFalse(json.contains("username"));
+        assertFalse(json.contains("user_roles"));
+        assertFalse(json.contains("backend_roles"));
+    }
+
+    public void testSerializationWithNullRolesLists() throws IOException {
+        LiveQueryRecord record = new LiveQueryRecord(
+            "query6",
+            "running",
+            5000L,
+            null,
+            100L,
+            50L,
+            256L,
+            null,
+            List.of(),
+            "user_with_null_roles",
+            null,
+            null
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        record.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+        LiveQueryRecord deserialized = new LiveQueryRecord(in);
+
+        assertEquals("user_with_null_roles", deserialized.getUsername());
+        assertEquals(List.of(), deserialized.getUserRoles());
+        assertEquals(List.of(), deserialized.getBackendRoles());
     }
 }

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesActionTests.java
@@ -113,6 +113,27 @@ public class TransportLiveQueriesActionTests extends OpenSearchTestCase {
         when(queryInsightsService.getFinishedQueriesCache()).thenReturn(mockCache);
         when(mockCache.getFinishedQueries()).thenReturn(List.of());
 
+        // Default stub for the live query user info fan-out: return an empty (no identities) response
+        // so tests that don't care about user info aren't left hanging on the async callback.
+        doAnswer(inv -> {
+            ActionListener<org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoResponse> listener = inv.getArgument(
+                2
+            );
+            listener.onResponse(
+                new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoResponse(
+                    new ClusterName("test-cluster"),
+                    emptyList(),
+                    emptyList()
+                )
+            );
+            return null;
+        }).when(client)
+            .execute(
+                org.mockito.Mockito.eq(org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoAction.INSTANCE),
+                any(),
+                any()
+            );
+
         transportLiveQueriesAction = new TransportLiveQueriesAction(transportService, client, actionFilters, queryInsightsService);
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesActionTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/transport/live_queries/TransportLiveQueriesActionTests.java
@@ -44,6 +44,7 @@ import org.opensearch.plugin.insights.core.service.FinishedQueriesCache;
 import org.opensearch.plugin.insights.core.service.QueryInsightsService;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesRequest;
 import org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesResponse;
+import org.opensearch.plugin.insights.rules.model.FilterByMode;
 import org.opensearch.plugin.insights.rules.model.FinishedQueryRecord;
 import org.opensearch.plugin.insights.rules.model.LiveQueryRecord;
 import org.opensearch.plugin.insights.rules.model.Measurement;
@@ -1051,6 +1052,328 @@ public class TransportLiveQueriesActionTests extends OpenSearchTestCase {
             any(),
             any()
         );
+    }
+
+    // =====================================================================
+    // RBAC / filter_by_mode / enrichment tests
+    // =====================================================================
+
+    /**
+     * Helper: set up the thread-context so that UserPrincipalContext (used by filterLiveRecordsByMode)
+     * sees the given user string. Format: "username|backendRoles|roles" (pipe-separated).
+     */
+    private void setRequestingUser(String userInfoString) {
+        org.opensearch.common.util.concurrent.ThreadContext threadContext = new org.opensearch.common.util.concurrent.ThreadContext(
+            Settings.EMPTY
+        );
+        threadContext.putTransient("_opendistro_security_user_info", userInfoString);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+    }
+
+    /**
+     * Helper: stub the LiveQueriesUserInfoAction fan-out to return a populated map of task-key -> identity.
+     */
+    private void stubUserInfoFanOut(Map<String, org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO> infoMap) {
+        doAnswer(inv -> {
+            ActionListener<org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoResponse> listener = inv.getArgument(
+                2
+            );
+            org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoNodeResponse nodeResp =
+                new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoNodeResponse(node1, infoMap);
+            listener.onResponse(
+                new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoResponse(
+                    new ClusterName("test-cluster"),
+                    List.of(nodeResp),
+                    emptyList()
+                )
+            );
+            return null;
+        }).when(client)
+            .execute(
+                org.mockito.Mockito.eq(org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoAction.INSTANCE),
+                any(),
+                any()
+            );
+    }
+
+    /**
+     * Helper: stub the listTasks to return a single search task on node1 with the given TaskId.
+     * Returns the TaskInfo so callers can reference its taskId.
+     */
+    private TaskInfo stubSingleSearchTask() throws IOException {
+        TaskInfo task = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 1000000L, "test-desc", 100L, 200L);
+        ListTasksResponse mockResponse = mock(ListTasksResponse.class);
+        when(mockResponse.getTaskGroups()).thenReturn(List.of(new TaskGroup(task, emptyList())));
+        doAnswer(inv -> {
+            ActionListener<ListTasksResponse> listener = inv.getArgument(1);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(clusterAdminClient).listTasks(any(ListTasksRequest.class), any(ActionListener.class));
+        return task;
+    }
+
+    /**
+     * Test: Enrichment - stub LiveQueriesUserInfoAction to return a populated identity for a known
+     * task key; assert the resulting LiveQueryRecord carries the expected username, roles, and backend roles.
+     */
+    public void testEnrichmentPopulatesUserIdentity() throws Exception {
+        when(queryInsightsService.getFilterByMode()).thenReturn(FilterByMode.NONE);
+        // Set requesting user (not relevant for filtering since mode=NONE, but needed for the context)
+        setRequestingUser("admin|admin_role|all_access");
+
+        TaskInfo task = stubSingleSearchTask();
+        String taskKey = task.getTaskId().toString();
+
+        // Stub the user info fan-out to return identity for this task key
+        Map<String, org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO> infoMap = new HashMap<>();
+        infoMap.put(
+            taskKey,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO("bob", List.of("role_a"), List.of("be_role_x"))
+        );
+        stubUserInfoFanOut(infoMap);
+
+        LiveQueriesRequest request = new LiveQueriesRequest(true);
+        PlainActionFuture<LiveQueriesResponse> future = PlainActionFuture.newFuture();
+        transportLiveQueriesAction.execute(request, future);
+        LiveQueriesResponse response = future.actionGet();
+
+        assertEquals(1, response.getLiveQueries().size());
+        LiveQueryRecord record = response.getLiveQueries().get(0);
+        assertEquals("bob", record.getUsername());
+        assertEquals(List.of("role_a"), record.getUserRoles());
+        assertEquals(List.of("be_role_x"), record.getBackendRoles());
+    }
+
+    /**
+     * Test: filter_by_mode=USERNAME - non-admin caller sees only records whose username matches theirs.
+     */
+    public void testFilterByModeUsername_NonAdminSeesOwnRecords() throws Exception {
+        when(queryInsightsService.getFilterByMode()).thenReturn(FilterByMode.USERNAME);
+        setRequestingUser("alice|backend1|user_role");
+
+        // Create two search tasks
+        TaskInfo task1 = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 1000000L, "t1", 100L, 200L);
+        TaskInfo task2 = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 2000000L, "t2", 300L, 400L);
+        ListTasksResponse mockResponse = mock(ListTasksResponse.class);
+        when(mockResponse.getTaskGroups()).thenReturn(List.of(new TaskGroup(task1, emptyList()), new TaskGroup(task2, emptyList())));
+        doAnswer(inv -> {
+            ActionListener<ListTasksResponse> listener = inv.getArgument(1);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(clusterAdminClient).listTasks(any(ListTasksRequest.class), any(ActionListener.class));
+
+        // Enrich task1 with username "alice" and task2 with "bob"
+        String key1 = task1.getTaskId().toString();
+        String key2 = task2.getTaskId().toString();
+        Map<String, org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO> infoMap = new HashMap<>();
+        infoMap.put(
+            key1,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO(
+                "alice",
+                List.of("user_role"),
+                List.of("backend1")
+            )
+        );
+        infoMap.put(
+            key2,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO(
+                "bob",
+                List.of("user_role"),
+                List.of("backend2")
+            )
+        );
+        stubUserInfoFanOut(infoMap);
+
+        LiveQueriesRequest request = new LiveQueriesRequest(true);
+        PlainActionFuture<LiveQueriesResponse> future = PlainActionFuture.newFuture();
+        transportLiveQueriesAction.execute(request, future);
+        LiveQueriesResponse response = future.actionGet();
+
+        // Alice should only see her own record
+        assertEquals(1, response.getLiveQueries().size());
+        assertEquals("alice", response.getLiveQueries().get(0).getUsername());
+        assertEquals(key1, response.getLiveQueries().get(0).getQueryId());
+    }
+
+    /**
+     * Test: filter_by_mode=USERNAME - admin (all_access role) sees all records.
+     */
+    public void testFilterByModeUsername_AdminSeesAll() throws Exception {
+        when(queryInsightsService.getFilterByMode()).thenReturn(FilterByMode.USERNAME);
+        setRequestingUser("superadmin|admin_backend|all_access");
+
+        // Create two search tasks from different users
+        TaskInfo task1 = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 1000000L, "t1", 100L, 200L);
+        TaskInfo task2 = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 2000000L, "t2", 300L, 400L);
+        ListTasksResponse mockResponse = mock(ListTasksResponse.class);
+        when(mockResponse.getTaskGroups()).thenReturn(List.of(new TaskGroup(task1, emptyList()), new TaskGroup(task2, emptyList())));
+        doAnswer(inv -> {
+            ActionListener<ListTasksResponse> listener = inv.getArgument(1);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(clusterAdminClient).listTasks(any(ListTasksRequest.class), any(ActionListener.class));
+
+        String key1 = task1.getTaskId().toString();
+        String key2 = task2.getTaskId().toString();
+        Map<String, org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO> infoMap = new HashMap<>();
+        infoMap.put(
+            key1,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO(
+                "alice",
+                List.of("user_role"),
+                List.of("backend1")
+            )
+        );
+        infoMap.put(
+            key2,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO(
+                "bob",
+                List.of("user_role"),
+                List.of("backend2")
+            )
+        );
+        stubUserInfoFanOut(infoMap);
+
+        LiveQueriesRequest request = new LiveQueriesRequest(true);
+        PlainActionFuture<LiveQueriesResponse> future = PlainActionFuture.newFuture();
+        transportLiveQueriesAction.execute(request, future);
+        LiveQueriesResponse response = future.actionGet();
+
+        // Admin sees all records
+        assertEquals(2, response.getLiveQueries().size());
+    }
+
+    /**
+     * Test: filter_by_mode=USERNAME - when user extraction fails (no thread context), returns empty list.
+     */
+    public void testFilterByModeUsername_MissingUserExtractionYieldsEmpty() throws Exception {
+        when(queryInsightsService.getFilterByMode()).thenReturn(FilterByMode.USERNAME);
+        // Do NOT set requestingUser - threadPool.getThreadContext() returns null
+        when(transportService.getThreadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(null);
+
+        TaskInfo task = stubSingleSearchTask();
+        String taskKey = task.getTaskId().toString();
+        Map<String, org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO> infoMap = new HashMap<>();
+        infoMap.put(
+            taskKey,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO(
+                "bob",
+                List.of("user_role"),
+                List.of("backend1")
+            )
+        );
+        stubUserInfoFanOut(infoMap);
+
+        LiveQueriesRequest request = new LiveQueriesRequest(true);
+        PlainActionFuture<LiveQueriesResponse> future = PlainActionFuture.newFuture();
+        transportLiveQueriesAction.execute(request, future);
+        LiveQueriesResponse response = future.actionGet();
+
+        // Missing user extraction yields empty list
+        assertEquals(0, response.getLiveQueries().size());
+    }
+
+    /**
+     * Test: filter_by_mode=BACKEND_ROLES - caller sees only records sharing at least one backend role.
+     */
+    public void testFilterByModeBackendRoles_SharedRoleVisible() throws Exception {
+        when(queryInsightsService.getFilterByMode()).thenReturn(FilterByMode.BACKEND_ROLES);
+        setRequestingUser("carol|engineering,data_team|user_role");
+
+        TaskInfo task1 = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 1000000L, "t1", 100L, 200L);
+        TaskInfo task2 = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 2000000L, "t2", 300L, 400L);
+        TaskInfo task3 = createTaskInfo(node1, "indices:data/read/search", System.currentTimeMillis(), 3000000L, "t3", 500L, 600L);
+        ListTasksResponse mockResponse = mock(ListTasksResponse.class);
+        when(mockResponse.getTaskGroups()).thenReturn(
+            List.of(new TaskGroup(task1, emptyList()), new TaskGroup(task2, emptyList()), new TaskGroup(task3, emptyList()))
+        );
+        doAnswer(inv -> {
+            ActionListener<ListTasksResponse> listener = inv.getArgument(1);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(clusterAdminClient).listTasks(any(ListTasksRequest.class), any(ActionListener.class));
+
+        String key1 = task1.getTaskId().toString();
+        String key2 = task2.getTaskId().toString();
+        String key3 = task3.getTaskId().toString();
+        Map<String, org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO> infoMap = new HashMap<>();
+        // task1: shares "engineering" with carol
+        infoMap.put(
+            key1,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO(
+                "alice",
+                List.of("user_role"),
+                List.of("engineering", "marketing")
+            )
+        );
+        // task2: no shared roles with carol
+        infoMap.put(
+            key2,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO(
+                "bob",
+                List.of("user_role"),
+                List.of("finance")
+            )
+        );
+        // task3: shares "data_team" with carol
+        infoMap.put(
+            key3,
+            new org.opensearch.plugin.insights.rules.action.live_queries.LiveQueryUserInfoDTO(
+                "dave",
+                List.of("user_role"),
+                List.of("data_team", "ops")
+            )
+        );
+        stubUserInfoFanOut(infoMap);
+
+        LiveQueriesRequest request = new LiveQueriesRequest(true);
+        PlainActionFuture<LiveQueriesResponse> future = PlainActionFuture.newFuture();
+        transportLiveQueriesAction.execute(request, future);
+        LiveQueriesResponse response = future.actionGet();
+
+        // Carol should see task1 (shares engineering) and task3 (shares data_team), but not task2
+        assertEquals(2, response.getLiveQueries().size());
+        List<String> visibleIds = response.getLiveQueries().stream().map(LiveQueryRecord::getQueryId).toList();
+        assertTrue(visibleIds.contains(key1));
+        assertTrue(visibleIds.contains(key3));
+        assertFalse(visibleIds.contains(key2));
+    }
+
+    /**
+     * Test: Fail-open guard - when the user info fan-out fails, the filter is still applied before responding.
+     * With a non-NONE filter mode and a valid requesting user, the fail-open branch enriches records
+     * without identity (username=null), so the filter removes them.
+     */
+    public void testFailOpenGuardStillAppliesFilter() throws Exception {
+        when(queryInsightsService.getFilterByMode()).thenReturn(FilterByMode.USERNAME);
+        setRequestingUser("alice|backend1|user_role");
+
+        TaskInfo task = stubSingleSearchTask();
+
+        // Override the user-info fan-out to FAIL
+        doAnswer(inv -> {
+            ActionListener<org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoResponse> listener = inv.getArgument(
+                2
+            );
+            listener.onFailure(new RuntimeException("Simulated user-info fan-out failure"));
+            return null;
+        }).when(client)
+            .execute(
+                org.mockito.Mockito.eq(org.opensearch.plugin.insights.rules.action.live_queries.LiveQueriesUserInfoAction.INSTANCE),
+                any(),
+                any()
+            );
+
+        LiveQueriesRequest request = new LiveQueriesRequest(true);
+        PlainActionFuture<LiveQueriesResponse> future = PlainActionFuture.newFuture();
+        transportLiveQueriesAction.execute(request, future);
+        LiveQueriesResponse response = future.actionGet();
+
+        // Records have no enriched username (because fan-out failed), so the USERNAME filter
+        // removes them (username on records is null, does not match "alice").
+        assertEquals(0, response.getLiveQueries().size());
     }
 
     public void testCoordinatorAndShardResourceAggregation() throws Exception {


### PR DESCRIPTION
### Description
Add user info capture via QueryInsightsListener onPhaseStart and extract user attributes into LiveQueryRecord and finished cache. This enables filtering and grouping queries by user in the dashboards.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
