### PR TITLE
Defer security plugin download to execution phase (query-insights)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -416,13 +416,15 @@ run {
 testClusters.register('runWithSecurity') {
 }
 
-configureSecurityPlugin(testClusters.'runWithSecurity')
-
 tasks.register('runWithSecurity', RunTask) {
     dependsOn(project.tasks.bundlePlugin)
     useCluster testClusters.'runWithSecurity'
     description = 'Runs OpenSearch with security plugin in the foreground'
     group = 'Verification'
+}
+
+if (gradle.startParameter.taskNames.any { it.contains('runWithSecurity') }) {
+    configureSecurityPlugin(testClusters.'runWithSecurity')
 }
 
 jacocoTestReport {
@@ -442,8 +444,10 @@ task integTestWithSecurity(type: RestIntegTestTask) {
   systemProperty "cluster.names",
     getClusters().stream().map(cluster -> cluster.getName()).collect(Collectors.joining(","))
 
-  getClusters().forEach { cluster ->
-    configureSecurityPlugin(cluster)
+  if (gradle.startParameter.taskNames.any { it.contains('integTestWithSecurity') }) {
+    getClusters().forEach { cluster ->
+      configureSecurityPlugin(cluster)
+    }
   }
 
   dependsOn project.tasks.bundlePlugin


### PR DESCRIPTION
### Description
Defer security plugin download to execution phase (query-insights)

The configureSecurityPlugin closure downloads the security plugin zip during Gradle configuration phase, which means it runs even for `./gradlew assemble`. This causes a 403 failure when the artifact hasn't been published yet. Moving to doFirst ensures it only runs when the test tasks actually execute.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803