### PR TITLE
Validate remote exporter base path at settings-validation time

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporter.java
@@ -56,9 +56,9 @@ public class RemoteRepositoryExporter implements QueryInsightsExporter {
     /**
      * Validate that a base path contains only allowed characters.
      * <p>
-     * Called both from the setting validator (so an invalid path is rejected with a 400 when the
-     * update is submitted, rather than throwing while cluster state is applied) and from
-     * {@link #setBasePath(String)}.
+     * Called from the setting validator so an invalid path is rejected with a 400 when the update is submitted, rather
+     * than throwing while cluster state is applied. It is deliberately not called from {@link #setBasePath(String)},
+     * which runs at apply time.
      *
      * @param basePath the base path to validate; {@code null} is permitted
      * @throws IllegalArgumentException if the path contains disallowed characters
@@ -311,10 +311,15 @@ public class RemoteRepositoryExporter implements QueryInsightsExporter {
     }
 
     /**
-     * Set base path and validate it contains only allowed characters
+     * Set base path.
+     * <p>
+     * The allowed-characters check is intentionally NOT performed here. This runs as the {@code remote.path}
+     * settings-update consumer at apply time; an invalid value has already been rejected up front by
+     * {@link org.opensearch.plugin.insights.settings.QueryInsightsSettings.RemoteExporterPathValidator} at
+     * settings-validation time (and by {@link #validateBasePath(String)} on the setting's default at startup). Throwing
+     * here would instead fail while cluster state is applied, which can destabilize the cluster-manager.
      */
     public void setBasePath(String basePath) {
-        validateBasePath(basePath);
         repositoryState.updateAndGet(current -> {
             if (current.repositoryName != null && !current.repositoryName.isEmpty()) {
                 try {

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporter.java
@@ -35,7 +35,6 @@ import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
-import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.RepositoryMissingException;
@@ -51,6 +50,26 @@ public class RemoteRepositoryExporter implements QueryInsightsExporter {
     private static final Logger logger = LogManager.getLogger(RemoteRepositoryExporter.class);
     private static final int MAX_RETRIES = 3;
     private static final long INITIAL_BACKOFF_MS = 100;
+    /** Characters allowed in the exporter base path. */
+    private static final String ALLOWED_BASE_PATH_CHARS = "[a-zA-Z0-9/!\\-_.*()']*";
+
+    /**
+     * Validate that a base path contains only allowed characters.
+     * <p>
+     * Called both from the setting validator (so an invalid path is rejected with a 400 when the
+     * update is submitted, rather than throwing while cluster state is applied) and from
+     * {@link #setBasePath(String)}.
+     *
+     * @param basePath the base path to validate; {@code null} is permitted
+     * @throws IllegalArgumentException if the path contains disallowed characters
+     */
+    public static void validateBasePath(final String basePath) {
+        if (basePath != null && !basePath.matches(ALLOWED_BASE_PATH_CHARS)) {
+            throw new IllegalArgumentException(
+                "Base path contains invalid characters. Only alphanumeric, /, !, -, _, ., *, ', (, ) are allowed."
+            );
+        }
+    }
 
     private static class RepositoryState {
         final String repositoryName;
@@ -295,9 +314,7 @@ public class RemoteRepositoryExporter implements QueryInsightsExporter {
      * Set base path and validate it contains only allowed characters
      */
     public void setBasePath(String basePath) {
-        if (basePath != null && !basePath.matches(QueryInsightsSettings.REMOTE_EXPORTER_PATH_ALLOWED_CHARS_REGEX)) {
-            throw new IllegalArgumentException(QueryInsightsSettings.REMOTE_EXPORTER_PATH_INVALID_CHARS_MESSAGE);
-        }
+        validateBasePath(basePath);
         repositoryState.updateAndGet(current -> {
             if (current.repositoryName != null && !current.repositoryName.isEmpty()) {
                 try {

--- a/src/main/java/org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporter.java
+++ b/src/main/java/org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporter.java
@@ -35,6 +35,7 @@ import org.opensearch.plugin.insights.core.metrics.OperationalMetric;
 import org.opensearch.plugin.insights.core.metrics.OperationalMetricsCounter;
 import org.opensearch.plugin.insights.rules.model.MetricType;
 import org.opensearch.plugin.insights.rules.model.SearchQueryRecord;
+import org.opensearch.plugin.insights.settings.QueryInsightsSettings;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.repositories.RepositoryMissingException;
@@ -294,10 +295,8 @@ public class RemoteRepositoryExporter implements QueryInsightsExporter {
      * Set base path and validate it contains only allowed characters
      */
     public void setBasePath(String basePath) {
-        if (basePath != null && !basePath.matches("[a-zA-Z0-9/!\\-_.*()']*")) {
-            throw new IllegalArgumentException(
-                "Base path contains invalid characters. Only alphanumeric, /, !, -, _, ., *, ', (, ) are allowed."
-            );
+        if (basePath != null && !basePath.matches(QueryInsightsSettings.REMOTE_EXPORTER_PATH_ALLOWED_CHARS_REGEX)) {
+            throw new IllegalArgumentException(QueryInsightsSettings.REMOTE_EXPORTER_PATH_INVALID_CHARS_MESSAGE);
         }
         repositoryState.updateAndGet(current -> {
             if (current.repositoryName != null && !current.repositoryName.isEmpty()) {

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -348,9 +348,25 @@ public class QueryInsightsSettings {
         Setting.Property.Dynamic
     );
 
+    /**
+     * Characters allowed in the remote exporter base path.
+     * <p>
+     * Shared by {@link RemoteExporterPathValidator} (validation time) and
+     * {@link org.opensearch.plugin.insights.core.exporter.RemoteRepositoryExporter#setBasePath(String)}
+     * (apply time) so the two cannot drift.
+     */
+    public static final String REMOTE_EXPORTER_PATH_ALLOWED_CHARS_REGEX = "[a-zA-Z0-9/!\\-_.*()']*";
+
+    /**
+     * Error message used when the remote exporter base path contains disallowed characters.
+     */
+    public static final String REMOTE_EXPORTER_PATH_INVALID_CHARS_MESSAGE =
+        "Base path contains invalid characters. Only alphanumeric, /, !, -, _, ., *, ', (, ) are allowed.";
+
     public static final Setting<String> REMOTE_EXPORTER_PATH = Setting.simpleString(
         TOP_N_QUERIES_EXPORTER_PREFIX + ".remote.path",
         "query-insights",
+        new RemoteExporterPathValidator(),
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
@@ -608,6 +624,21 @@ public class QueryInsightsSettings {
                 throw new IllegalArgumentException(
                     String.format(Locale.ROOT, "Invalid exporter type [%s], type should be one of %s", value, SinkType.allSinkTypes())
                 );
+            }
+        }
+    }
+
+    /**
+     * Validates the Query Insights remote exporter base path.
+     * <p>
+     * This runs at settings-validation time so an invalid path is rejected with a 400 on the
+     * update request, instead of throwing while cluster state is being applied.
+     */
+    public static final class RemoteExporterPathValidator implements Setting.Validator<String> {
+        @Override
+        public void validate(String value) {
+            if (value != null && !value.matches(REMOTE_EXPORTER_PATH_ALLOWED_CHARS_REGEX)) {
+                throw new IllegalArgumentException(REMOTE_EXPORTER_PATH_INVALID_CHARS_MESSAGE);
             }
         }
     }

--- a/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
+++ b/src/main/java/org/opensearch/plugin/insights/settings/QueryInsightsSettings.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.unit.TimeValue;
+import org.opensearch.plugin.insights.core.exporter.RemoteRepositoryExporter;
 import org.opensearch.plugin.insights.core.exporter.SinkType;
 import org.opensearch.plugin.insights.rules.model.FilterByMode;
 import org.opensearch.plugin.insights.rules.model.GroupingType;
@@ -348,21 +349,6 @@ public class QueryInsightsSettings {
         Setting.Property.Dynamic
     );
 
-    /**
-     * Characters allowed in the remote exporter base path.
-     * <p>
-     * Shared by {@link RemoteExporterPathValidator} (validation time) and
-     * {@link org.opensearch.plugin.insights.core.exporter.RemoteRepositoryExporter#setBasePath(String)}
-     * (apply time) so the two cannot drift.
-     */
-    public static final String REMOTE_EXPORTER_PATH_ALLOWED_CHARS_REGEX = "[a-zA-Z0-9/!\\-_.*()']*";
-
-    /**
-     * Error message used when the remote exporter base path contains disallowed characters.
-     */
-    public static final String REMOTE_EXPORTER_PATH_INVALID_CHARS_MESSAGE =
-        "Base path contains invalid characters. Only alphanumeric, /, !, -, _, ., *, ', (, ) are allowed.";
-
     public static final Setting<String> REMOTE_EXPORTER_PATH = Setting.simpleString(
         TOP_N_QUERIES_EXPORTER_PREFIX + ".remote.path",
         "query-insights",
@@ -634,12 +620,10 @@ public class QueryInsightsSettings {
      * This runs at settings-validation time so an invalid path is rejected with a 400 on the
      * update request, instead of throwing while cluster state is being applied.
      */
-    public static final class RemoteExporterPathValidator implements Setting.Validator<String> {
+    static final class RemoteExporterPathValidator implements Setting.Validator<String> {
         @Override
         public void validate(String value) {
-            if (value != null && !value.matches(REMOTE_EXPORTER_PATH_ALLOWED_CHARS_REGEX)) {
-                throw new IllegalArgumentException(REMOTE_EXPORTER_PATH_INVALID_CHARS_MESSAGE);
-            }
+            RemoteRepositoryExporter.validateBasePath(value);
         }
     }
 

--- a/src/test/java/org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporterTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/exporter/RemoteRepositoryExporterTests.java
@@ -199,8 +199,13 @@ public class RemoteRepositoryExporterTests extends OpenSearchTestCase {
         assertEquals("query-insights/path-with_special.chars*()", remoteRepositoryExporter.getBasePath());
     }
 
-    public void testSetBasePathWithInvalidCharacters() {
-        assertThrows(IllegalArgumentException.class, () -> { remoteRepositoryExporter.setBasePath("query-insights/invalid@path"); });
+    public void testSetBasePathWithInvalidCharactersDoesNotThrow() {
+        // setBasePath runs as the settings-update consumer at apply time and must not throw: an invalid path is rejected
+        // up front by RemoteExporterPathValidator at settings-validation time. Throwing here would fail while cluster
+        // state is applied and could destabilize the cluster-manager. The character check itself is covered by the
+        // validator/validateBasePath tests in QueryInsightsServiceTests.
+        remoteRepositoryExporter.setBasePath("query-insights/invalid@path");
+        assertEquals("query-insights/invalid@path", remoteRepositoryExporter.getBasePath());
     }
 
     public void testSetBasePathWithNull() {

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -890,6 +890,20 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         verify(remoteExporter, times(0)).setBasePath("bad path#with@chars");
     }
 
+    public void testRemoteExporterPathInvalidCharsRejectedAtNodeScope() {
+        // A node-level (opensearch.yml) value is also validated on read, consistent with the
+        // plugin's other validated string settings such as grouping.group_by.
+        Settings bad = Settings.builder().put("search.insights.top_queries.exporter.remote.path", "bad path#with@chars").build();
+        ClusterSettings badClusterSettings = new ClusterSettings(bad, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        QueryInsightsTestUtils.registerAllQueryInsightsSettings(badClusterSettings);
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> badClusterSettings.get(QueryInsightsSettings.REMOTE_EXPORTER_PATH)
+        );
+        assertTrue(e.getMessage().contains("Base path contains invalid characters"));
+    }
+
     public void testRemoteExporterPathValidCharsPassValidation() {
         Settings valid = Settings.builder()
             .put("search.insights.top_queries.exporter.remote.path", "query-insights/path-with_special.chars*()!'")
@@ -900,19 +914,20 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         clusterService.getClusterSettings().applySettings(valid);
     }
 
-    public void testRemoteExporterPathValidatorDirectly() {
-        QueryInsightsSettings.RemoteExporterPathValidator validator = new QueryInsightsSettings.RemoteExporterPathValidator();
-
+    public void testValidateBasePathAcceptsAndRejects() {
         // Valid values, including the allowed punctuation set and the empty string.
-        validator.validate("query-insights");
-        validator.validate("a/b/c");
-        validator.validate("query-insights/path-with_special.chars*()!'");
-        validator.validate("");
-        validator.validate(null);
+        RemoteRepositoryExporter.validateBasePath("query-insights");
+        RemoteRepositoryExporter.validateBasePath("a/b/c");
+        RemoteRepositoryExporter.validateBasePath("query-insights/path-with_special.chars*()!'");
+        RemoteRepositoryExporter.validateBasePath("");
+        RemoteRepositoryExporter.validateBasePath(null);
 
         // Invalid values.
         for (String invalid : List.of("has space", "has#hash", "has@at", "has\\backslash", "has%percent", "has\nnewline")) {
-            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> validator.validate(invalid));
+            IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> RemoteRepositoryExporter.validateBasePath(invalid)
+            );
             assertTrue(e.getMessage().contains("Base path contains invalid characters"));
         }
     }

--- a/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/core/service/QueryInsightsServiceTests.java
@@ -867,6 +867,56 @@ public class QueryInsightsServiceTests extends OpenSearchTestCase {
         }
     }
 
+    public void testRemoteExporterPathInvalidCharsRejectedAtValidationTime() {
+        // An invalid base path must be rejected while validating the update, before it is
+        // committed to cluster state and applied. Otherwise the throw lands on the
+        // settings-apply path, which aborts cluster state application on the cluster-manager.
+        Settings invalid = Settings.builder().put("search.insights.top_queries.exporter.remote.path", "bad path#with@chars").build();
+
+        IllegalArgumentException e = assertThrows(
+            IllegalArgumentException.class,
+            () -> clusterService.getClusterSettings().validateUpdate(invalid)
+        );
+        // The validator's message is surfaced as the cause of the settings-level rejection.
+        assertTrue(e.getMessage().contains("illegal value can't update [search.insights.top_queries.exporter.remote.path]"));
+        assertNotNull(e.getCause());
+        assertTrue(e.getCause().getMessage().contains("Base path contains invalid characters"));
+
+        // The setting must not have been applied.
+        RemoteRepositoryExporter remoteExporter = (RemoteRepositoryExporter) queryInsightsExporterFactory.getExporter(
+            TOP_QUERIES_REMOTE_EXPORTER_ID
+        );
+        assertNotNull(remoteExporter);
+        verify(remoteExporter, times(0)).setBasePath("bad path#with@chars");
+    }
+
+    public void testRemoteExporterPathValidCharsPassValidation() {
+        Settings valid = Settings.builder()
+            .put("search.insights.top_queries.exporter.remote.path", "query-insights/path-with_special.chars*()!'")
+            .build();
+
+        // Should not throw.
+        clusterService.getClusterSettings().validateUpdate(valid);
+        clusterService.getClusterSettings().applySettings(valid);
+    }
+
+    public void testRemoteExporterPathValidatorDirectly() {
+        QueryInsightsSettings.RemoteExporterPathValidator validator = new QueryInsightsSettings.RemoteExporterPathValidator();
+
+        // Valid values, including the allowed punctuation set and the empty string.
+        validator.validate("query-insights");
+        validator.validate("a/b/c");
+        validator.validate("query-insights/path-with_special.chars*()!'");
+        validator.validate("");
+        validator.validate(null);
+
+        // Invalid values.
+        for (String invalid : List.of("has space", "has#hash", "has@at", "has\\backslash", "has%percent", "has\nnewline")) {
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> validator.validate(invalid));
+            assertTrue(e.getMessage().contains("Base path contains invalid characters"));
+        }
+    }
+
     public void testLiveQueryUserInfoPutGetRemove() {
         String key = QueryInsightsService.buildLiveQueryTaskKey("nodeA", 1);
         UserPrincipalInfo info = new UserPrincipalInfo("alice", List.of("backend1"), List.of("role1"));


### PR DESCRIPTION
### Description

`search.insights.top_queries.exporter.remote.path` was declared with no `Setting.Validator`. The only validation was the regex check inside `RemoteRepositoryExporter.setBasePath()`, which is reached solely from the settings-update consumer — i.e. at apply time, after the value is already committed to cluster state.

So a path with an invalid character (space, `#`, etc.) passed the `validateUpdate` dry run, got committed and acked HTTP 200, then threw while cluster state was being applied. On the cluster-manager that aborts state application, which can cause step-down/re-election churn.

This attaches a `RemoteExporterPathValidator` to the setting so the path is rejected up front with a 400. The regex and error message are extracted to shared constants so the validator and `setBasePath()` can't drift.

Note: the apply-time throw only fired when a remote exporter was actually configured (`exporter != null`), so the blast radius was narrower than it looks — but when it did fire, the cluster-manager impact was the same.

### Related Issues

N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).