### PR TITLE
Use Eclipse P2 mirror (query-insights)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ spotless {
     }
     removeUnusedImports()
     importOrder()
-    eclipse().configFile rootProject.file('config/formatterConfig.xml')
+    eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('config/formatterConfig.xml')
     trimTrailingWhitespace()
     endWithNewline()
   }


### PR DESCRIPTION
Routes Spotless Eclipse P2 downloads through https://ci.opensearch.org/ to avoid direct download.eclipse.org outages.

Tracking bulletin: https://github.com/opensearch-project/opensearch-build/issues/6421#issuecomment-5271186726