### PR TITLE
Document and test Top Queries API permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,41 @@ You can use the Insights API endpoint to obtain top N queries:
 GET /_insights/top_queries
 ```
 
-When the Security plugin is enabled, the caller must have the following cluster permission:
+When the Security plugin is enabled, the caller's security role must grant the following cluster permission:
 
 ```
 cluster:admin/opensearch/insights/top_queries
 ```
 
-For example, create a dedicated role:
+The Security plugin provides the predefined `query_insights_full_access` role for access to Query Insights APIs and
+local exporter indexes. Because the role definition varies by Security plugin version, verify that the installed role
+includes either the exact permission above or `cluster:admin/opensearch/insights/*`:
+
+```
+GET /_plugins/_security/api/roles/query_insights_full_access
+```
+
+Map the caller's backend role to `query_insights_full_access`:
+
+```
+PUT /_plugins/_security/api/rolesmapping/query_insights_full_access
+{
+  "backend_roles": [
+    "query_insights_users"
+  ],
+  "hosts": [],
+  "users": []
+}
+```
+
+For IAM-authenticated callers, use the IAM role ARN reported as the caller's backend role. The role-mapping `PUT`
+request creates or replaces the complete mapping, so preserve any existing assignments when updating it.
+
+The predefined `all_access` role also authorizes the API, but it grants unrestricted cluster and index access and
+should not be assigned solely for Query Insights.
+
+If the predefined Query Insights role in the installed Security plugin does not include the required permission, or
+if the caller should access only the Top Queries API, create a dedicated least-privilege role:
 
 ```
 PUT /_plugins/_security/api/roles/query_insights_read_access
@@ -69,6 +97,7 @@ PUT /_plugins/_security/api/rolesmapping/query_insights_read_access
   "backend_roles": [
     "query_insights_readers"
   ],
+  "hosts": [],
   "users": []
 }
 ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,39 @@ You can use the Insights API endpoint to obtain top N queries:
 GET /_insights/top_queries
 ```
 
+When the Security plugin is enabled, the caller must have the following cluster permission:
+
+```
+cluster:admin/opensearch/insights/top_queries
+```
+
+For example, create a dedicated role:
+
+```
+PUT /_plugins/_security/api/roles/query_insights_read_access
+{
+  "cluster_permissions": [
+    "cluster:admin/opensearch/insights/top_queries"
+  ]
+}
+```
+
+Then map the role to the appropriate backend role:
+
+```
+PUT /_plugins/_security/api/rolesmapping/query_insights_read_access
+{
+  "backend_roles": [
+    "query_insights_readers"
+  ],
+  "users": []
+}
+```
+
+If you add the action to an existing role instead, preserve that role's existing cluster, index, and tenant permissions.
+
+Requests without this permission receive an HTTP `403` response with a `security_exception`.
+
 ### Export top N query data
 
 You can configure your desired exporter to export top N query data to different sinks, allowing for better monitoring and analysis of your OpenSearch queries.

--- a/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRbacIT.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/resthandler/top_queries/TopQueriesRbacIT.java
@@ -59,6 +59,10 @@ public class TopQueriesRbacIT extends QueryInsightsRestTestCase {
     private static final String PASSWORD_B = "UserTeamB_1234";
     private static final String PASSWORD_C = "UserTeamC_1234";
     private static final String TEST_ROLE = "query_insights_test_role";
+    private static final String USER_WITHOUT_TOP_QUERIES_PERMISSION = "user_without_top_queries_permission";
+    private static final String PASSWORD_WITHOUT_TOP_QUERIES_PERMISSION = "UserWithoutTopQueries_1234";
+    private static final String ROLE_WITHOUT_TOP_QUERIES_PERMISSION = "role_without_top_queries_permission";
+    private static final String TOP_QUERIES_PERMISSION = "cluster:admin/opensearch/insights/top_queries";
     private static final String TEST_INDEX = "test-rbac-index";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT)
         .withZone(ZoneOffset.UTC);
@@ -86,14 +90,63 @@ public class TopQueriesRbacIT extends QueryInsightsRestTestCase {
         deleteSecurityResource("internalusers", USER_TEAM_A);
         deleteSecurityResource("internalusers", USER_TEAM_B);
         deleteSecurityResource("internalusers", USER_TEAM_C);
+        deleteSecurityResource("internalusers", USER_WITHOUT_TOP_QUERIES_PERMISSION);
         deleteSecurityResource("rolesmapping", TEST_ROLE);
+        deleteSecurityResource("rolesmapping", ROLE_WITHOUT_TOP_QUERIES_PERMISSION);
         deleteSecurityResource("roles", TEST_ROLE);
+        deleteSecurityResource("roles", ROLE_WITHOUT_TOP_QUERIES_PERMISSION);
 
         // Delete test index
         try {
             client().performRequest(new Request("DELETE", "/" + TEST_INDEX));
         } catch (Exception e) {
             log.warning("Failed to delete test index: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verify that the Security plugin preserves the authorization failure as an HTTP 403 response.
+     */
+    public void testTopQueriesRequiresExplicitPermission() throws Exception {
+        assumeTrue("This test requires the security plugin", isSecurityPluginInstalled());
+        setupUserWithoutTopQueriesPermission();
+
+        Request topQueriesRequest = new Request("GET", "/_insights/top_queries");
+        try (RestClient userClient = buildClientForUser(USER_WITHOUT_TOP_QUERIES_PERMISSION, PASSWORD_WITHOUT_TOP_QUERIES_PERMISSION)) {
+            Response clusterHealthResponse = userClient.performRequest(new Request("GET", "/_cluster/health"));
+            assertEquals(200, clusterHealthResponse.getStatusLine().getStatusCode());
+
+            try {
+                userClient.performRequest(topQueriesRequest);
+                fail("A user without the top queries action permission should be denied");
+            } catch (ResponseException e) {
+                assertEquals(403, e.getResponse().getStatusLine().getStatusCode());
+                String responseBody = new String(e.getResponse().getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+                assertTrue(
+                    "Expected a security_exception response but received: " + responseBody,
+                    responseBody.contains("security_exception")
+                );
+                assertTrue(
+                    "Expected the denied action in the response but received: " + responseBody,
+                    responseBody.contains(TOP_QUERIES_PERMISSION)
+                );
+            }
+        }
+
+        grantTopQueriesPermission();
+        try (RestClient userClient = buildClientForUser(USER_WITHOUT_TOP_QUERIES_PERMISSION, PASSWORD_WITHOUT_TOP_QUERIES_PERMISSION)) {
+            assertBusy(() -> {
+                try {
+                    Response response = userClient.performRequest(new Request("GET", "/_insights/top_queries"));
+                    assertEquals(200, response.getStatusLine().getStatusCode());
+                } catch (ResponseException e) {
+                    int statusCode = e.getResponse().getStatusLine().getStatusCode();
+                    if (statusCode != 403) {
+                        throw e;
+                    }
+                    throw new AssertionError("Top Queries permission has not propagated yet", e);
+                }
+            }, 10, TimeUnit.SECONDS);
         }
     }
 
@@ -377,6 +430,48 @@ public class TopQueriesRbacIT extends QueryInsightsRestTestCase {
         assertTrue(
             "Role mapping creation should succeed",
             mappingResp.getStatusLine().getStatusCode() == 200 || mappingResp.getStatusLine().getStatusCode() == 201
+        );
+    }
+
+    /**
+     * Create a user that can monitor the cluster but cannot invoke the Top Queries transport action.
+     */
+    private void setupUserWithoutTopQueriesPermission() throws IOException {
+        Request createRole = new Request("PUT", "/_plugins/_security/api/roles/" + ROLE_WITHOUT_TOP_QUERIES_PERMISSION);
+        createRole.setJsonEntity("{\"cluster_permissions\":[\"cluster_monitor\"]}");
+        Response roleResponse = client().performRequest(createRole);
+        assertTrue(
+            "Role creation should succeed",
+            roleResponse.getStatusLine().getStatusCode() == 200 || roleResponse.getStatusLine().getStatusCode() == 201
+        );
+
+        Request createUser = new Request("PUT", "/_plugins/_security/api/internalusers/" + USER_WITHOUT_TOP_QUERIES_PERMISSION);
+        createUser.setJsonEntity("{\"password\":\"" + PASSWORD_WITHOUT_TOP_QUERIES_PERMISSION + "\"}");
+        Response userResponse = client().performRequest(createUser);
+        assertTrue(
+            "User creation should succeed",
+            userResponse.getStatusLine().getStatusCode() == 200 || userResponse.getStatusLine().getStatusCode() == 201
+        );
+
+        Request createMapping = new Request("PUT", "/_plugins/_security/api/rolesmapping/" + ROLE_WITHOUT_TOP_QUERIES_PERMISSION);
+        createMapping.setJsonEntity("{\"users\":[\"" + USER_WITHOUT_TOP_QUERIES_PERMISSION + "\"]}");
+        Response mappingResponse = client().performRequest(createMapping);
+        assertTrue(
+            "Role mapping creation should succeed",
+            mappingResponse.getStatusLine().getStatusCode() == 200 || mappingResponse.getStatusLine().getStatusCode() == 201
+        );
+    }
+
+    /**
+     * Replace the test role's monitor permission with the Top Queries action permission.
+     */
+    private void grantTopQueriesPermission() throws IOException {
+        Request updateRole = new Request("PUT", "/_plugins/_security/api/roles/" + ROLE_WITHOUT_TOP_QUERIES_PERMISSION);
+        updateRole.setJsonEntity("{\"cluster_permissions\":[\"" + TOP_QUERIES_PERMISSION + "\"]}");
+        Response roleResponse = client().performRequest(updateRole);
+        assertTrue(
+            "Role update should succeed",
+            roleResponse.getStatusLine().getStatusCode() == 200 || roleResponse.getStatusLine().getStatusCode() == 201
         );
     }
 


### PR DESCRIPTION
## Summary
- Document the predefined, broad, and least-privilege authorization options for the Top Queries API.
- Add secured integration coverage for unauthorized requests.