### PR TITLE
Handle unknown Attribute enum values gracefully during rolling upgrades

### DIFF
--- a/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
+++ b/src/main/java/org/opensearch/plugin/insights/rules/model/Attribute.java
@@ -204,7 +204,37 @@ public enum Attribute {
         Map<Attribute, Object> map = new HashMap<>(size);
 
         for (int i = 0; i < size; i++) {
-            Attribute key = readFromStream(in);
+            final Attribute key;
+            try {
+                key = readFromStream(in);
+            } catch (IllegalArgumentException e) {
+                // The attribute name doesn't match any constant this node's Attribute enum
+                // knows about. This happens during a rolling upgrade: a node running a newer
+                // version can add new Attribute constants (e.g. USER_ROLES, BACKEND_ROLES) and
+                // send them to an older-version coordinator whose enum predates them, and
+                // Attribute.valueOf() throws IllegalArgumentException for the unknown name.
+                //
+                // We can't just let this exception propagate: readAttributeMap is reading a
+                // fixed-size sequence of key/value pairs, so any entry we fail to fully consume
+                // corrupts the byte alignment for every entry after it in this stream, not just
+                // this one. Every attribute defined today other than the handful with bespoke
+                // encodings (TASK_RESOURCE_USAGES, SOURCE, GROUP_BY -- all handled explicitly in
+                // readAttributeValue below) is written through the self-describing
+                // writeGenericValue()/readGenericValue() wire format, so we can read and discard
+                // the value here to stay aligned, without needing to know what the attribute
+                // means. This trades knowledge of the new attribute for correctness of everything
+                // else in the record, which matches the documented expected behavior: "Query
+                // insight should not fail, or at least give up on trying to collect this
+                // particular event." See https://github.com/opensearch-project/query-insights/issues/510
+                //
+                // Caveat: writeValueTo() also special-cases java.util.List through the
+                // Writeable-based out.writeList(), which is NOT self-describing. No attribute
+                // uses a List value today (USER_ROLES/BACKEND_ROLES are String[]), but a future
+                // attribute that does would need its own explicit case in readAttributeValue()
+                // AND readAttributeMap() -- this generic skip cannot safely consume it.
+                in.readGenericValue();
+                continue;
+            }
             Object value = readAttributeValue(in, key);
             map.put(key, value);
         }

--- a/src/test/java/org/opensearch/plugin/insights/rules/model/AttributeTests.java
+++ b/src/test/java/org/opensearch/plugin/insights/rules/model/AttributeTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.plugin.insights.rules.model;
 
 import java.io.IOException;
+import java.util.Map;
 import org.opensearch.Version;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -135,6 +136,86 @@ public class AttributeTests extends OpenSearchTestCase {
 
         assertTrue("Should handle invalid JSON gracefully", result instanceof SourceString);
         assertNotNull("Should not be null", result);
+    }
+
+    /**
+     * Test for https://github.com/opensearch-project/query-insights/issues/510
+     *
+     * Simulates a rolling upgrade: a newer node writes an attribute map containing a key this
+     * node's Attribute enum doesn't have yet (as would happen if a newer node sent USER_ROLES /
+     * BACKEND_ROLES / USERNAME to a coordinator whose build predates those attributes). Reading
+     * that map must not throw, and every attribute this node *does* recognize -- both before and
+     * after the unknown one in the map -- must still come through with the correct value,
+     * proving the stream stays byte-aligned across the skipped entry.
+     */
+    public void testReadAttributeMapSkipsUnknownAttributeFromNewerNode() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+
+        // Manually write a 3-entry attribute map the way Attribute.writeTo/writeValueTo would,
+        // with an unrecognized key in the middle -- standing in for a newer-node-only attribute
+        // (e.g. "user_roles") that this test's Attribute enum build doesn't define.
+        out.writeVInt(3);
+
+        out.writeString("node_id");
+        Attribute.writeValueTo(out, "node-abc");
+
+        out.writeString("totally_unknown_future_attribute");
+        // USER_ROLES/BACKEND_ROLES are written as String[] (see QueryInsightsListener), not
+        // List -- Attribute#writeValueTo special-cases java.util.List through out.writeList(),
+        // which is Writeable-based, not the self-describing generic codec this fix relies on.
+        Attribute.writeValueTo(out, new String[] { "admin", "readall" });
+
+        out.writeString("total_shards");
+        Attribute.writeValueTo(out, 5);
+
+        StreamInput in = out.bytes().streamInput();
+        Map<Attribute, Object> result = Attribute.readAttributeMap(in);
+
+        assertEquals("Unknown attribute should be skipped, not counted", 2, result.size());
+        assertEquals("node-abc", result.get(Attribute.NODE_ID));
+        assertEquals(5, result.get(Attribute.TOTAL_SHARDS));
+        assertFalse(result.containsKey(null));
+    }
+
+    /**
+     * Same scenario as above but with the unknown attribute as the very last entry, to make sure
+     * there's no off-by-one in how the loop continues after a skip.
+     */
+    public void testReadAttributeMapSkipsUnknownAttributeAtEnd() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+
+        out.writeVInt(2);
+        out.writeString("node_id");
+        Attribute.writeValueTo(out, "node-xyz");
+        out.writeString("another_unknown_future_attribute");
+        Attribute.writeValueTo(out, "some-value");
+
+        StreamInput in = out.bytes().streamInput();
+        Map<Attribute, Object> result = Attribute.readAttributeMap(in);
+
+        assertEquals(1, result.size());
+        assertEquals("node-xyz", result.get(Attribute.NODE_ID));
+    }
+
+    /**
+     * A map made up entirely of known attributes must round-trip exactly as before -- this fix
+     * must not change behavior for the common (no version skew) case.
+     */
+    public void testReadAttributeMapAllKnownAttributesUnaffected() throws IOException {
+        BytesStreamOutput out = new BytesStreamOutput();
+
+        out.writeVInt(2);
+        out.writeString("node_id");
+        Attribute.writeValueTo(out, "node-1");
+        out.writeString("total_shards");
+        Attribute.writeValueTo(out, 3);
+
+        StreamInput in = out.bytes().streamInput();
+        Map<Attribute, Object> result = Attribute.readAttributeMap(in);
+
+        assertEquals(2, result.size());
+        assertEquals("node-1", result.get(Attribute.NODE_ID));
+        assertEquals(3, result.get(Attribute.TOTAL_SHARDS));
     }
 
 }


