### PR TITLE
[Backport 3.8] Fix flaky grouper and top queries ITs by hardening waits for slow CI (#653)

### DIFF
--- a/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
+++ b/src/test/java/org/opensearch/plugin/insights/QueryInsightsRestTestCase.java
@@ -619,8 +619,8 @@ public abstract class QueryInsightsRestTestCase extends OpenSearchRestTestCase {
         Thread.sleep(QueryInsightsSettings.QUERY_RECORD_QUEUE_DRAIN_INTERVAL.millis());
         int topNArraySize = 0;
 
-        // run five times to make sure the records are drained to the top queries services
-        for (int i = 0; i < 5; i++) {
+        // Retry while under expected count (records still draining on a slow CI node)
+        for (int i = 0; i < 10; i++) {
             String responseBody = getTopQueries(type);
             if (subString != null) {
                 topNArraySize = countOccurrences(responseBody, subString);

--- a/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/grouper/MinMaxQueryGrouperIT.java
@@ -29,6 +29,8 @@ public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
         assertTopQueriesCount(6, "latency");
 
         updateClusterSettings(this::defaultTopQueryGroupingSettings);
+        // Wait for the grouping change to propagate before searching so records aren't collected under NONE
+        waitForSettingsPropagation("latency");
 
         // Top queries should be drained due to grouping change from NONE -> SIMILARITY
         assertTopQueriesCount(0, "latency");
@@ -57,6 +59,8 @@ public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
         assertTopQueriesCount(3, "latency");
 
         updateClusterSettings(this::defaultTopQueriesSettings);
+        // Wait for the grouping change to propagate before searching so records aren't collected under SIMILARITY
+        waitForSettingsPropagation("latency");
 
         // Top queries should be drained due to grouping change from SIMILARITY -> NONE
         assertTopQueriesCount(0, "latency");
@@ -85,6 +89,8 @@ public class MinMaxQueryGrouperIT extends QueryInsightsRestTestCase {
 
         // Change max groups exluding topn setting
         updateClusterSettings(this::updateMaxGroupsExcludingTopNSetting);
+        // Wait for the max groups change to propagate before searching
+        waitForSettingsPropagation("latency");
 
         // Top queries should be drained due to max group change
         assertTopQueriesCount(0, "latency");


### PR DESCRIPTION
Backport of #653 to the `3.8` branch.

### Description

MinMaxQueryGrouperIT.testNoneToSimilarityGroupingTransition and TopQueriesRestIT.testExcludedIndices failed in the 3.8.0 release integ-test (#648) with expected:<3> but was:<4> and Top N queries count [1] is not equal to expected [2].

Both are propagation/drain-timing races that only surface on slow CI nodes. This is a follow-up to #644 by waiting to ensure that the updated grouping settings have propagated to all the nodes before proceeding with the test. Retry amounts were increased in QueryInsightsRestTestCase to match other loops (such as `validateGroups` in `MinMaxQueryGrouperBySimilarityIT.java`).

### Issues Resolved
Closes #648.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.