### PR DESCRIPTION
## Problem
During rolling upgrades, when a newer OpenSearch node sends a `TopQueriesResponse` 
containing new attribute keys (e.g., `USER_ROLES`, `BACKEND_ROLES`) to an older 
coordinator whose `Attribute` enum predates those constants, the deserialization 
fails. The older node calls `Attribute.valueOf()` on the unknown attribute name, 
which throws an `IllegalArgumentException`, causing the entire response to be 
rejected and corrupting metrics collection.

## Solution
Wrap the `Attribute.valueOf()` call in a try-catch block within 
`readAttributeMap()`. When an unknown attribute is encountered:
1. Catch the `IllegalArgumentException`
2. Read and discard the value using `readGenericValue()` to maintain byte alignment
3. Continue processing the rest of the map

This approach works because all attributes (except those with special codecs like 
`TASK_RESOURCE_USAGES`, `SOURCE`, and `GROUP_BY`) use the self-describing generic 
value format that can be read and skipped safely without knowledge of the attribute.

## Key Insights
- **Byte alignment**: Since `readAttributeMap()` processes a fixed-size sequence of 
  key-value pairs, skipping any entry would corrupt the stream for all subsequent 
  entries without this fix.
- **Backwards compatible**: The fix doesn't change behavior for clusters with uniform 
  versions (no version skew).
- **Future-proof caveat**: The generic skip cannot safely consume `List` values (which 
  use `out.writeList()`). Currently, no attributes use `List` values, but future ones 
  with `List` values would need explicit handling in both `readAttributeMap()` and 
  `readAttributeValue()`.

Fixes #510